### PR TITLE
Update Twitter icon import and URL

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import { SiDiscord, SiGithub, SiTwitter } from 'react-icons/si'
+import { SiDiscord, SiGithub, SiX } from 'react-icons/si'
 import { Button } from './ui/button'
 
 const Footer: React.FC = () => {
@@ -21,8 +21,8 @@ const Footer: React.FC = () => {
           size={'icon'}
           className="text-muted-foreground/50"
         >
-          <Link href="https://twitter.com/morphic_ai" target="_blank">
-            <SiTwitter size={18} />
+          <Link href="https://x.com/morphic_ai" target="_blank">
+            <SiX size={18} />
           </Link>
         </Button>
         <Button


### PR DESCRIPTION
This pull request updates footer component to reflect recent changes in Twitter's branding:

1. Modified the icon import from 'react-icons/si':
   - Replaced SiTwitter with SiX to use the new X icon

2. Updated the Twitter/X link:
   - Changed the URL from https://twitter.com/morphic_ai to https://x.com/morphic_ai

These changes ensure footer stays current with Twitter's rebranding to X. The functionality remains the same, but users will now see the X icon and be directed to the x.com domain when clicking the link.

Please review and test to ensure the footer renders correctly with the new icon and that the link works as expected.

![image](https://github.com/user-attachments/assets/74598917-b45e-487e-b5d9-484b33ad9ec1)
