### PR TITLE
fix: add env flag to disable chat history saving

### DIFF
--- a/lib/streaming/handle-stream-finish.ts
+++ b/lib/streaming/handle-stream-finish.ts
@@ -64,6 +64,10 @@ export async function handleStreamFinish({
       ...responseMessages.slice(-1)
     ] as ExtendedCoreMessage[]
 
+    if (process.env.NEXT_PUBLIC_ENABLE_SAVE_CHAT_HISTORY !== 'true') {
+      return
+    }
+
     // Get the chat from the database if it exists, otherwise create a new one
     const savedChat = (await getChat(chatId)) ?? {
       messages: [],


### PR DESCRIPTION
## Changes
- Add environment variable `NEXT_PUBLIC_ENABLE_SAVE_CHAT_HISTORY` to control chat history saving
- When set to 'false', the function returns early without saving chat history
