### PR TITLE
fix: filter out disabled models from UI

### DIFF
--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -19,14 +19,16 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 
 function groupModelsByProvider(models: Model[]) {
-  return models.reduce((groups, model) => {
-    const provider = model.provider
-    if (!groups[provider]) {
-      groups[provider] = []
-    }
-    groups[provider].push(model)
-    return groups
-  }, {} as Record<string, Model[]>)
+  return models
+    .filter(model => model.enabled)
+    .reduce((groups, model) => {
+      const provider = model.provider
+      if (!groups[provider]) {
+        groups[provider] = []
+      }
+      groups[provider].push(model)
+      return groups
+    }, {} as Record<string, Model[]>)
 }
 
 interface ModelSelectorProps {


### PR DESCRIPTION
- Add filter to groupModelsByProvider to only show enabled models
- Improve user experience by hiding unavailable models