### PR TITLE
Fix: Ensure search-mode cookie is set on initial load

### DIFF
--- a/components/search-mode-toggle.tsx
+++ b/components/search-mode-toggle.tsx
@@ -13,6 +13,8 @@ export function SearchModeToggle() {
     const savedMode = getCookie('search-mode')
     if (savedMode !== null) {
       setIsSearchMode(savedMode === 'true')
+    } else {
+      setCookie('search-mode', 'true')
     }
   }, [])
 


### PR DESCRIPTION
This PR addresses issue #470.

Previously, the search-mode cookie was not set on initial page load if it didn't already exist. This caused an inconsistency between the UI (showing search as active by default) and the actual cookie state, leading to the first search attempt failing.

This change modifies the `SearchModeToggle` component to set the 'search-mode' cookie to 'true' in `useEffect` if the cookie is not found, ensuring the UI state and cookie state are synchronized from the beginning.