### PR TITLE
Improve chat history with pagination and infinite scroll

### DIFF
--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -1,0 +1,33 @@
+import { getChatsPage } from '@/lib/actions/chat'
+import { type Chat } from '@/lib/types'
+import { NextRequest, NextResponse } from 'next/server'
+
+interface ChatPageResponse {
+  chats: Chat[]
+  nextOffset: number | null
+}
+
+export async function GET(request: NextRequest) {
+  const enableSaveChatHistory = process.env.ENABLE_SAVE_CHAT_HISTORY === 'true'
+  if (!enableSaveChatHistory) {
+    return NextResponse.json<ChatPageResponse>({ chats: [], nextOffset: null })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const offset = parseInt(searchParams.get('offset') || '0', 10)
+  const limit = parseInt(searchParams.get('limit') || '20', 10)
+
+  // Replace 'anonymous' with your actual user ID logic
+  const userId = 'anonymous'
+
+  try {
+    const result = await getChatsPage(userId, limit, offset)
+    return NextResponse.json<ChatPageResponse>(result)
+  } catch (error) {
+    console.error('API route error fetching chats:', error)
+    return NextResponse.json<ChatPageResponse>(
+      { chats: [], nextOffset: null },
+      { status: 500 }
+    )
+  }
+}

--- a/components/sidebar/chat-history-client.tsx
+++ b/components/sidebar/chat-history-client.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { SidebarMenu } from '@/components/ui/sidebar'
+import { Chat } from '@/lib/types'
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { ChatHistorySkeleton } from './chat-history-skeleton'
+import { ChatMenuItem } from './chat-menu-item'
+
+interface ChatHistoryClientProps {
+  initialChats: Chat[]
+  initialNextOffset: number | null
+}
+
+interface ChatPageResponse {
+  chats: Chat[]
+  nextOffset: number | null
+}
+
+export function ChatHistoryClient({
+  initialChats,
+  initialNextOffset
+}: ChatHistoryClientProps) {
+  const [chats, setChats] = useState<Chat[]>(initialChats)
+  const [nextOffset, setNextOffset] = useState<number | null>(initialNextOffset)
+  const [isLoading, setIsLoading] = useState(false)
+  const loadMoreRef = useRef<HTMLDivElement>(null)
+  const [isPending, startTransition] = useTransition()
+
+  // Synchronize state with props when initial data changes (e.g., after router.refresh)
+  useEffect(() => {
+    setChats(initialChats)
+    setNextOffset(initialNextOffset)
+  }, [initialChats, initialNextOffset])
+
+  const fetchMoreChats = useCallback(async () => {
+    if (isLoading || nextOffset === null) return
+
+    setIsLoading(true)
+    try {
+      const response = await fetch(`/api/chats?offset=${nextOffset}&limit=20`)
+      if (!response.ok) {
+        throw new Error('Failed to fetch chat history')
+      }
+      const { chats: newChats, nextOffset: newNextOffset } =
+        (await response.json()) as ChatPageResponse
+
+      startTransition(() => {
+        setChats(prevChats => [...prevChats, ...newChats])
+        setNextOffset(newNextOffset)
+      })
+    } catch (error) {
+      console.error('Failed to load more chats:', error)
+      toast.error('Failed to load more chat history.')
+      // Optionally stop trying to load more if there's an error
+      setNextOffset(null)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [nextOffset, isLoading])
+
+  useEffect(() => {
+    const observerRefValue = loadMoreRef.current
+    if (!observerRefValue || nextOffset === null) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !isLoading) {
+          fetchMoreChats()
+        }
+      },
+      { threshold: 0.1 } // Trigger when 10% visible
+    )
+
+    observer.observe(observerRefValue)
+
+    return () => {
+      if (observerRefValue) {
+        observer.unobserve(observerRefValue)
+      }
+    }
+  }, [fetchMoreChats, nextOffset, isLoading])
+
+  return (
+    <div className="flex-1 overflow-y-auto mb-2 relative">
+      {!chats?.length && !isLoading && nextOffset === null ? (
+        <div className="px-2 text-foreground/30 text-sm text-center py-4">
+          No search history
+        </div>
+      ) : (
+        <SidebarMenu>
+          {chats.map(
+            (chat: Chat) => chat && <ChatMenuItem key={chat.id} chat={chat} />
+          )}
+        </SidebarMenu>
+      )}
+
+      {/* Sentinel Element */}
+      <div ref={loadMoreRef} style={{ height: '1px' }} />
+
+      {/* Loading Skeleton/Spinner */}
+      {(isLoading || isPending) && (
+        <div className="py-2">
+          <ChatHistorySkeleton />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/sidebar/chat-history-section.tsx
+++ b/components/sidebar/chat-history-section.tsx
@@ -1,11 +1,6 @@
-import {
-  SidebarGroup,
-  SidebarGroupLabel,
-  SidebarMenu
-} from '@/components/ui/sidebar'
-import { getChats } from '@/lib/actions/chat'
-import { Chat } from '@/lib/types'
-import { ChatMenuItem } from './chat-menu-item'
+import { SidebarGroup, SidebarGroupLabel } from '@/components/ui/sidebar'
+import { getChatsPage } from '@/lib/actions/chat'
+import { ChatHistoryClient } from './chat-history-client'
 import { ClearHistoryAction } from './clear-history-action'
 
 export async function ChatHistorySection() {
@@ -14,30 +9,19 @@ export async function ChatHistorySection() {
     return null
   }
 
-  // Replace with your own user ID
-  const chats = await getChats('anonymous')
+  // Fetch the initial page of chats
+  // Replace 'anonymous' with your actual user ID logic
+  const { chats, nextOffset } = await getChatsPage('anonymous', 20, 0)
 
   return (
     <div className="flex flex-col flex-1 h-full">
       <SidebarGroup>
         <div className="flex items-center justify-between w-full">
           <SidebarGroupLabel className="p-0">History</SidebarGroupLabel>
-          <ClearHistoryAction empty={!chats?.length} />
+          <ClearHistoryAction empty={!chats?.length && !nextOffset} />
         </div>
       </SidebarGroup>
-      <div className="flex-1 overflow-y-auto mb-2">
-        {!chats?.length ? (
-          <div className="px-2 text-foreground/30 text-sm text-center py-4">
-            No search history
-          </div>
-        ) : (
-          <SidebarMenu>
-            {chats.map(
-              (chat: Chat) => chat && <ChatMenuItem key={chat.id} chat={chat} />
-            )}
-          </SidebarMenu>
-        )}
-      </div>
+      <ChatHistoryClient initialChats={chats} initialNextOffset={nextOffset} />
     </div>
   )
 }


### PR DESCRIPTION
## Overview

This PR addresses task #3 from the v0.4 Roadmap (issue #501): "Improve the chat history component".

## Implementation Details

- Added paginated chat history with infinite scroll:
  - Created new `getChatsPage` server action that supports pagination with limit/offset
  - Implemented `/api/chats` endpoint to fetch pages of chat history
  - Refactored sidebar history into server wrapper + client component architecture
  - Added intersection observer to detect scroll position and load more items
  - Added effect to synchronize props to state when new chats are created
  
- Improvements:
  - Initial load limited to 20 chats (vs. all chats previously)
  - Infinite scroll automatically loads next 20 chats when user scrolls to bottom
  - Memory usage is optimized by loading only what's needed
  - Fixes issue with new chats not appearing in history until manual refresh

## Testing

- Confirmed smooth loading of initial and subsequent chat pages
- Verified chat history updates properly when new chats are created
- Tested with large chat history to ensure performance remains good
- Validated mobile and desktop scrolling behavior

Related issue: #501 (partial)