### PR TITLE
Update query-suggestor to use streamText

### DIFF
--- a/lib/agents/query-suggestor.tsx
+++ b/lib/agents/query-suggestor.tsx
@@ -1,6 +1,6 @@
 import { createStreamableUI, createStreamableValue } from 'ai/rsc'
-import { CoreMessage, streamObject } from 'ai'
-import { PartialRelated, relatedSchema } from '@/lib/schema/related'
+import { CoreMessage, streamText } from 'ai'
+import { PartialRelated } from '@/lib/schema/related'
 import SearchRelated from '@/components/search-related'
 import { getModel } from '../utils'
 
@@ -19,31 +19,31 @@ export async function querySuggestor(
   }) as CoreMessage[]
 
   let finalRelatedQueries: PartialRelated = {}
-  await streamObject({
+  let accumulatedQueryString = ''
+  await streamText({
     model: getModel(),
     system: `As a professional web researcher, your task is to generate a set of three queries that explore the subject matter more deeply, building upon the initial query and the information uncovered in its search results.
 
     For instance, if the original query was "Starship's third test flight key milestones", your output should follow this format:
 
-    "{
-      "related": [
-        "What were the primary objectives achieved during Starship's third test flight?",
-        "What factors contributed to the ultimate outcome of Starship's third test flight?",
-        "How will the results of the third test flight influence SpaceX's future development plans for Starship?"
-      ]
-    }"
+    "What were the primary objectives achieved during Starship's third test flight?,What factors contributed to the ultimate outcome of Starship's third test flight?,How will the results of the third test flight influence SpaceX's future development plans for Starship?"
 
     Aim to create queries that progressively delve into more specific aspects, implications, or adjacent topics related to the initial query. The goal is to anticipate the user's potential information needs and guide them towards a more comprehensive understanding of the subject matter.
-    Please match the language of the response to the user's language.`,
-    messages: lastMessages,
-    schema: relatedSchema
+    Please match the language of the response to the user's language.
+    Output the three queries as a comma-separated string, without any additional formatting or object structure.`,
+    messages: lastMessages
   })
     .then(async result => {
-      for await (const obj of result.partialObjectStream) {
-        if (obj.items) {
-          objectStream.update(obj)
-          finalRelatedQueries = obj
+      for await (const chunk of result.textStream) {
+        accumulatedQueryString += chunk
+        const queries = accumulatedQueryString
+          .split(',')
+          .map(query => query.trim())
+        const relatedQueries: PartialRelated = {
+          items: queries.map(query => ({ query }))
         }
+        objectStream.update(relatedQueries)
+        finalRelatedQueries = relatedQueries
       }
     })
     .finally(() => {


### PR DESCRIPTION
Generate follow-up queries using streamText from streamObject. This is because the number of failure cases increases depending on the model.