### PR TITLE
Fix TypeScript Error in window.prompt Call in Codeblock Component

### DIFF
--- a/components/ui/codeblock.tsx
+++ b/components/ui/codeblock.tsx
@@ -57,7 +57,7 @@ const CodeBlock: FC<Props> = memo(({ language, value }) => {
     }
     const fileExtension = programmingLanguages[language] || '.file'
     const suggestedFileName = `file-${generateId()}${fileExtension}`
-    const fileName = window.prompt('Enter file name' || '', suggestedFileName)
+    const fileName = window.prompt('Enter file name', suggestedFileName)
 
     if (!fileName) {
       // User pressed cancel on prompt.


### PR DESCRIPTION
This PR resolves a TypeScript error encountered while attempting to build the Next.js application.

The error occurred in the Codeblock component due to a redundant || expression in a `window.prompt` call. The issue blocked the build process.

```
./components/ui/codeblock.tsx:60:36
Type error: This kind of expression is always truthy.

  58 |     const fileExtension = programmingLanguages[language] || '.file'
  59 |     const suggestedFileName = `file-${generateId()}${fileExtension}`
> 60 |     const fileName = window.prompt('Enter file name' || '', suggestedFileName)
     |                                    ^
  61 |
  62 |     if (!fileName) {
  63 |       // User pressed cancel on prompt.

Error: Failed to build the Next.js project. Check the logs above.
```

The error arises because the expression 'Enter file name' || '' is always truthy, making the || redundant. TypeScript flagged this as unnecessary, preventing the build.

## Fix
- Removed the redundant || expression. The `window.prompt` call now directly uses the message `'Enter file name'`.

## Testing
- Verified the fix locally by successfully building the application.
- Tested the window.prompt functionality in the browser to confirm the expected behaviour.