### PR TITLE
chore: Update the handleClear function to disable the button during generation

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -76,6 +76,8 @@ export function ChatPanel({ messages, query }: ChatPanelProps) {
   // Clear messages
   const handleClear = () => {
     setIsGenerating(false)
+    setMessages([])
+    setInput('')
     router.push('/')
   }
 
@@ -93,6 +95,7 @@ export function ChatPanel({ messages, query }: ChatPanelProps) {
           variant={'secondary'}
           className="rounded-full bg-secondary/80 group transition-all hover:scale-105 pointer-events-auto"
           onClick={() => handleClear()}
+          disabled={isGenerating}
         >
           <span className="text-sm mr-2 group-hover:block hidden animate-in fade-in duration-300">
             New


### PR DESCRIPTION
- Update handleClear function
- Disabled the `new` button while generating.

This will likely resolve issue #169 as well.