### PR TITLE
feat: add BASE_URL environment variable support for Docker environments

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,6 +9,9 @@ OPENAI_API_KEY=[YOUR_OPENAI_API_KEY]
 # Search Configuration
 TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]  # Get your API key at: https://app.tavily.com/home
 
+# Optional Docker Configuration (only needed in some Docker environments)
+# BASE_URL=http://localhost:3000  # Use only if models.json fails to load in Docker
+
 ###############################################################################
 # Optional Features
 # Enable these features by uncommenting and configuring the settings below


### PR DESCRIPTION
# Add BASE_URL environment variable support for Docker environments

## Overview
Added support for the `BASE_URL` environment variable to solve resource loading issues (especially `models.json`) in Docker environments. This makes Docker setup easier and provides a more intuitive configuration for users.

## Changes
1. **lib/config/models.ts**:
   - Check for the `BASE_URL` environment variable first and prioritize it if set
   - Fall back to header-based URL retrieval if the environment variable is invalid
   - Refactored code to separate header-based URL retrieval into a helper function

2. **.env.local.example**:
   - Added documentation for the `BASE_URL` environment variable that may be needed in Docker environments

## Related Issues
- Fixes #469 - Docker prebuilt image fails to load models.json

## Testing
- Verified that `models.json` loads correctly when the `BASE_URL` environment variable is set in a Docker environment
- Confirmed that existing behavior is maintained when the environment variable is not set

## Additional Information
This change makes using Morphic in Docker environments easier and provides a solution that doesn't feel "hackish" to users.