### PR TITLE
feat: Support Groq AI Provider

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -57,6 +57,10 @@ SEARXNG_SAFESEARCH=0 # Safe search setting: 0 (off), 1 (moderate), 2 (strict)
 # If you want to use Anthropic instead of OpenAI, enable the following settings.
 # ANTHROPIC_API_KEY=[YOUR_ANTHROPIC_API_KEY]
 
+# If you want to use Groq, enable the following variables. only available for tool use compatible models.
+# GROQ_API_KEY=[YOUR_GROQ_API_KEY]
+# GROQ_API_MODEL=[YOUR_GROQ_API_MODEL] # e.g. llama3-groq-8b-8192-tool-use-preview
+
 # If you want to use Ollama, enable the following variables.
 # OLLAMA_MODEL=[YOUR_OLLAMA_MODEL] # The main model to use. Currently compatible: qwen2.5
 # OLLAMA_BASE_URL=[YOUR_OLLAMA_URL] # The base URL to use. e.g. http://localhost:11434

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ An AI-powered search engine with a generative UI.
   - Azure OpenAI Provider [※](https://github.com/miurla/morphic/issues/13)
   - Anthropic Provider [※](https://github.com/miurla/morphic/pull/239)
   - Ollama Provider [※](https://github.com/miurla/morphic/issues/215#issuecomment-2381902347)
+  - Groq Provider
 - Local Redis support
 - SearXNG Search API support with customizable depth (basic or advanced)
 - Configurable search depth (basic or advanced)
@@ -233,3 +234,6 @@ engines:
   - Claude 3.5 Sonnet
 - Ollama
   - qwen2.5
+- Groq
+  - llama3-groq-8b-8192-tool-use-preview
+  - llama3-groq-70b-8192-tool-use-preview

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -23,6 +23,8 @@ export function getModel(useSubModel = false) {
   let azureDeploymentName = process.env.AZURE_DEPLOYMENT_NAME || 'gpt-4o'
   const googleApiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY
+  const groqApiKey = process.env.GROQ_API_KEY
+  const groqApiModel = process.env.GROQ_API_MODEL
 
   if (
     !(ollamaBaseUrl && ollamaModel) &&
@@ -61,6 +63,15 @@ export function getModel(useSubModel = false) {
     })
 
     return azure.chat(azureDeploymentName)
+  }
+
+  if (groqApiKey && groqApiModel) {
+    const groq = createOpenAI({
+      apiKey: groqApiKey,
+      baseURL: 'https://api.groq.com/openai/v1'
+    })
+
+    return groq.chat(groqApiModel)
   }
 
   // Fallback to OpenAI instead


### PR DESCRIPTION
Until now, Groq was only applied to the Writer agent, but it has been made selectable as a provider option.
Only models compatible with tool use are available.
Set the following environment variables:

```
# GROQ_API_KEY=[YOUR_GROQ_API_KEY]
# GROQ_API_MODEL=[YOUR_GROQ_API_MODEL] # e.g. llama3-groq-8b-8192-tool-use-preview
```

Along with this change, the writer agent and `SPECIFIC_API_xxx` have been removed.