### PR TITLE
Add restriction to retrieve tool

### DIFF
--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -30,7 +30,7 @@ export function SearchSection({ result }: SearchSectionProps) {
               />
             </Section>
           )}
-          <Section title="Results">
+          <Section title="Sources">
             <SearchResults results={searchResults.results} />
           </Section>
         </>

--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -41,6 +41,7 @@ export async function researcher(
     If there are any images relevant to your answer, be sure to include them as well.
     Aim to directly address the user's question, augmenting your response with insights gleaned from the search results.
     Whenever quoting or referencing information from a specific URL, always cite the source URL explicitly.
+    The retrieve tool can only be used with URLs provided by the user. URLs from search results cannot be used.
     Please match the language of the response to the user's language. Current date and time: ${currentDate}`,
     messages,
     tools: getTools({


### PR DESCRIPTION
closes: #159

## Cause
Due to the addition of the retry tool, the URL of the search results was being further read by the retry tool.

## Changes
Fixed the prompt.

## Additional Info
Also, the section titles were not unified, so they were corrected.