### PR TITLE
Add ask_question tool and improve tool UX

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -10,6 +10,7 @@ interface ChatMessagesProps {
   onQuerySelect: (query: string) => void
   isLoading: boolean
   chatId?: string
+  addToolResult?: (params: { toolCallId: string; result: any }) => void
 }
 
 export function ChatMessages({
@@ -17,7 +18,8 @@ export function ChatMessages({
   data,
   onQuerySelect,
   isLoading,
-  chatId
+  chatId,
+  addToolResult
 }: ChatMessagesProps) {
   const [openStates, setOpenStates] = useState<Record<string, boolean>>({})
   const manualToolCallId = 'manual-tool-call'
@@ -103,6 +105,7 @@ export function ChatMessages({
             onOpenChange={handleOpenChange}
             onQuerySelect={onQuerySelect}
             chatId={chatId}
+            addToolResult={addToolResult}
           />
         </div>
       ))}
@@ -113,6 +116,7 @@ export function ChatMessages({
             tool={lastToolData}
             isOpen={getIsOpen(manualToolCallId)}
             onOpenChange={open => handleOpenChange(manualToolCallId, open)}
+            addToolResult={addToolResult}
           />
         ) : (
           <Spinner />

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -60,6 +60,21 @@ export function ChatPanel({
     router.push('/')
   }
 
+  const isToolInvocationInProgress = () => {
+    if (!messages.length) return false
+
+    const lastMessage = messages[messages.length - 1]
+    if (lastMessage.role !== 'assistant' || !lastMessage.parts) return false
+
+    const parts = lastMessage.parts
+    const lastPart = parts[parts.length - 1]
+
+    return (
+      lastPart?.type === 'tool-invocation' &&
+      lastPart?.toolInvocation?.state === 'call'
+    )
+  }
+
   // if query is not empty, submit the query
   useEffect(() => {
     if (isFirstRender.current && query && query.trim().length > 0) {
@@ -108,6 +123,7 @@ export function ChatPanel({
             placeholder="Ask a question..."
             spellCheck={false}
             value={input}
+            disabled={isLoading || isToolInvocationInProgress()}
             className="resize-none w-full min-h-12 bg-transparent border-0 p-4 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             onChange={e => {
               handleInputChange(e)
@@ -147,7 +163,7 @@ export function ChatPanel({
                   onClick={handleNewChat}
                   className="shrink-0 rounded-full group"
                   type="button"
-                  disabled={isLoading}
+                  disabled={isLoading || isToolInvocationInProgress()}
                 >
                   <MessageCirclePlus className="size-4 group-hover:rotate-12 transition-all" />
                 </Button>
@@ -157,7 +173,10 @@ export function ChatPanel({
                 size={'icon'}
                 variant={'outline'}
                 className={cn(isLoading && 'animate-pulse', 'rounded-full')}
-                disabled={input.length === 0 && !isLoading}
+                disabled={
+                  (input.length === 0 && !isLoading) ||
+                  isToolInvocationInProgress()
+                }
                 onClick={isLoading ? stop : undefined}
               >
                 {isLoading ? <Square size={20} /> : <ArrowUp size={20} />}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -29,7 +29,8 @@ export function Chat({
     stop,
     append,
     data,
-    setData
+    setData,
+    addToolResult
   } = useChat({
     initialMessages: savedMessages,
     id: CHAT_ID,
@@ -70,6 +71,7 @@ export function Chat({
         onQuerySelect={onQuerySelect}
         isLoading={isLoading}
         chatId={id}
+        addToolResult={addToolResult}
       />
       <ChatPanel
         input={input}

--- a/components/question-confirmation.tsx
+++ b/components/question-confirmation.tsx
@@ -11,7 +11,6 @@ import { useState } from 'react'
 interface QuestionConfirmationProps {
   toolInvocation: ToolInvocation
   onConfirm: (toolCallId: string, approved: boolean, response?: any) => void
-  pending?: boolean
   isCompleted?: boolean
 }
 
@@ -23,7 +22,6 @@ interface QuestionOption {
 export function QuestionConfirmation({
   toolInvocation,
   onConfirm,
-  pending = false,
   isCompleted = false
 }: QuestionConfirmationProps) {
   const { question, options, allowsInput, inputLabel, inputPlaceholder } =
@@ -38,14 +36,10 @@ export function QuestionConfirmation({
   const [selectedOptions, setSelectedOptions] = useState<string[]>([])
   const [inputText, setInputText] = useState('')
   const [completed, setCompleted] = useState(isCompleted)
-  const [isGenerating, setIsGenerating] = useState(false)
   const [skipped, setSkipped] = useState(false)
 
   const isButtonDisabled =
-    (selectedOptions.length === 0 &&
-      (!allowsInput || inputText.trim() === '')) ||
-    pending ||
-    isGenerating
+    selectedOptions.length === 0 && (!allowsInput || inputText.trim() === '')
 
   const handleOptionChange = (label: string) => {
     setSelectedOptions(prev => {
@@ -69,7 +63,6 @@ export function QuestionConfirmation({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    setIsGenerating(true)
 
     const response = {
       selectedOptions,
@@ -193,12 +186,7 @@ export function QuestionConfirmation({
           )}
 
           <div className="flex justify-end space-x-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleSkip}
-              disabled={pending || isGenerating}
-            >
+            <Button type="button" variant="outline" onClick={handleSkip}>
               <SkipForward size={16} className="mr-1" />
               Skip
             </Button>

--- a/components/question-confirmation.tsx
+++ b/components/question-confirmation.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card'
+import { ToolInvocation } from 'ai'
+
+interface QuestionConfirmationProps {
+  toolInvocation: ToolInvocation
+  onConfirm: (toolCallId: string, approved: boolean) => void
+}
+
+interface QuestionOption {
+  value: string
+  label: string
+}
+
+export function QuestionConfirmation({
+  toolInvocation,
+  onConfirm
+}: QuestionConfirmationProps) {
+  const { question, options, allowsInput, inputLabel, inputPlaceholder } =
+    toolInvocation.args
+
+  return (
+    <Card className="my-4 border border-yellow-200 bg-yellow-50">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          AI wants to ask a clarifying question
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="font-medium mb-2">{question}</p>
+        {options && options.length > 0 && (
+          <div>
+            <p className="text-sm text-gray-500 mb-1">With these options:</p>
+            <ul className="list-disc pl-5">
+              {options.map((option: QuestionOption, i: number) => (
+                <li key={i}>{option.label}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {allowsInput && (
+          <p className="text-sm text-gray-500 mt-2">
+            {inputLabel
+              ? `With free input: ${inputLabel}`
+              : 'With free text input option'}
+          </p>
+        )}
+      </CardContent>
+      <CardFooter className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          onClick={() => onConfirm(toolInvocation.toolCallId, false)}
+        >
+          Decline
+        </Button>
+        <Button onClick={() => onConfirm(toolInvocation.toolCallId, true)}>
+          Allow Question
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/components/question-confirmation.tsx
+++ b/components/question-confirmation.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle
-} from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
 import { ToolInvocation } from 'ai'
+import { ArrowRight, Check, FastForward } from 'lucide-react'
+import { useState } from 'react'
 
 interface QuestionConfirmationProps {
   toolInvocation: ToolInvocation
-  onConfirm: (toolCallId: string, approved: boolean) => void
+  onConfirm: (toolCallId: string, approved: boolean, response?: any) => void
+  pending?: boolean
 }
 
 interface QuestionOption {
@@ -22,49 +21,143 @@ interface QuestionOption {
 
 export function QuestionConfirmation({
   toolInvocation,
-  onConfirm
+  onConfirm,
+  pending = false
 }: QuestionConfirmationProps) {
   const { question, options, allowsInput, inputLabel, inputPlaceholder } =
     toolInvocation.args
 
+  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const [inputText, setInputText] = useState('')
+  const [completed, setCompleted] = useState(false)
+  const [isGenerating, setIsGenerating] = useState(false)
+
+  const isButtonDisabled =
+    (selectedOptions.length === 0 &&
+      (!allowsInput || inputText.trim() === '')) ||
+    pending ||
+    isGenerating
+
+  const handleOptionChange = (label: string) => {
+    setSelectedOptions(prev => {
+      if (prev.includes(label)) {
+        return prev.filter(item => item !== label)
+      } else {
+        return [...prev, label]
+      }
+    })
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputText(e.target.value)
+  }
+
+  const handleSkip = () => {
+    onConfirm(toolInvocation.toolCallId, false, { skipped: true })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsGenerating(true)
+
+    const response = {
+      selectedOptions,
+      inputText: inputText.trim(),
+      question
+    }
+
+    onConfirm(toolInvocation.toolCallId, true, response)
+    setCompleted(true)
+  }
+
+  const updatedQuery = () => {
+    const optionsText =
+      selectedOptions.length > 0
+        ? `Selected: ${selectedOptions.join(', ')}`
+        : ''
+
+    const inputTextDisplay =
+      inputText.trim() !== '' ? `Input: ${inputText}` : ''
+
+    return [optionsText, inputTextDisplay].filter(Boolean).join(' | ')
+  }
+
+  if (completed) {
+    return (
+      <Card className="p-3 md:p-4 w-full flex justify-between items-center">
+        <div className="flex items-center space-x-2 flex-1 min-w-0">
+          <h5 className="text-muted-foreground text-xs truncate">
+            {updatedQuery()}
+          </h5>
+        </div>
+        <Check size={16} className="text-green-500 w-4 h-4" />
+      </Card>
+    )
+  }
+
   return (
-    <Card className="my-4 border border-yellow-200 bg-yellow-50">
+    <Card>
       <CardHeader>
-        <CardTitle className="text-lg">
-          AI wants to ask a clarifying question
-        </CardTitle>
+        <CardTitle className="text-lg">{question}</CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="font-medium mb-2">{question}</p>
-        {options && options.length > 0 && (
-          <div>
-            <p className="text-sm text-gray-500 mb-1">With these options:</p>
-            <ul className="list-disc pl-5">
-              {options.map((option: QuestionOption, i: number) => (
-                <li key={i}>{option.label}</li>
+        <form onSubmit={handleSubmit}>
+          <div className="flex flex-wrap justify-start mb-4">
+            {options &&
+              options.map((option: QuestionOption, index: number) => (
+                <div
+                  key={`option-${index}`}
+                  className="flex items-center space-x-1.5 mb-2"
+                >
+                  <Checkbox
+                    id={option.value}
+                    checked={selectedOptions.includes(option.label)}
+                    onCheckedChange={() => handleOptionChange(option.label)}
+                  />
+                  <label
+                    className="text-sm whitespace-nowrap pr-4"
+                    htmlFor={option.value}
+                  >
+                    {option.label}
+                  </label>
+                </div>
               ))}
-            </ul>
           </div>
-        )}
-        {allowsInput && (
-          <p className="text-sm text-gray-500 mt-2">
-            {inputLabel
-              ? `With free input: ${inputLabel}`
-              : 'With free text input option'}
-          </p>
-        )}
+
+          {allowsInput && (
+            <div className="mb-6 flex flex-col space-y-2 text-sm">
+              <label className="text-muted-foreground" htmlFor="query">
+                {inputLabel}
+              </label>
+              <Input
+                type="text"
+                name="additional_query"
+                className="w-full"
+                id="query"
+                placeholder={inputPlaceholder}
+                value={inputText}
+                onChange={handleInputChange}
+              />
+            </div>
+          )}
+
+          <div className="flex justify-end space-x-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleSkip}
+              disabled={pending || isGenerating}
+            >
+              <FastForward size={16} className="mr-1" />
+              Skip
+            </Button>
+            <Button type="submit" disabled={isButtonDisabled}>
+              <ArrowRight size={16} className="mr-1" />
+              Send
+            </Button>
+          </div>
+        </form>
       </CardContent>
-      <CardFooter className="flex justify-end gap-2">
-        <Button
-          variant="outline"
-          onClick={() => onConfirm(toolInvocation.toolCallId, false)}
-        >
-          Decline
-        </Button>
-        <Button onClick={() => onConfirm(toolInvocation.toolCallId, true)}>
-          Allow Question
-        </Button>
-      </CardFooter>
     </Card>
   )
 }

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -13,6 +13,7 @@ interface RenderMessageProps {
   onOpenChange: (id: string, open: boolean) => void
   onQuerySelect: (query: string) => void
   chatId?: string
+  addToolResult?: (params: { toolCallId: string; result: any }) => void
 }
 
 export function RenderMessage({
@@ -21,7 +22,8 @@ export function RenderMessage({
   getIsOpen,
   onOpenChange,
   onQuerySelect,
-  chatId
+  chatId,
+  addToolResult
 }: RenderMessageProps) {
   const relatedQuestions = useMemo(
     () =>
@@ -101,6 +103,7 @@ export function RenderMessage({
           tool={tool}
           isOpen={getIsOpen(tool.toolCallId)}
           onOpenChange={open => onOpenChange(tool.toolCallId, open)}
+          addToolResult={addToolResult}
         />
       ))}
       {message.parts?.map((part, index) => {
@@ -114,6 +117,7 @@ export function RenderMessage({
                 onOpenChange={open =>
                   onOpenChange(part.toolInvocation.toolCallId, open)
                 }
+                addToolResult={addToolResult}
               />
             )
           case 'text':

--- a/components/tool-section.tsx
+++ b/components/tool-section.tsx
@@ -27,8 +27,6 @@ export function ToolSection({
         <QuestionConfirmation
           toolInvocation={tool}
           onConfirm={(toolCallId, approved, response) => {
-            // If approved, return the response with user selections
-            // If declined, return a message that the user declined
             addToolResult({
               toolCallId,
               result: approved

--- a/components/tool-section.tsx
+++ b/components/tool-section.tsx
@@ -1,17 +1,47 @@
 'use client'
 
 import { ToolInvocation } from 'ai'
+import { QuestionConfirmation } from './question-confirmation'
+import RetrieveSection from './retrieve-section'
 import { SearchSection } from './search-section'
 import { VideoSearchSection } from './video-search-section'
-import RetrieveSection from './retrieve-section'
 
 interface ToolSectionProps {
   tool: ToolInvocation
   isOpen: boolean
   onOpenChange: (open: boolean) => void
+  addToolResult?: (params: { toolCallId: string; result: any }) => void
 }
 
-export function ToolSection({ tool, isOpen, onOpenChange }: ToolSectionProps) {
+export function ToolSection({
+  tool,
+  isOpen,
+  onOpenChange,
+  addToolResult
+}: ToolSectionProps) {
+  // Special handling for ask_question tool
+  if (
+    tool.toolName === 'ask_question' &&
+    tool.state === 'call' &&
+    addToolResult
+  ) {
+    return (
+      <QuestionConfirmation
+        toolInvocation={tool}
+        onConfirm={(toolCallId, approved) => {
+          // If approved, return the original args so the question can be displayed
+          // If declined, return a message that the user declined
+          addToolResult({
+            toolCallId,
+            result: approved
+              ? tool.args
+              : { declined: true, message: 'User declined this question' }
+          })
+        }}
+      />
+    )
+  }
+
   switch (tool.toolName) {
     case 'search':
       return (

--- a/components/tool-section.tsx
+++ b/components/tool-section.tsx
@@ -20,30 +20,40 @@ export function ToolSection({
   addToolResult
 }: ToolSectionProps) {
   // Special handling for ask_question tool
-  if (
-    tool.toolName === 'ask_question' &&
-    tool.state === 'call' &&
-    addToolResult
-  ) {
-    return (
-      <QuestionConfirmation
-        toolInvocation={tool}
-        onConfirm={(toolCallId, approved, response) => {
-          // If approved, return the response with user selections
-          // If declined, return a message that the user declined
-          addToolResult({
-            toolCallId,
-            result: approved
-              ? response
-              : {
-                  declined: true,
-                  skipped: response?.skipped,
-                  message: 'User declined this question'
-                }
-          })
-        }}
-      />
-    )
+  if (tool.toolName === 'ask_question') {
+    // When waiting for user input
+    if (tool.state === 'call' && addToolResult) {
+      return (
+        <QuestionConfirmation
+          toolInvocation={tool}
+          onConfirm={(toolCallId, approved, response) => {
+            // If approved, return the response with user selections
+            // If declined, return a message that the user declined
+            addToolResult({
+              toolCallId,
+              result: approved
+                ? response
+                : {
+                    declined: true,
+                    skipped: response?.skipped,
+                    message: 'User declined this question'
+                  }
+            })
+          }}
+        />
+      )
+    }
+
+    // When result is available, display the result
+    if (tool.state === 'result') {
+      return (
+        <QuestionConfirmation
+          toolInvocation={tool}
+          isCompleted={true}
+          onConfirm={() => {}} // Not used in result display mode
+        />
+      )
+    }
   }
 
   switch (tool.toolName) {

--- a/components/tool-section.tsx
+++ b/components/tool-section.tsx
@@ -28,14 +28,18 @@ export function ToolSection({
     return (
       <QuestionConfirmation
         toolInvocation={tool}
-        onConfirm={(toolCallId, approved) => {
-          // If approved, return the original args so the question can be displayed
+        onConfirm={(toolCallId, approved, response) => {
+          // If approved, return the response with user selections
           // If declined, return a message that the user declined
           addToolResult({
             toolCallId,
             result: approved
-              ? tool.args
-              : { declined: true, message: 'User declined this question' }
+              ? response
+              : {
+                  declined: true,
+                  skipped: response?.skipped,
+                  message: 'User declined this question'
+                }
           })
         }}
       />

--- a/lib/agents/researcher.ts
+++ b/lib/agents/researcher.ts
@@ -1,4 +1,5 @@
 import { CoreMessage, smoothStream, streamText } from 'ai'
+import { askQuestionTool } from '../tools/question'
 import { retrieveTool } from '../tools/retrieve'
 import { searchTool } from '../tools/search'
 import { videoSearchTool } from '../tools/video-search'
@@ -7,17 +8,26 @@ import { getModel } from '../utils/registry'
 const SYSTEM_PROMPT = `
 Instructions:
 
-You are a helpful AI assistant with access to real-time web search, content retrieval, and video search capabilities.
+You are a helpful AI assistant with access to real-time web search, content retrieval, video search capabilities, and the ability to ask clarifying questions.
+
 When asked a question, you should:
-1. Search for relevant information using the search tool when needed
-2. Use the retrieve tool to get detailed content from specific URLs
-3. Use the video search tool when looking for video content
-4. Analyze all search results to provide accurate, up-to-date information
-5. Always cite sources using the [number](url) format, matching the order of search results. If multiple sources are relevant, include all of them, and comma separate them. Only use information that has a URL available for citation.
-6. If results are not relevant or helpful, rely on your general knowledge
-7. Provide comprehensive and detailed responses based on search results, ensuring thorough coverage of the user's question
-8. Use markdown to structure your responses. Use headings to break up the content into sections.
-9. **Use the retrieve tool only with user-provided URLs.**
+1. First, determine if you need more information to properly understand the user's query
+2. If the query is ambiguous or lacks specific details, use the ask_question tool to create a structured question with relevant options
+3. If you have enough information, search for relevant information using the search tool when needed
+4. Use the retrieve tool to get detailed content from specific URLs
+5. Use the video search tool when looking for video content
+6. Analyze all search results to provide accurate, up-to-date information
+7. Always cite sources using the [number](url) format, matching the order of search results. If multiple sources are relevant, include all of them, and comma separate them. Only use information that has a URL available for citation.
+8. If results are not relevant or helpful, rely on your general knowledge
+9. Provide comprehensive and detailed responses based on search results, ensuring thorough coverage of the user's question
+10. Use markdown to structure your responses. Use headings to break up the content into sections.
+11. **Use the retrieve tool only with user-provided URLs.**
+
+When using the ask_question tool:
+- Create clear, concise questions
+- Provide relevant predefined options
+- Enable free-form input when appropriate
+- Match the language to the user's language (except option values which must be in English)
 
 Citation Format:
 [number](url)
@@ -44,10 +54,11 @@ export function researcher({
       tools: {
         search: searchTool,
         retrieve: retrieveTool,
-        videoSearch: videoSearchTool
+        videoSearch: videoSearchTool,
+        ask_question: askQuestionTool
       },
       experimental_activeTools: searchMode
-        ? ['search', 'retrieve', 'videoSearch']
+        ? ['search', 'retrieve', 'videoSearch', 'ask_question']
         : [],
       maxSteps: searchMode ? 5 : 1,
       experimental_transform: smoothStream({ chunking: 'word' })

--- a/lib/agents/researcher.ts
+++ b/lib/agents/researcher.ts
@@ -12,7 +12,7 @@ You are a helpful AI assistant with access to real-time web search, content retr
 
 When asked a question, you should:
 1. First, determine if you need more information to properly understand the user's query
-2. If the query is ambiguous or lacks specific details, use the ask_question tool to create a structured question with relevant options
+2. **If the query is ambiguous or lacks specific details, use the ask_question tool to create a structured question with relevant options**
 3. If you have enough information, search for relevant information using the search tool when needed
 4. Use the retrieve tool to get detailed content from specific URLs
 5. Use the video search tool when looking for video content

--- a/lib/streaming/create-tool-calling-stream.ts
+++ b/lib/streaming/create-tool-calling-stream.ts
@@ -1,6 +1,7 @@
 import { researcher } from '@/lib/agents/researcher'
 import {
   convertToCoreMessages,
+  CoreMessage,
   createDataStreamResponse,
   DataStreamWriter,
   streamText
@@ -9,6 +10,19 @@ import { getMaxAllowedTokens, truncateMessages } from '../utils/context-window'
 import { isReasoningModel } from '../utils/registry'
 import { handleStreamFinish } from './handle-stream-finish'
 import { BaseStreamConfig } from './types'
+
+// Function to check if a message contains ask_question tool invocation
+function containsAskQuestionTool(message: CoreMessage) {
+  // For CoreMessage format, we check the content array
+  if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+    return false
+  }
+
+  // Check if any content item is a tool-call with ask_question tool
+  return message.content.some(
+    item => item.type === 'tool-call' && item.toolName === 'ask_question'
+  )
+}
 
 export function createToolCallingStreamResponse(config: BaseStreamConfig) {
   return createDataStreamResponse({
@@ -32,13 +46,29 @@ export function createToolCallingStreamResponse(config: BaseStreamConfig) {
         const result = streamText({
           ...researcherConfig,
           onFinish: async result => {
+            // Check if the last message contains an ask_question tool invocation
+            const shouldSkipRelatedQuestions =
+              isReasoningModel(modelId) ||
+              (result.response.messages.length > 0 &&
+                containsAskQuestionTool(
+                  result.response.messages[
+                    result.response.messages.length - 1
+                  ] as CoreMessage
+                ))
+
+            console.log(
+              'shouldSkipRelatedQuestions',
+              shouldSkipRelatedQuestions,
+              JSON.stringify(result.response.messages)
+            )
+
             await handleStreamFinish({
               responseMessages: result.response.messages,
               originalMessages: messages,
               model: modelId,
               chatId,
               dataStream,
-              skipRelatedQuestions: isReasoningModel(modelId)
+              skipRelatedQuestions: shouldSkipRelatedQuestions
             })
           }
         })
@@ -50,7 +80,7 @@ export function createToolCallingStreamResponse(config: BaseStreamConfig) {
       }
     },
     onError: error => {
-      console.error('Stream error:', error)
+      // console.error('Stream error:', error)
       return error instanceof Error ? error.message : String(error)
     }
   })

--- a/lib/streaming/create-tool-calling-stream.ts
+++ b/lib/streaming/create-tool-calling-stream.ts
@@ -56,12 +56,6 @@ export function createToolCallingStreamResponse(config: BaseStreamConfig) {
                   ] as CoreMessage
                 ))
 
-            console.log(
-              'shouldSkipRelatedQuestions',
-              shouldSkipRelatedQuestions,
-              JSON.stringify(result.response.messages)
-            )
-
             await handleStreamFinish({
               responseMessages: result.response.messages,
               originalMessages: messages,

--- a/lib/tools/question.ts
+++ b/lib/tools/question.ts
@@ -1,0 +1,28 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+export const askQuestionTool = tool({
+  description:
+    'Ask a clarifying question with multiple options when more information is needed',
+  parameters: z.object({
+    question: z.string().describe('The main question to ask the user'),
+    options: z
+      .array(
+        z.object({
+          value: z.string().describe('Option identifier (always in English)'),
+          label: z.string().describe('Display text for the option')
+        })
+      )
+      .describe('List of predefined options'),
+    allowsInput: z.boolean().describe('Whether to allow free-form text input'),
+    inputLabel: z
+      .string()
+      .optional()
+      .describe('Label for free-form input field'),
+    inputPlaceholder: z
+      .string()
+      .optional()
+      .describe('Placeholder text for input field')
+  })
+  // execute function removed to enable frontend confirmation
+})


### PR DESCRIPTION
## Description
This PR adds the `ask_question` tool functionality and improves the overall tool UX:

1. Added `ask_question` tool to help the assistant ask clarifying questions when user queries are ambiguous
2. Added input disabling during tool invocation to prevent users from sending messages while tools are running
3. Created question confirmation component to allow users to respond to questions from the assistant
4. Enhanced tool section display and documentation

## Changes
- Added `ask_question` tool implementation in `lib/tools/question.ts`
- Created question confirmation UI component
- Added `isToolInvocationInProgress()` function to detect active tool invocations
- Disabled input and buttons during tool execution
- Updated documentation and improved tool-related UI elements

## Note
The feature was previously available in AI SDK v2 RSC implementation and has been restored in this PR.

## Testing
- Verified ask_question tool works correctly when the assistant needs clarification
- Confirmed input field and buttons are disabled when tools are running
- Tested question confirmation UI with various question types