### PR TITLE
fix: display search results from manual tool calls

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -77,6 +77,9 @@ export function ChatMessages({
   const showLoading = isLoading && messages[messages.length - 1].role === 'user'
 
   const getIsOpen = (id: string) => {
+    if (id.includes('call')) {
+      return openStates[id] ?? true
+    }
     const baseId = id.endsWith('-related') ? id.slice(0, -8) : id
     const index = messages.findIndex(msg => msg.id === baseId)
     return openStates[id] ?? index >= lastUserIndex

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -95,6 +95,14 @@ export function RenderMessage({
   // New way: Use parts instead of toolInvocations
   return (
     <>
+      {toolData.map(tool => (
+        <ToolSection
+          key={tool.toolCallId}
+          tool={tool}
+          isOpen={getIsOpen(tool.toolCallId)}
+          onOpenChange={open => onOpenChange(tool.toolCallId, open)}
+        />
+      ))}
       {message.parts?.map((part, index) => {
         switch (part.type) {
           case 'tool-invocation':


### PR DESCRIPTION
This PR fixes the issue where search results from manual tool calls were not being displayed after the recent changes in PR #473 and #474.

## Changes:
1. Added support for rendering results from `toolData` in `render-message.tsx`, ensuring manual tool call results are displayed.
2. Enhanced the `getIsOpen` function in `chat-messages.tsx` to properly handle tool call IDs, defaulting them to open state.

This fixes issue #476.

## Screenshot
![image](https://github.com/user-attachments/assets/bdcb86cc-a8e8-49fe-a1cd-2295d4820ba2)
