### PR TITLE
docs: remove prebuilt image documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,25 +145,6 @@ Host your own live version of Morphic with Vercel, Cloudflare Pages, or Docker.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmiurla%2Fmorphic&env=OPENAI_API_KEY,TAVILY_API_KEY,UPSTASH_REDIS_REST_URL,UPSTASH_REDIS_REST_TOKEN)
 
-### Docker Prebuilt Image
-
-Prebuilt Docker images are available on GitHub Container Registry:
-
-```bash
-docker pull ghcr.io/miurla/morphic:latest
-```
-
-You can use it with docker-compose:
-
-```yaml
-services:
-  morphic:
-    image: ghcr.io/miurla/morphic:latest
-    env_file: .env.local
-    ports:
-      - '3000:3000'
-```
-
 ## 🔎 Search Engine
 
 ### Setting up the Search Engine in Your Browser


### PR DESCRIPTION
Due to limitations with NEXT_PUBLIC_ environment variables in pre-built Docker images, removing the prebuilt image documentation from README. Users should use docker-compose up instead for now.

Related to #439