### PR TITLE
Fix: Update Azure OpenAI API version to support newer models

### DIFF
--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -23,7 +23,8 @@ export const registry = createProviderRegistry({
   }),
   azure: createAzure({
     apiKey: process.env.AZURE_API_KEY,
-    resourceName: process.env.AZURE_RESOURCE_NAME
+    resourceName: process.env.AZURE_RESOURCE_NAME,
+    apiVersion: '2025-03-01-preview'
   }),
   deepseek,
   fireworks: {


### PR DESCRIPTION
This PR addresses issue #498 by updating the Azure OpenAI API version to `2025-03-01-preview`.

## Problem
The current default Azure OpenAI API version (`2024-10-01-preview`) is too old to support newer models like o3-mini, resulting in errors when attempting to use these models.

## Solution
- Updated the API version to `2025-03-01-preview` in the Azure OpenAI provider initialization
- This change enables support for newer models without requiring per-model configuration

## Testing
- Confirmed the change allows the use of newer Azure OpenAI models such as o3-mini
- Verified existing Azure OpenAI functionality continues to work with the updated API version

Fixes #498