### PR TITLE
fix: Add generated answer section component

### DIFF
--- a/components/answer-section-generated.tsx
+++ b/components/answer-section-generated.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Section } from './section'
+import { BotMessage } from './message'
+
+export type AnswerSectionProps = {
+  result: string
+}
+
+export function AnswerSectionGenerated({ result }: AnswerSectionProps) {
+  return (
+    <div>
+      <Section title="Answer">
+        <BotMessage content={result} />
+      </Section>
+    </div>
+  )
+}

--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -3,6 +3,7 @@ import { CoreMessage, ToolCallPart, ToolResultPart, streamText } from 'ai'
 import { getTools } from './tools'
 import { getModel, transformToolMessages } from '../utils'
 import { AnswerSection } from '@/components/answer-section'
+import { AnswerSectionGenerated } from '@/components/answer-section-generated'
 
 export async function researcher(
   uiStream: ReturnType<typeof createStreamableUI>,
@@ -43,7 +44,14 @@ export async function researcher(
     tools: getTools({
       uiStream,
       fullResponse
-    })
+    }),
+    onFinish: event => {
+      // If the response is generated, update the generated answer section
+      // There is a bug where a new instance of the answer section is displayed once when the next section is added
+      if (event.text.length > 0) {
+        uiStream.update(<AnswerSectionGenerated result={event.text} />)
+      }
+    }
   }).catch(err => {
     hasError = true
     fullResponse = 'Error: ' + err.message

--- a/lib/agents/writer.tsx
+++ b/lib/agents/writer.tsx
@@ -2,6 +2,7 @@ import { createStreamableUI, createStreamableValue } from 'ai/rsc'
 import { CoreMessage, streamText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 import { AnswerSection } from '@/components/answer-section'
+import { AnswerSectionGenerated } from '@/components/answer-section-generated'
 
 export async function writer(
   uiStream: ReturnType<typeof createStreamableUI>,
@@ -28,7 +29,12 @@ export async function writer(
     Link format: [link text](url)
     Image format: ![alt text](url)
     `,
-    messages
+    messages,
+    onFinish: event => {
+      // If the response is generated, update the generated answer section
+      // There is a bug where a new instance of the answer section is displayed once when the next section is added
+      uiStream.update(<AnswerSectionGenerated result={event.text} />)
+    }
   })
     .then(async result => {
       for await (const text of result.textStream) {


### PR DESCRIPTION
## Issue
There is a bug where a new instance of the answer section is displayed once when the next section is added.

## Solution
Update the generated answer section if the response is generated. This ensures that the answer section prevents an empty answer from being displayed even if a new instance is called.