### PR TITLE
fix: use bun start for production mode in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 # Base image
 FROM oven/bun:1.1.3-alpine AS builder
 
@@ -27,5 +26,5 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/bun.lockb ./bun.lockb
 COPY --from=builder /app/node_modules ./node_modules
 
-# Start development server
-CMD ["bun", "dev", "-H", "0.0.0.0"]
+# Start production server
+CMD ["bun", "start", "-H", "0.0.0.0"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,13 +4,13 @@ name: morphic-stack
 services:
   morphic:
     image: ghcr.io/${GITHUB_REPOSITORY:-your-username/morphic}:latest
+    command: bun start -H 0.0.0.0
     build:
       context: .
       dockerfile: Dockerfile
       cache_from:
         - morphic:builder
         - morphic:latest
-    command: bun dev -H 0.0.0.0
     env_file: .env.local # Load environment variables
     ports:
       - '3000:3000' # Maps port 3000 on the host to port 3000 in the container.


### PR DESCRIPTION
fix: #432 

- Update docker-compose.yaml to use bun start
- Ensure consistency with Dockerfile CMD
- Optimize for production environment