### PR TITLE
feat: update Ollama model configuration and enhance tool call support

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -43,8 +43,11 @@ TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]  # Get your API key at: https://app.tavily.
 # Groq
 # GROQ_API_KEY=[YOUR_GROQ_API_KEY]
 
-# Ollama (Local AI)
+# Ollama
 # OLLAMA_BASE_URL=http://localhost:11434
+# NEXT_PUBLIC_OLLAMA_MODEL=[YOUR_MODEL_NAME] (eg: deepseek-r1)
+# If you want to use a different model for tool call, set the model name here.
+# NEXT_PUBLIC_OLLAMA_TOOL_CALL_MODEL=[YOUR_MODEL_NAME] (eg: phi4) (optional)
 
 # Azure OpenAI
 # AZURE_API_KEY=

--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -27,8 +27,8 @@ export function SearchSection({
   const isToolLoading = tool.state === 'call'
   const searchResults: TypeSearchResults =
     tool.state === 'result' ? tool.result : undefined
-  const query = tool.args.query as string | undefined
-  const includeDomains = tool.args.includeDomains as string[] | undefined
+  const query = tool.args?.query as string | undefined
+  const includeDomains = tool.args?.includeDomains as string[] | undefined
   const includeDomainsString = includeDomains
     ? ` [${includeDomains.join(', ')}]`
     : ''

--- a/lib/streaming/parse-tool-call.ts
+++ b/lib/streaming/parse-tool-call.ts
@@ -39,15 +39,17 @@ export function parseToolCallXml<T>(
     // Parse parameters using the provided schema
     const parameters = schema.parse({
       ...rawParameters,
-      // Convert comma-separated strings to arrays for array fields
-      include_domains: rawParameters.include_domains
-        ?.split(',')
-        .map(d => d.trim())
-        .filter(Boolean),
-      exclude_domains: rawParameters.exclude_domains
-        ?.split(',')
-        .map(d => d.trim())
-        .filter(Boolean),
+      // Convert comma-separated strings to arrays for array fields with default empty arrays
+      include_domains:
+        rawParameters.include_domains
+          ?.split(',')
+          .map(d => d.trim())
+          .filter(Boolean) ?? [],
+      exclude_domains:
+        rawParameters.exclude_domains
+          ?.split(',')
+          .map(d => d.trim())
+          .filter(Boolean) ?? [],
       // Convert string to number for numeric fields
       max_results: rawParameters.max_results
         ? parseInt(rawParameters.max_results, 10)

--- a/lib/streaming/tool-execution.ts
+++ b/lib/streaming/tool-execution.ts
@@ -91,8 +91,8 @@ export async function executeToolCall(
     toolCall.parameters?.query ?? '',
     toolCall.parameters?.max_results,
     toolCall.parameters?.search_depth as 'basic' | 'advanced',
-    toolCall.parameters?.include_domains,
-    toolCall.parameters?.exclude_domains
+    toolCall.parameters?.include_domains ?? [],
+    toolCall.parameters?.exclude_domains ?? []
   )
 
   const updatedToolCallAnnotation = {

--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -82,6 +82,7 @@ export const searchTool = tool({
       }
     }
 
+    console.log('completed search')
     return searchResult
   }
 })

--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -61,8 +61,8 @@ export const models: Model[] = [
     providerId: 'groq'
   },
   {
-    id: 'deepseek-r1',
-    name: 'DeepSeek R1',
+    id: process.env.NEXT_PUBLIC_OLLAMA_MODEL || 'deepseek-r1',
+    name: process.env.NEXT_PUBLIC_OLLAMA_MODEL || 'DeepSeek R1',
     provider: 'Ollama',
     providerId: 'ollama'
   },

--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -114,6 +114,7 @@ export function isProviderEnabled(providerId: string): boolean {
 
 export function getToolCallModel(model?: string) {
   const provider = model?.split(':')[0]
+  const modelName = model?.split(':')[1]
   switch (provider) {
     case 'deepseek':
       return getModel('deepseek:deepseek-chat')
@@ -124,15 +125,21 @@ export function getToolCallModel(model?: string) {
     case 'groq':
       return getModel('groq:llama-3.1-8b-instant')
     case 'ollama':
-      return getModel('ollama:phi4')
+      const ollamaModel =
+        process.env.NEXT_PUBLIC_OLLAMA_TOOL_CALL_MODEL || modelName
+      return getModel(`ollama:${ollamaModel}`)
     default:
       return getModel('openai:gpt-4o-mini')
   }
 }
 
 export function isToolCallSupported(model?: string) {
+  const provider = model?.split(':')[0]
   const modelName = model?.split(':')[1]
 
+  if (provider === 'ollama') {
+    return false
+  }
   // Deepseek R1 is not supported
   // Deepseek v3's tool call is unstable, so we include it in the list
   return !modelName?.includes('deepseek')


### PR DESCRIPTION
ref: #419 #420

Make Ollama models configurable through .env

Use `NEXT_PUBLIC_OLLAMA_MODEL`. Falls back to 'deepseek-r1' if not set.

For inference models like deepseek-r1, made it possible to optionally set a separate model for tool calls using `NEXT_PUBLIC_OLLAMA_TOOL_CALL_MODEL`. If not set, it uses `NEXT_PUBLIC_OLLAMA_MODEL`

<img width="368" alt="image" src="https://github.com/user-attachments/assets/87f06aca-10c7-4f94-9965-b6488d009a4e" />
