### PR TITLE
chore: nanoid is deprecated, use `generateId` instead

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -6,7 +6,7 @@ import {
   getAIState,
   getMutableAIState
 } from 'ai/rsc'
-import { CoreMessage, nanoid, ToolResultPart } from 'ai'
+import { CoreMessage, generateId, ToolResultPart } from 'ai'
 import { Spinner } from '@/components/ui/spinner'
 import { Section } from '@/components/section'
 import { FollowupPanel } from '@/components/followup-panel'
@@ -53,7 +53,7 @@ async function submit(
     })
 
   // goupeiId is used to group the messages for collapse
-  const groupeId = nanoid()
+  const groupeId = generateId()
 
   const useSpecificAPI = process.env.USE_SPECIFIC_API_FOR_WRITER === 'true'
   const useOllamaProvider = !!(
@@ -87,7 +87,7 @@ async function submit(
       messages: [
         ...aiState.get().messages,
         {
-          id: nanoid(),
+          id: generateId(),
           role: 'user',
           content,
           type
@@ -116,7 +116,7 @@ async function submit(
         messages: [
           ...aiState.get().messages,
           {
-            id: nanoid(),
+            id: generateId(),
             role: 'assistant',
             content: `inquiry: ${inquiry?.question}`,
             type: 'inquiry'
@@ -259,7 +259,7 @@ async function submit(
   processEvents()
 
   return {
-    id: nanoid(),
+    id: generateId(),
     isGenerating: isGenerating.value,
     component: uiStream.value,
     isCollapsed: isCollapsed.value
@@ -280,7 +280,7 @@ export type UIState = {
 }[]
 
 const initialAIState: AIState = {
-  chatId: nanoid(),
+  chatId: generateId(),
   messages: []
 }
 
@@ -325,7 +325,7 @@ export const AI = createAI<AIState, UIState>({
     const updatedMessages: AIMessage[] = [
       ...messages,
       {
-        id: nanoid(),
+        id: generateId(),
         role: 'assistant',
         content: `end`,
         type: 'end'

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,11 @@
 import { Chat } from '@/components/chat'
-import { nanoid } from 'ai'
+import { generateId } from 'ai'
 import { AI } from './actions'
 
 export const maxDuration = 60
 
 export default function Page() {
-  const id = nanoid()
+  const id = generateId()
   return (
     <AI initialAIState={{ chatId: id, messages: [] }}>
       <Chat id={id} />

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,5 +1,5 @@
 import { Chat } from '@/components/chat'
-import { nanoid } from 'ai'
+import { generateId } from 'ai'
 import { AI } from '@/app/actions'
 import { redirect } from 'next/navigation'
 
@@ -13,7 +13,7 @@ export default function Page({
   if (!searchParams.q) {
     redirect('/')
   }
-  const id = nanoid()
+  const id = generateId()
 
   return (
     <AI initialAIState={{ chatId: id, messages: [] }}>

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -10,7 +10,7 @@ import { Button } from './ui/button'
 import { ArrowRight, Plus } from 'lucide-react'
 import { EmptyScreen } from './empty-screen'
 import Textarea from 'react-textarea-autosize'
-import { nanoid } from 'ai'
+import { generateId } from 'ai'
 import { useAppState } from '@/lib/utils/app-state'
 
 interface ChatPanelProps {
@@ -37,7 +37,7 @@ export function ChatPanel({ messages, query }: ChatPanelProps) {
     setMessages(currentMessages => [
       ...currentMessages,
       {
-        id: nanoid(),
+        id: generateId(),
         component: <UserMessage message={query} />
       }
     ])


### PR DESCRIPTION
Hi,

nanoid is deprecated by AI SDK, use `generateId` instead : https://github.com/vercel/ai/pull/1929/commits/b4db8b20dda9c7ca0853e8a564602aeac707a733
