### PR TITLE
feat: Add current date and time to prompt for researcher

### DIFF
--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -31,6 +31,7 @@ export async function researcher(
   )
 
   let isFirstToolResponse = true
+  const currentDate = new Date().toLocaleString();
   const result = await nonexperimental_streamText({
     model: openai.chat(process.env.OPENAI_API_MODEL || 'gpt-4o'),
     maxTokens: 2500,
@@ -40,7 +41,7 @@ export async function researcher(
     If there are any images relevant to your answer, be sure to include them as well.
     Aim to directly address the user's question, augmenting your response with insights gleaned from the search results.
     Whenever quoting or referencing information from a specific URL, always cite the source URL explicitly.
-    Please match the language of the response to the user's language.`,
+    Please match the language of the response to the user's language. Current date and time: ${currentDate}`,
     messages,
     tools: getTools({
       uiStream,


### PR DESCRIPTION
## Overview
This pull request introduces a new feature to the `researcher` function in the `researcher.tsx` file. The feature adds the current date and time to the system prompt that is passed to the Language Model (LLM). The date and time are fetched programmatically and change based on the system time.

Ensures that any web searches related to time sensitive topics have the correct current datetime e.g. 
<img width="951" alt="image" src="https://github.com/miurla/morphic/assets/25386449/52252c6d-ec75-4cc9-893c-45b02104f948">

## Changes Introduced
`researcher` Function: The `researcher` function in the `researcher.tsx` file has been updated to include the current date and time in the system prompt:

* A new constant `currentDate` is declared and assigned the current date and time using the JavaScript `Date` object.
The `currentDate` is then converted to a string and included in the system prompt that is passed to the `nonexperimental_streamText` function.
* I think this is the correct place to put the datetime but if the researcher is not called for any reason then we won't get this current datetime info.

## Usage
No additional steps are required to use this feature. The date and time will be automatically included in the system prompt each time the `researcher` function is called.

## Testing
The updated `researcher` function has been tested locally to ensure that the current date and time are correctly included in the system prompt and that they change based on the system time.
