### PR TITLE
fix: Update search depth parameter to accept string values

### DIFF
--- a/lib/agents/tools/search.tsx
+++ b/lib/agents/tools/search.tsx
@@ -81,7 +81,7 @@ export const searchTool = ({ uiStream, fullResponse }: ToolProps) =>
             : searxngSearch)(
             filledQuery,
             max_results,
-            effectiveSearchDepth,
+            effectiveSearchDepth === 'advanced' ? 'advanced' : 'basic',
             include_domains,
             exclude_domains
           )

--- a/lib/schema/search.tsx
+++ b/lib/schema/search.tsx
@@ -7,8 +7,10 @@ export const searchSchema = z.object({
     .number()
     .describe('The maximum number of results to return'),
   search_depth: z
-    .enum(['basic', 'advanced'])
-    .describe('The depth of the search'),
+    .string()
+    .describe(
+      'The depth of the search. Allowed values are "basic" or "advanced"'
+    ),
   include_domains: z
     .array(z.string())
     .optional()


### PR DESCRIPTION
closes: #357 

Solved the issue of the Gemini model not calling tools

Cause:
> The Google Generative AI API uses a subset of the OpenAPI 3.0 schema, which does not support features such as unions.

We are using enum in the schema specification, but it was not supported by the Google Generative AI API

doc: https://sdk.vercel.ai/providers/ai-sdk-providers/google-generative-ai#troubleshooting-schema-limitations
issue: https://github.com/vercel/ai/issues/2926#issuecomment-2337289714