### PR TITLE
fix: preserve full model name after provider

### DIFF
--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -38,7 +38,8 @@ export const registry = createProviderRegistry({
 })
 
 export function getModel(model: string) {
-  const modelName = model.split(':')[1]
+  const [provider, ...modelNameParts] = model.split(':') ?? []
+  const modelName = modelNameParts.join(':')
   if (model.includes('ollama')) {
     const ollama = createOllama({
       baseURL: `${process.env.OLLAMA_BASE_URL}/api`
@@ -113,8 +114,8 @@ export function isProviderEnabled(providerId: string): boolean {
 }
 
 export function getToolCallModel(model?: string) {
-  const provider = model?.split(':')[0]
-  const modelName = model?.split(':')[1]
+  const [provider, ...modelNameParts] = model?.split(':') ?? []
+  const modelName = modelNameParts.join(':')
   switch (provider) {
     case 'deepseek':
       return getModel('deepseek:deepseek-chat')
@@ -134,8 +135,8 @@ export function getToolCallModel(model?: string) {
 }
 
 export function isToolCallSupported(model?: string) {
-  const provider = model?.split(':')[0]
-  const modelName = model?.split(':')[1]
+  const [provider, ...modelNameParts] = model?.split(':') ?? []
+  const modelName = modelNameParts.join(':')
 
   if (provider === 'ollama') {
     return false


### PR DESCRIPTION
## Issue
When using model names with multiple colons (e.g., "ollama:deepseek-r1:32b"), the function was only capturing the first part after the provider ("deepseek-r1"), dropping the rest of the model specification: https://github.com/miurla/morphic/issues/420#issuecomment-2636302096

## Solution
Modified the model name parsing to preserve everything after the provider prefix, allowing for proper handling of complex model names like "ollama:deepseek-r1:32b".

## Example
Before:
- Input: "ollama:deepseek-r1:32b"
- Result: modelName = "deepseek-r1"

After:
- Input: "ollama:deepseek-r1:32b"
- Result: modelName = "deepseek-r1:32b"