### PR TITLE
Add SearchApi search engine

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -17,7 +17,7 @@ UPSTASH_REDIS_REST_TOKEN=[YOUR_UPSTASH_REDIS_REST_TOKEN]
 
 # SearXNG Configuration
 SEARXNG_API_URL=http://localhost:8080  # Replace with your local SearXNG API URL or docker http://searxng:8080
-SEARCH_API=tavily  #  use searxng, tavily or exa
+SEARCH_API=searchapi  #  use searchapi, searxng, tavily or exa
 SEARXNG_SECRET="" # generate a secret key e.g. openssl rand -base64 32
 SEARXNG_PORT=8080 # default port
 SEARXNG_BIND_ADDRESS=0.0.0.0 # default address
@@ -31,6 +31,11 @@ SEARXNG_SAFESEARCH=0 # Safe search setting: 0 (off), 1 (moderate), 2 (strict)
 
 # Optional
 # The settings below can be used optionally as needed.
+
+# SearchApi credentials
+# SearchApi API Key retrieved here: https://www.searchapi.io/
+# SEARCHAPI_API_KEY=[YOUR_SEARCHAPI_API_KEY]
+# SEARCHAPI_ENGINE=google # e.g. google, bing, baidu, youtube, google_news
 
 # Used to set the base URL path for OpenAI API requests.
 # If you need to set a BASE URL, uncomment and set the following:

--- a/.env.local.example
+++ b/.env.local.example
@@ -17,7 +17,7 @@ UPSTASH_REDIS_REST_TOKEN=[YOUR_UPSTASH_REDIS_REST_TOKEN]
 
 # SearXNG Configuration
 SEARXNG_API_URL=http://localhost:8080  # Replace with your local SearXNG API URL or docker http://searxng:8080
-SEARCH_API=searchapi  #  use searchapi, searxng, tavily or exa
+SEARCH_API=tavily  #  use searchapi, searxng, tavily or exa
 SEARXNG_SECRET="" # generate a secret key e.g. openssl rand -base64 32
 SEARXNG_PORT=8080 # default port
 SEARXNG_BIND_ADDRESS=0.0.0.0 # default address

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ An AI-powered search engine with a generative UI.
 - App framework: [Next.js](https://nextjs.org/)
 - Text streaming / Generative UI: [Vercel AI SDK](https://sdk.vercel.ai/docs)
 - Generative Model: [OpenAI](https://openai.com/)
-- Search API: [Tavily AI](https://tavily.com/) / [Serper](https://serper.dev) / [SearXNG](https://docs.searxng.org/)
+- Search API: [Tavily AI](https://tavily.com/) / [SearchApi](https://www.searchapi.io/) / [Serper](https://serper.dev) / [SearXNG](https://docs.searxng.org/)
 - Reader API: [Jina AI](https://jina.ai/)
 - Database (Serverless/Local): [Upstash](https://upstash.com/) / [Redis](https://redis.io/)
 - Component library: [shadcn/ui](https://ui.shadcn.com/)
@@ -105,7 +105,7 @@ To use Upstash Redis:
 
 # SearXNG Configuration
 SEARXNG_API_URL=http://localhost:8080  # Replace with your local SearXNG API URL or docker http://searxng:8080
-SEARCH_API=tavily  #  use searxng, tavily or exa
+SEARCH_API=tavily  #  use searchapi, searxng, tavily or exa
 SEARXNG_SECRET="" # generate a secret key e.g. openssl rand -base64 32
 SEARXNG_PORT=8080 # default port
 SEARXNG_BIND_ADDRESS=0.0.0.0 # default address


### PR DESCRIPTION
Added SearchApi to search engines list.

The end user can change the search engine used on the SearchApi side via the engine parameter. Organic results share the same structure across all existing and upcoming SERP engines, so we will always have a title, snippet, and link. Google, Bing, Baidu, Google News, Bing News, Google Videos, Google Scholar, and Google Patents are already supported. Yandex and Yahoo are coming soon as well.

SearchApi is committed to supporting open-source integrations. Please feel free to mention [@SebastjanPrachovskij](https://github.com/SebastjanPrachovskij) for any future PR reviews related to SearchApi. We would be glad to help.