### PR TITLE
Make the share feature optional

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -28,3 +28,7 @@ UPSTASH_REDIS_REST_TOKEN=[YOUR_UPSTASH_REDIS_REST_TOKEN]
 # SPECIFIC_API_BASE=
 # SPECIFIC_API_KEY=
 # SPECIFIC_API_MODEL=
+
+# enable the share feature
+# If you enable this feature, separate account management implementation is required.
+# ENABLE_SHARE=true

--- a/components/user-message.tsx
+++ b/components/user-message.tsx
@@ -12,10 +12,11 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   chatId,
   showShare = false
 }) => {
+  const enableShare = process.env.ENABLE_SHARE === 'true'
   return (
     <div className="flex items-center w-full space-x-1 mt-2 min-h-10">
       <div className="text-xl flex-1">{message}</div>
-      {showShare && chatId && <ChatShare chatId={chatId} />}
+      {enableShare && showShare && chatId && <ChatShare chatId={chatId} />}
     </div>
   )
 }


### PR DESCRIPTION
Since this repo does not have authentication, the search results page itself is shareable. Therefore, the share feature is made optional and disabled by default. If enabling the feature, authentication needs to be implemented.