### PR TITLE
Add message retry functionality

### DIFF
--- a/components/answer-section.tsx
+++ b/components/answer-section.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ChatRequestOptions } from 'ai'
 import { CollapsibleMessage } from './collapsible-message'
 import { DefaultSkeleton } from './default-skeleton'
 import { BotMessage } from './message'
@@ -11,6 +12,11 @@ export type AnswerSectionProps = {
   onOpenChange: (open: boolean) => void
   chatId?: string
   showActions?: boolean
+  messageId: string
+  reload?: (
+    messageId: string,
+    options?: ChatRequestOptions
+  ) => Promise<string | null | undefined>
 }
 
 export function AnswerSection({
@@ -18,18 +24,29 @@ export function AnswerSection({
   isOpen,
   onOpenChange,
   chatId,
-  showActions = true // Default to true for backward compatibility
+  showActions = true, // Default to true for backward compatibility
+  messageId,
+  reload
 }: AnswerSectionProps) {
   const enableShare = process.env.NEXT_PUBLIC_ENABLE_SHARE === 'true'
+
+  const handleReload = () => {
+    if (reload) {
+      return reload(messageId)
+    }
+    return Promise.resolve(undefined)
+  }
 
   const message = content ? (
     <div className="flex flex-col gap-1">
       <BotMessage message={content} />
       {showActions && (
         <MessageActions
-          message={content}
+          message={content} // Keep original message content for copy
+          messageId={messageId}
           chatId={chatId}
           enableShare={enableShare}
+          reload={handleReload}
         />
       )}
     </div>

--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -1,4 +1,4 @@
-import { JSONValue, Message } from 'ai'
+import { ChatRequestOptions, JSONValue, Message } from 'ai'
 import { useEffect, useMemo, useState } from 'react'
 import { RenderMessage } from './render-message'
 import { ToolSection } from './tool-section'
@@ -14,6 +14,10 @@ interface ChatMessagesProps {
   /** Ref for anchoring auto-scroll position */
   anchorRef: React.RefObject<HTMLDivElement>
   onUpdateMessage?: (messageId: string, newContent: string) => Promise<void>
+  reload?: (
+    messageId: string,
+    options?: ChatRequestOptions
+  ) => Promise<string | null | undefined>
 }
 
 export function ChatMessages({
@@ -24,7 +28,8 @@ export function ChatMessages({
   chatId,
   addToolResult,
   anchorRef,
-  onUpdateMessage
+  onUpdateMessage,
+  reload
 }: ChatMessagesProps) {
   const [openStates, setOpenStates] = useState<Record<string, boolean>>({})
   const manualToolCallId = 'manual-tool-call'
@@ -99,6 +104,7 @@ export function ChatMessages({
             chatId={chatId}
             addToolResult={addToolResult}
             onUpdateMessage={onUpdateMessage}
+            reload={reload}
           />
         </div>
       ))}

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { CHAT_ID } from '@/lib/constants'
 import { cn } from '@/lib/utils'
-import { useChat } from 'ai/react'
 import { Copy } from 'lucide-react'
 import { toast } from 'sonner'
 import { ChatShare } from './chat-share'
+import { RetryButton } from './retry-button'
 import { Button } from './ui/button'
 
 interface MessageActionsProps {
   message: string
+  messageId: string
+  reload?: () => Promise<string | null | undefined>
   chatId?: string
   enableShare?: boolean
   className?: string
@@ -17,24 +18,20 @@ interface MessageActionsProps {
 
 export function MessageActions({
   message,
+  messageId,
+  reload,
   chatId,
   enableShare,
   className
 }: MessageActionsProps) {
-  const { isLoading } = useChat({
-    id: CHAT_ID
-  })
   async function handleCopy() {
     await navigator.clipboard.writeText(message)
     toast.success('Message copied to clipboard')
   }
 
-  if (isLoading) {
-    return <div className="size-10" />
-  }
-
   return (
     <div className={cn('flex items-center gap-0.5 self-end', className)}>
+      {reload && <RetryButton reload={reload} messageId={messageId} />}
       <Button
         variant="ghost"
         size="icon"

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -1,4 +1,4 @@
-import { JSONValue, Message, ToolInvocation } from 'ai'
+import { ChatRequestOptions, JSONValue, Message, ToolInvocation } from 'ai'
 import { useMemo } from 'react'
 import { AnswerSection } from './answer-section'
 import { ReasoningSection } from './reasoning-section'
@@ -15,6 +15,10 @@ interface RenderMessageProps {
   chatId?: string
   addToolResult?: (params: { toolCallId: string; result: any }) => void
   onUpdateMessage?: (messageId: string, newContent: string) => Promise<void>
+  reload?: (
+    messageId: string,
+    options?: ChatRequestOptions
+  ) => Promise<string | null | undefined>
 }
 
 export function RenderMessage({
@@ -25,7 +29,8 @@ export function RenderMessage({
   onQuerySelect,
   chatId,
   addToolResult,
-  onUpdateMessage
+  onUpdateMessage,
+  reload
 }: RenderMessageProps) {
   const relatedQuestions = useMemo(
     () =>
@@ -141,6 +146,8 @@ export function RenderMessage({
                 onOpenChange={open => onOpenChange(messageId, open)}
                 chatId={chatId}
                 showActions={isLastPart}
+                messageId={messageId}
+                reload={reload}
               />
             )
           case 'reasoning':

--- a/components/retry-button.tsx
+++ b/components/retry-button.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { RotateCcw } from 'lucide-react'
+import { Button } from './ui/button'
+
+interface RetryButtonProps {
+  reload: () => Promise<string | null | undefined>
+  messageId: string
+}
+
+export const RetryButton: React.FC<RetryButtonProps> = ({
+  reload,
+  messageId
+}) => {
+  return (
+    <Button
+      className="rounded-full h-8 w-8"
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={() => reload()}
+      aria-label={`Retry from message ${messageId}`}
+    >
+      <RotateCcw className="w-4 h-4" />
+      <span className="sr-only">Retry</span>
+    </Button>
+  )
+}


### PR DESCRIPTION
# Add Message Retry Functionality

This PR adds the ability to retry responses from any point in the conversation. When users click the retry button on an assistant message, the conversation is regenerated from the user message that preceded it.

## Features

- Added retry button to assistant messages
- Implemented message-specific retry functionality
- Created a reusable RetryButton component
- Enhanced state management to support conversation regeneration

## Implementation Details

- Added `handleReloadFrom` function to the Chat component that:
  - Trims messages to the selected point in the conversation
  - Uses the `reload` function from the `useChat` hook to regenerate the conversation
- Created a proper prop-passing chain from Chat down to MessageActions
- Implemented a standalone RetryButton component with clear visual indication

## How to Test

1. Start a conversation with the app
2. Observe the retry button (rotating arrow icon) in the action bar of assistant messages
3. Click the retry button
4. The conversation should regenerate from that point, discarding any subsequent messages