### PR TITLE
Fix: Add experimental_throttle to useChat to prevent infinite update loops

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -42,7 +42,8 @@ export function Chat({
     onError: error => {
       toast.error(`Error in chat: ${error.message}`)
     },
-    sendExtraMessageFields: false // Disable extra message fields
+    sendExtraMessageFields: false, // Disable extra message fields,
+    experimental_throttle: 100
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR adds the `experimental_throttle` option to the `useChat` hook to prevent infinite update loops that were causing the 'Maximum update depth exceeded' error.

## Issue

The application was experiencing a React error: 'Maximum update depth exceeded'. This occurs when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate, creating an infinite loop.

## Solution

Added the `experimental_throttle: 100` option to the `useChat` hook configuration to limit update frequency and prevent the infinite loop.