### PR TITLE
Only show MessageActions on the last text part

### DIFF
--- a/components/answer-section.tsx
+++ b/components/answer-section.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Text } from 'lucide-react'
 import { CollapsibleMessage } from './collapsible-message'
 import { DefaultSkeleton } from './default-skeleton'
 import { BotMessage } from './message'
@@ -11,30 +10,28 @@ export type AnswerSectionProps = {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
   chatId?: string
+  showActions?: boolean
 }
 
 export function AnswerSection({
   content,
   isOpen,
   onOpenChange,
-  chatId
+  chatId,
+  showActions = true // Default to true for backward compatibility
 }: AnswerSectionProps) {
   const enableShare = process.env.NEXT_PUBLIC_ENABLE_SHARE === 'true'
 
-  const header = (
-    <div className="flex items-center gap-1">
-      <Text size={16} />
-      <div>Answer</div>
-    </div>
-  )
   const message = content ? (
     <div className="flex flex-col gap-1">
       <BotMessage message={content} />
-      <MessageActions
-        message={content}
-        chatId={chatId}
-        enableShare={enableShare}
-      />
+      {showActions && (
+        <MessageActions
+          message={content}
+          chatId={chatId}
+          enableShare={enableShare}
+        />
+      )}
     </div>
   ) : (
     <DefaultSkeleton />
@@ -43,7 +40,6 @@ export function AnswerSection({
     <CollapsibleMessage
       role="assistant"
       isCollapsible={false}
-      header={header}
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       showBorder={false}

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -104,6 +104,9 @@ export function RenderMessage({
         />
       ))}
       {message.parts?.map((part, index) => {
+        // Check if this is the last part in the array
+        const isLastPart = index === (message.parts?.length ?? 0) - 1
+
         switch (part.type) {
           case 'tool-invocation':
             return (
@@ -117,6 +120,7 @@ export function RenderMessage({
               />
             )
           case 'text':
+            // Only show actions if this is the last part and it's a text part
             return (
               <AnswerSection
                 key={`${messageId}-text-${index}`}
@@ -124,6 +128,7 @@ export function RenderMessage({
                 isOpen={getIsOpen(messageId)}
                 onOpenChange={open => onOpenChange(messageId, open)}
                 chatId={chatId}
+                showActions={isLastPart}
               />
             )
           case 'reasoning':


### PR DESCRIPTION
Only show actions on the last text part of a message to improve UI clarity.