### PR TITLE
Fix: Update deprecated useChat import from ai/react to @ai-sdk/react

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -2,7 +2,8 @@
 
 import { CHAT_ID } from '@/lib/constants'
 import { Model } from '@/lib/types/models'
-import { Message, useChat } from 'ai/react'
+import { useChat } from '@ai-sdk/react'
+import { Message } from 'ai/react'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { ChatMessages } from './chat-messages'
@@ -24,7 +25,7 @@ export function Chat({
     input,
     handleInputChange,
     handleSubmit,
-    isLoading,
+    status,
     setMessages,
     stop,
     append,
@@ -45,6 +46,8 @@ export function Chat({
     sendExtraMessageFields: false, // Disable extra message fields,
     experimental_throttle: 100
   })
+
+  const isLoading = status === 'submitted' || status === 'streaming'
 
   useEffect(() => {
     setMessages(savedMessages)


### PR DESCRIPTION
## Description

This PR updates the deprecated `useChat` import from `ai/react` to `@ai-sdk/react` and makes the necessary adjustments to work with the new API.

## Changes

1. Changed the import source for `useChat` from `ai/react` to `@ai-sdk/react`
2. Kept the `Message` import from `ai/react`
3. Updated the API usage:
   - The `isLoading` property is no longer directly available from the hook
   - Added a derived `isLoading` variable based on the `status` property: `status === 'submitted' || status === 'streaming'`

## Rationale

The `useChat` hook from `ai/react` is deprecated, and the recommended replacement is to use `@ai-sdk/react` instead. This change ensures we're using the current supported version of the hook while maintaining the same functionality.