### PR TITLE
Add help message to empty chat screen

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -82,8 +82,11 @@ export function ChatPanel({
       )}
     >
       {messages.length === 0 && (
-        <div className="mb-8">
+        <div className="mb-10 flex flex-col items-center gap-4">
           <IconLogo className="size-12 text-muted-foreground" />
+          <p className="text-center text-3xl font-semibold">
+            How can I help you today?
+          </p>
         </div>
       )}
       <form
@@ -105,7 +108,7 @@ export function ChatPanel({
             placeholder="Ask a question..."
             spellCheck={false}
             value={input}
-            className="resize-none w-full min-h-12 bg-transparent border-0 px-4 py-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="resize-none w-full min-h-12 bg-transparent border-0 p-4 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             onChange={e => {
               handleInputChange(e)
               setShowEmptyScreen(e.target.value.length === 0)


### PR DESCRIPTION
This PR adds a welcome message "How can I help you today?" below the logo on the empty chat screen.

Changes:
- Added a bold, large text message below the logo
- Improved styling with better spacing
- Centered the text with the logo
- Adjusted the input field padding for consistency