### PR TITLE
feat: Add docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+# This is a Docker Compose file for setting up the morphic-stack environment.
+
+name: morphic-stack
+services:
+  morphic:
+    build:
+      context: . # The build context is the current directory
+      dockerfile: Dockerfile
+    command: bun dev # Use `bun dev -H 0.0.0.0` to listen on all interfaces
+    env_file: .env.local # Load environment variables
+    ports:
+      - "3000:3000" # Maps port 3000 on the host to port 3000 in the container.


### PR DESCRIPTION
## Overview
This pull request introduces a new Docker Compose configuration to streamline the setup and execution of the Morphic project for local development environments. The `docker-compose.yml` file follows the defaults set out in the current README.

## Changes Introduced
Docker Compose File: A `docker-compose.yml` file has been added to the root of the project. This file defines the morphic service, specifying how it should be built and run:
* The Docker context is set to the current directory, with the `Dockerfile` specified for building the image.
* Reads .env.local for environment variables aligning with the README

The service is configured to run the command bun dev, aligning with the README.

Port forwarding is configurable but by default maps the container's port 3000 to localhost:3000.

## Usage
1. Ensure Docker and Docker Compose are installed on your system.
2. Navigate to the root of the repository where the `docker-compose.yml` file is located.
3. Copy `.env.local.example` to `.env.local` and set environment variable
4. Run `docker-compose up` to build and start the application.
5. Access the application at http://localhost:3000.

## Testing
The Docker Compose setup has been tested locally to ensure that the application builds, runs, and is accessible at the expected port.