### PR TITLE
Add individual chat delete action with confirmation dialog

### DIFF
--- a/app/api/chat/[id]/route.ts
+++ b/app/api/chat/[id]/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const enableSaveChatHistory = process.env.ENABLE_SAVE_CHAT_HISTORY === 'true'
   if (!enableSaveChatHistory) {
@@ -13,7 +13,7 @@ export async function DELETE(
     )
   }
 
-  const chatId = params.id
+  const chatId = (await params).id
   if (!chatId) {
     return NextResponse.json({ error: 'Chat ID is required' }, { status: 400 })
   }

--- a/app/api/chat/[id]/route.ts
+++ b/app/api/chat/[id]/route.ts
@@ -1,0 +1,40 @@
+import { deleteChat } from '@/lib/actions/chat'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const enableSaveChatHistory = process.env.ENABLE_SAVE_CHAT_HISTORY === 'true'
+  if (!enableSaveChatHistory) {
+    return NextResponse.json(
+      { error: 'Chat history saving is disabled.' },
+      { status: 403 }
+    )
+  }
+
+  const chatId = params.id
+  if (!chatId) {
+    return NextResponse.json({ error: 'Chat ID is required' }, { status: 400 })
+  }
+
+  // Replace 'anonymous' with your actual user ID logic if needed
+  const userId = 'anonymous'
+
+  try {
+    const result = await deleteChat(chatId, userId)
+
+    if (result.error) {
+      const statusCode = result.error === 'Chat not found' ? 404 : 500
+      return NextResponse.json({ error: result.error }, { status: statusCode })
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error(`API route error deleting chat ${chatId}:`, error)
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,9 +1,11 @@
 // Based on: https://github.com/vercel/ai/blob/main/examples/next-ai-rsc/components/llm-stocks/spinner.tsx
 
-import { Card } from './card'
+import { cn } from '@/lib/utils'
 import { IconLogo } from './icons'
 
-export const Spinner = () => (
+interface SpinnerProps extends React.SVGProps<SVGSVGElement> {}
+
+export const Spinner = ({ className, ...props }: SpinnerProps) => (
   <svg
     fill="none"
     stroke="currentColor"
@@ -12,7 +14,8 @@ export const Spinner = () => (
     strokeLinecap="round"
     strokeLinejoin="round"
     xmlns="http://www.w3.org/2000/svg"
-    className="h-5 w-5 animate-spin stroke-zinc-400"
+    className={cn('h-5 w-5 animate-spin stroke-zinc-400', className)}
+    {...props}
   >
     <path d="M12 3v3m6.366-.366-2.12 2.12M21 12h-3m.366 6.366-2.12-2.12M12 21v-3m-6.366.366 2.12-2.12M3 12h3m-.366-6.366 2.12 2.12"></path>
   </svg>


### PR DESCRIPTION
## Overview

This PR adds the ability to delete individual chat items from the history sidebar, enhancing the user experience by providing more granular control over chat history management.

## Implementation Details

- Added `deleteChat` server action to support deleting a single chat
- Implemented `/api/chat/[id]` endpoint with DELETE method for API-based removal
- Added dropdown menu with delete option to each chat history item
- Integrated confirmation dialog to prevent accidental deletions
- Supports proper error handling and feedback via toast notifications
- Manages loading states with spinners during deletion process
- Updated `Spinner` component to support className prop for better styling

## UX Improvements

- Each chat now has a kebab menu (three dots) on hover
- Clicking delete shows a confirmation dialog similar to "Clear History"
- After deletion, the sidebar refreshes automatically
- If the user deletes the currently active chat, they are redirected to home

## Testing

The implementation has been tested to ensure:
- Proper error handling for non-existent chats
- Correct UI feedback during loading states
- Sidebar list updates properly after deletion
- Confirmation dialog prevents accidental deletions
- Proper interaction with the existing chat history components

Related to v0.4 Roadmap (issue #501) as a complementary feature to the chat history improvements.