### PR TITLE
Add scroll cancelation during AI response streaming

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -1,4 +1,3 @@
-import { useAutoScroll } from '@/lib/hooks/use-auto-scroll'
 import { JSONValue, Message } from 'ai'
 import { useEffect, useMemo, useState } from 'react'
 import { RenderMessage } from './render-message'
@@ -12,6 +11,8 @@ interface ChatMessagesProps {
   isLoading: boolean
   chatId?: string
   addToolResult?: (params: { toolCallId: string; result: any }) => void
+  /** Ref for anchoring auto-scroll position */
+  anchorRef: React.RefObject<HTMLDivElement>
 }
 
 export function ChatMessages({
@@ -20,17 +21,11 @@ export function ChatMessages({
   onQuerySelect,
   isLoading,
   chatId,
-  addToolResult
+  addToolResult,
+  anchorRef
 }: ChatMessagesProps) {
   const [openStates, setOpenStates] = useState<Record<string, boolean>>({})
   const manualToolCallId = 'manual-tool-call'
-
-  // Use auto-scroll hook for continuous scrolling with user-cancel
-  const { anchorRef } = useAutoScroll({
-    isLoading,
-    dependency: messages.length,
-    isStreaming: () => messages[messages.length - 1]?.role === 'assistant'
-  })
 
   useEffect(() => {
     const lastMessage = messages[messages.length - 1]
@@ -116,7 +111,7 @@ export function ChatMessages({
         ) : (
           <Spinner />
         ))}
-      <div ref={anchorRef} /> {/* Auto-scroll anchor */}
+      <div ref={anchorRef} /> {/* Anchor for auto-scroll */}
     </div>
   )
 }

--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -27,6 +27,22 @@ export function ChatMessages({
   // Add ref for the messages container
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
+  // Add isAutoScroll state to enable/disable auto-scrolling
+  const [isAutoScroll, setIsAutoScroll] = useState(true)
+
+  // Listen to user scroll to toggle auto-scroll
+  useEffect(() => {
+    const handleScroll = () => {
+      const threshold = 40
+      const scrollHeight = document.documentElement.scrollHeight
+      const atBottom =
+        window.innerHeight + window.scrollY >= scrollHeight - threshold
+      setIsAutoScroll(atBottom)
+    }
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
   // Scroll to bottom function
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({
@@ -36,19 +52,23 @@ export function ChatMessages({
 
   // Scroll to bottom on mount and when messages change or during streaming
   useEffect(() => {
-    scrollToBottom()
+    if (isAutoScroll) scrollToBottom()
 
     // Set up interval for continuous scrolling during streaming
     let intervalId: ReturnType<typeof setInterval> | undefined
 
-    if (isLoading && messages[messages.length - 1]?.role === 'user') {
+    if (
+      isAutoScroll &&
+      isLoading &&
+      messages[messages.length - 1]?.role === 'assistant'
+    ) {
       intervalId = setInterval(scrollToBottom, 100)
     }
 
     return () => {
       if (intervalId) clearInterval(intervalId)
     }
-  }, [messages.length, isLoading, messages])
+  }, [messages.length, isLoading, isAutoScroll])
 
   useEffect(() => {
     const lastMessage = messages[messages.length - 1]

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -93,12 +93,29 @@ export function ChatPanel({
   return (
     <div
       className={cn(
-        'mx-auto w-full',
+        'mx-auto w-full relative',
         messages.length > 0
           ? 'fixed bottom-0 left-0 right-0 bg-background'
           : 'fixed bottom-8 left-0 right-0 top-6 flex flex-col items-center justify-center'
       )}
     >
+      {/* Scroll-down button: show when user is not at bottom */}
+      {!isAutoScroll && (
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="absolute top-4 right-4 z-20"
+          onClick={() =>
+            window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth'
+            })
+          }
+        >
+          <ArrowDown size={20} />
+        </Button>
+      )}
       {messages.length === 0 && (
         <div className="mb-10 flex flex-col items-center gap-4">
           <IconLogo className="size-12 text-muted-foreground" />
@@ -151,24 +168,6 @@ export function ChatPanel({
             onFocus={() => setShowEmptyScreen(true)}
             onBlur={() => setShowEmptyScreen(false)}
           />
-
-          {/* Scroll-down button: show when user is not at bottom */}
-          {!isAutoScroll && (
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="absolute top-3 right-3 z-10"
-              onClick={() =>
-                window.scrollTo({
-                  top: document.documentElement.scrollHeight,
-                  behavior: 'smooth'
-                })
-              }
-            >
-              <ArrowDown size={20} />
-            </Button>
-          )}
 
           {/* Bottom menu area */}
           <div className="flex items-center justify-between p-3">

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -93,29 +93,12 @@ export function ChatPanel({
   return (
     <div
       className={cn(
-        'mx-auto w-full relative',
+        'mx-auto w-full',
         messages.length > 0
           ? 'fixed bottom-0 left-0 right-0 bg-background'
           : 'fixed bottom-8 left-0 right-0 top-6 flex flex-col items-center justify-center'
       )}
     >
-      {/* Scroll-down button: show when user is not at bottom */}
-      {!isAutoScroll && (
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          className="absolute top-4 right-4 z-20"
-          onClick={() =>
-            window.scrollTo({
-              top: document.documentElement.scrollHeight,
-              behavior: 'smooth'
-            })
-          }
-        >
-          <ArrowDown size={20} />
-        </Button>
-      )}
       {messages.length === 0 && (
         <div className="mb-10 flex flex-col items-center gap-4">
           <IconLogo className="size-12 text-muted-foreground" />
@@ -127,10 +110,27 @@ export function ChatPanel({
       <form
         onSubmit={handleSubmit}
         className={cn(
-          'max-w-3xl w-full mx-auto',
+          'max-w-3xl w-full mx-auto relative',
           messages.length > 0 ? 'px-2 pb-4' : 'px-6'
         )}
       >
+        {/* Scroll-down button: show when user is not at bottom */}
+        {!isAutoScroll && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="absolute top-2 right-2 z-20"
+            onClick={() =>
+              window.scrollTo({
+                top: document.documentElement.scrollHeight,
+                behavior: 'smooth'
+              })
+            }
+          >
+            <ArrowDown size={20} />
+          </Button>
+        )}
         <div className="relative flex flex-col w-full gap-2 bg-muted rounded-3xl border border-input">
           <Textarea
             ref={inputRef}

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -3,7 +3,7 @@
 import { Model } from '@/lib/types/models'
 import { cn } from '@/lib/utils'
 import { Message } from 'ai'
-import { ArrowDown, ArrowUp, MessageCirclePlus, Square } from 'lucide-react'
+import { ArrowUp, ChevronDown, MessageCirclePlus, Square } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import Textarea from 'react-textarea-autosize'
@@ -120,7 +120,7 @@ export function ChatPanel({
             type="button"
             variant="outline"
             size="icon"
-            className="absolute top-2 right-2 z-20"
+            className="absolute -top-10 right-4 z-20 size-8 rounded-full"
             onClick={() =>
               window.scrollTo({
                 top: document.documentElement.scrollHeight,
@@ -128,7 +128,7 @@ export function ChatPanel({
               })
             }
           >
-            <ArrowDown size={20} />
+            <ChevronDown size={16} />
           </Button>
         )}
         <div className="relative flex flex-col w-full gap-2 bg-muted rounded-3xl border border-input">

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -3,7 +3,7 @@
 import { Model } from '@/lib/types/models'
 import { cn } from '@/lib/utils'
 import { Message } from 'ai'
-import { ArrowUp, MessageCirclePlus, Square } from 'lucide-react'
+import { ArrowDown, ArrowUp, MessageCirclePlus, Square } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import Textarea from 'react-textarea-autosize'
@@ -24,6 +24,8 @@ interface ChatPanelProps {
   stop: () => void
   append: (message: any) => void
   models?: Model[]
+  /** Whether auto-scroll is currently active (at bottom) */
+  isAutoScroll: boolean
 }
 
 export function ChatPanel({
@@ -36,7 +38,8 @@ export function ChatPanel({
   query,
   stop,
   append,
-  models
+  models,
+  isAutoScroll
 }: ChatPanelProps) {
   const [showEmptyScreen, setShowEmptyScreen] = useState(false)
   const router = useRouter()
@@ -148,6 +151,24 @@ export function ChatPanel({
             onFocus={() => setShowEmptyScreen(true)}
             onBlur={() => setShowEmptyScreen(false)}
           />
+
+          {/* Scroll-down button: show when user is not at bottom */}
+          {!isAutoScroll && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="absolute top-3 right-3 z-10"
+              onClick={() =>
+                window.scrollTo({
+                  top: document.documentElement.scrollHeight,
+                  behavior: 'smooth'
+                })
+              }
+            >
+              <ArrowDown size={20} />
+            </Button>
+          )}
 
           {/* Bottom menu area */}
           <div className="flex items-center justify-between p-3">

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { CHAT_ID } from '@/lib/constants'
+import { useAutoScroll } from '@/lib/hooks/use-auto-scroll'
 import { Model } from '@/lib/types/models'
 import { useChat } from '@ai-sdk/react'
 import { Message } from 'ai/react'
@@ -50,6 +51,13 @@ export function Chat({
 
   const isLoading = status === 'submitted' || status === 'streaming'
 
+  // Manage auto-scroll and user scroll cancel
+  const { anchorRef, isAutoScroll } = useAutoScroll({
+    isLoading,
+    dependency: messages.length,
+    isStreaming: () => status === 'streaming'
+  })
+
   useEffect(() => {
     setMessages(savedMessages)
   }, [id])
@@ -76,6 +84,7 @@ export function Chat({
         isLoading={isLoading}
         chatId={id}
         addToolResult={addToolResult}
+        anchorRef={anchorRef}
       />
       <ChatPanel
         input={input}
@@ -88,6 +97,7 @@ export function Chat({
         query={query}
         append={append}
         models={models}
+        isAutoScroll={isAutoScroll}
       />
     </div>
   )

--- a/lib/hooks/use-auto-scroll.ts
+++ b/lib/hooks/use-auto-scroll.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseAutoScrollOptions {
+  isLoading: boolean
+  dependency: number
+  isStreaming: () => boolean
+  threshold?: number
+  intervalMs?: number
+}
+
+interface UseAutoScrollReturn {
+  anchorRef: React.RefObject<HTMLDivElement>
+  isAutoScroll: boolean
+}
+
+/**
+ * Custom hook to auto-scroll to a target element and pause when the user scrolls away.
+ */
+export function useAutoScroll({
+  isLoading,
+  dependency,
+  isStreaming,
+  threshold = 162,
+  intervalMs = 100
+}: UseAutoScrollOptions): UseAutoScrollReturn {
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const [isAutoScroll, setIsAutoScroll] = useState(true)
+
+  // Detect user scroll to toggle auto-scroll
+  const handleScroll = useCallback(() => {
+    if (typeof window === 'undefined') return
+    const scrollHeight = document.documentElement.scrollHeight
+    const atBottom =
+      window.innerHeight + window.scrollY >= scrollHeight - threshold
+    setIsAutoScroll(atBottom)
+  }, [threshold])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [handleScroll])
+
+  // Scroll to anchor element
+  const scrollToBottom = useCallback(() => {
+    anchorRef.current?.scrollIntoView({
+      behavior: dependency > 5 ? 'instant' : 'smooth'
+    })
+  }, [dependency])
+
+  // Auto-scroll on updates and during streaming
+  useEffect(() => {
+    if (!isAutoScroll) return
+    scrollToBottom()
+    let intervalId: ReturnType<typeof setInterval> | undefined
+    if (isAutoScroll && isStreaming() && isLoading) {
+      intervalId = setInterval(scrollToBottom, intervalMs)
+    }
+    return () => {
+      if (intervalId) clearInterval(intervalId)
+    }
+  }, [
+    dependency,
+    isLoading,
+    isAutoScroll,
+    isStreaming,
+    intervalMs,
+    scrollToBottom
+  ])
+
+  return { anchorRef, isAutoScroll }
+}


### PR DESCRIPTION
This PR adds the ability to cancel auto-scrolling during AI response streaming.

## Features
- Created `useAutoScroll` hook to manage auto-scrolling behavior
- Added user scroll detection to pause auto-scrolling when user scrolls away
- Added a scroll-down button that appears when the user has scrolled away from the bottom
- Auto-scrolling automatically resumes when user returns to the bottom of the conversation

## Implementation Details
- Created a reusable hook in `lib/hooks/use-auto-scroll.ts`
- Moved auto-scroll management to parent `Chat` component
- Added user scroll detection with scroll events
- Added conditional ChevronDown button in ChatPanel for manual scrolling

This improves UX by allowing users to pause streaming content to read earlier messages without fighting the auto-scroll, while still providing an easy way to return to the latest content.