### PR TITLE
Add new AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,17 @@ This will allow you to use Morphic as your default search engine in the browser.
   - deepseek-r1
 - Groq
   - deepseek-r1-distill-llama-70b
+  - Llama 4 Maverick 17B
+- Fireworks
+  - DeepSeek R1
+  - Llama 4 Maverick
 - DeepSeek
   - DeepSeek V3
   - DeepSeek R1
 - xAI
   - grok-2
   - grok-2-vision
+  - grok-3-beta
 
 ## ⚡ AI SDK Implementation
 

--- a/lib/config/default-models.json
+++ b/lib/config/default-models.json
@@ -92,6 +92,15 @@
       "toolCallModel": "accounts/fireworks/models/llama-v3p1-8b-instruct"
     },
     {
+      "id": "accounts/fireworks/models/llama4-maverick-instruct-basic",
+      "name": "Llama 4 Maverick",
+      "provider": "Fireworks",
+      "providerId": "fireworks",
+      "enabled": true,
+      "toolCallType": "manual",
+      "toolCallModel": "accounts/fireworks/models/llama-v3p1-8b-instruct"
+    },
+    {
       "id": "deepseek-reasoner",
       "name": "DeepSeek R1",
       "provider": "DeepSeek",

--- a/lib/config/default-models.json
+++ b/lib/config/default-models.json
@@ -152,6 +152,14 @@
       "toolCallType": "native"
     },
     {
+      "id": "grok-3-beta",
+      "name": "Grok 3 Beta",
+      "provider": "xAI",
+      "providerId": "xai",
+      "enabled": true,
+      "toolCallType": "native"
+    },
+    {
       "id": "<OPENAI_COMPATIBLE_MODEL>",
       "name": "<OPENAI_COMPATIBLE_MODEL>",
       "provider": "OpenAI Compatible",

--- a/lib/config/default-models.json
+++ b/lib/config/default-models.json
@@ -118,6 +118,14 @@
       "toolCallModel": "llama-3.1-8b-instant"
     },
     {
+      "id": "meta-llama/llama-4-maverick-17b-128e-instruct",
+      "name": "Llama 4 Maverick 17B",
+      "provider": "Groq",
+      "providerId": "groq",
+      "enabled": true,
+      "toolCallType": "native"
+    },
+    {
       "id": "deepseek-r1",
       "name": "DeepSeek R1",
       "provider": "Ollama",

--- a/public/config/models.json
+++ b/public/config/models.json
@@ -92,6 +92,15 @@
       "toolCallModel": "accounts/fireworks/models/llama-v3p1-8b-instruct"
     },
     {
+      "id": "accounts/fireworks/models/llama4-maverick-instruct-basic",
+      "name": "Llama 4 Maverick",
+      "provider": "Fireworks",
+      "providerId": "fireworks",
+      "enabled": true,
+      "toolCallType": "manual",
+      "toolCallModel": "accounts/fireworks/models/llama-v3p1-8b-instruct"
+    },
+    {
       "id": "deepseek-reasoner",
       "name": "DeepSeek R1",
       "provider": "DeepSeek",

--- a/public/config/models.json
+++ b/public/config/models.json
@@ -152,6 +152,14 @@
       "toolCallType": "native"
     },
     {
+      "id": "grok-3-beta",
+      "name": "Grok 3 Beta",
+      "provider": "xAI",
+      "providerId": "xai",
+      "enabled": true,
+      "toolCallType": "native"
+    },
+    {
       "id": "<OPENAI_COMPATIBLE_MODEL>",
       "name": "<OPENAI_COMPATIBLE_MODEL>",
       "provider": "OpenAI Compatible",

--- a/public/config/models.json
+++ b/public/config/models.json
@@ -118,6 +118,14 @@
       "toolCallModel": "llama-3.1-8b-instant"
     },
     {
+      "id": "meta-llama/llama-4-maverick-17b-128e-instruct",
+      "name": "Llama 4 Maverick 17B",
+      "provider": "Groq",
+      "providerId": "groq",
+      "enabled": true,
+      "toolCallType": "native"
+    },
+    {
       "id": "deepseek-r1",
       "name": "DeepSeek R1",
       "provider": "Ollama",


### PR DESCRIPTION
## Description

This PR adds support for the following new AI models:

- **xAI:**
  - Added Grok 3 Beta model with native tool call support

- **Groq:**
  - Added Llama 4 Maverick 17B model with native tool call support

- **Fireworks:**
  - Added Llama 4 Maverick model with manual tool call support

## Changes

- Added new model configurations to both `lib/config/default-models.json` and `public/config/models.json`
- Updated the Verified Models section in README.md to reflect the newly added models

## Testing

Verified that the models appear in the UI model selector.

## Additional Notes

These models require their respective API keys to be configured in the environment variables as described in the documentation.