### PR TITLE
Fix: Handle Text Composition and Prevent Premature Form Submission on Enter Key (#360)

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -29,6 +29,19 @@ export function ChatPanel({ messages, query }: ChatPanelProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const isFirstRender = useRef(true) // For development environment
 
+  const [isComposing, setIsComposing] = useState(false) // Composition state
+  const [enterDisabled, setEnterDisabled] = useState(false) // Disable Enter after composition ends
+
+  const handleCompositionStart = () => setIsComposing(true);
+
+  const handleCompositionEnd = () => {
+    setIsComposing(false);
+    setEnterDisabled(true);
+    setTimeout(() => {
+      setEnterDisabled(false);
+    }, 300);
+  };
+
   async function handleQuerySubmit(query: string, formData?: FormData) {
     setInput(query)
     setIsGenerating(true)
@@ -125,6 +138,8 @@ export function ChatPanel({ messages, query }: ChatPanelProps) {
             rows={1}
             maxRows={5}
             tabIndex={0}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
             placeholder="Ask a question..."
             spellCheck={false}
             value={input}
@@ -134,11 +149,12 @@ export function ChatPanel({ messages, query }: ChatPanelProps) {
               setShowEmptyScreen(e.target.value.length === 0)
             }}
             onKeyDown={e => {
-              // Enter should submit the form
+              // Enter should submit the form, but disable it right after IME input confirmation
               if (
                 e.key === 'Enter' &&
                 !e.shiftKey &&
-                !e.nativeEvent.isComposing
+                !isComposing && // Not in composition
+                !enterDisabled // Not within the delay after confirmation
               ) {
                 // Prevent the default action to avoid adding a new line
                 if (input.trim().length === 0) {


### PR DESCRIPTION
This PR addresses [issue #360](https://github.com/miurla/morphic/issues/360), which involves premature form submission when pressing the Enter key during IME input on macOS Safari and other environments that use text composition.

### Key Changes:
1. **Composition State Management**:
   - Added `isComposing` state to track when the user is in the middle of IME (Input Method Editor) input.
   - The form submission is now blocked while composition is ongoing, preventing premature submissions.

2. **Enter Key Behavior with Delay**:
   - The Enter key is disabled briefly after composition ends using `setEnterDisabled`, ensuring that form submission occurs only when composition has fully completed.
   - Added a **300 millisecond delay** after composition ends before re-enabling the Enter key, using `setTimeout`. This ensures that pressing Enter to confirm IME input doesn't trigger unwanted form submission.