### PR TITLE
Add Gemini 2.5 Pro (Experimental) model

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ This will allow you to use Morphic as your default search engine in the browser.
   - gpt-4-turbo
   - gpt-3.5-turbo
 - Google
-  - Gemini 2.0 Pro (Experimental)
+  - Gemini 2.5 Pro (Experimental)
   - Gemini 2.0 Flash Thinking (Experimental)
   - Gemini 2.0 Flash
 - Anthropic

--- a/lib/config/default-models.json
+++ b/lib/config/default-models.json
@@ -65,8 +65,8 @@
       "toolCallType": "manual"
     },
     {
-      "id": "gemini-2.0-pro-exp-02-05",
-      "name": "Gemini 2.0 Pro (Exp)",
+      "id": "gemini-2.0-flash-thinking-exp-01-21",
+      "name": "Gemini 2.0 Flash Thinking (Exp)",
       "provider": "Google Generative AI",
       "providerId": "google",
       "enabled": true,
@@ -74,8 +74,8 @@
       "toolCallModel": "gemini-2.0-flash"
     },
     {
-      "id": "gemini-2.0-flash-thinking-exp-01-21",
-      "name": "Gemini 2.0 Flash Thinking (Exp)",
+      "id": "gemini-2.5-pro-exp-03-25",
+      "name": "Gemini 2.5 Pro (Exp)",
       "provider": "Google Generative AI",
       "providerId": "google",
       "enabled": true,

--- a/public/config/models.json
+++ b/public/config/models.json
@@ -65,8 +65,8 @@
       "toolCallType": "manual"
     },
     {
-      "id": "gemini-2.0-pro-exp-02-05",
-      "name": "Gemini 2.0 Pro (Exp)",
+      "id": "gemini-2.0-flash-thinking-exp-01-21",
+      "name": "Gemini 2.0 Flash Thinking (Exp)",
       "provider": "Google Generative AI",
       "providerId": "google",
       "enabled": true,
@@ -74,8 +74,8 @@
       "toolCallModel": "gemini-2.0-flash"
     },
     {
-      "id": "gemini-2.0-flash-thinking-exp-01-21",
-      "name": "Gemini 2.0 Flash Thinking (Exp)",
+      "id": "gemini-2.5-pro-exp-03-25",
+      "name": "Gemini 2.5 Pro (Exp)",
       "provider": "Google Generative AI",
       "providerId": "google",
       "enabled": true,


### PR DESCRIPTION
## Changes

- Added Gemini 2.5 Pro (Experimental) model configuration
- Removed deprecated Gemini 2.0 Pro (Experimental) model
- Updated verified models list in README.md

### Model Configuration Details
- ID: `gemini-2.5-pro-exp-03-25`
- Name: "Gemini 2.5 Pro (Exp)"
- Provider: Google Generative AI
- Tool Call: Manual (using gemini-2.0-flash as tool call model)

### Files Changed
- `public/config/models.json`
- `lib/config/default-models.json`
- `README.md`