### PR TITLE
feat: Display user avatar in chat messages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^1.3.12",
         "@ai-sdk/xai": "^1.1.10",
         "@radix-ui/react-alert-dialog": "^1.0.5",
-        "@radix-ui/react-avatar": "^1.0.4",
+        "@radix-ui/react-avatar": "^1.1.9",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-dialog": "^1.1.11",

--- a/components/collapsible-message.tsx
+++ b/components/collapsible-message.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils'
-import { ChevronDown, UserCircle2 } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
+import { CurrentUserAvatar } from './current-user-avatar'
 import {
   Collapsible,
   CollapsibleContent,
@@ -35,11 +36,11 @@ export function CollapsibleMessage({
     <div className="flex">
       {showIcon && (
         <div className="relative flex flex-col items-center">
-          <div className={cn('mt-[2px] w-5', role === 'assistant' && 'mt-4')}>
-            {role === 'user' ? (
-              <UserCircle2 size={20} className="text-muted-foreground" />
-            ) : (
+          <div className="w-5">
+            {role === 'assistant' ? (
               <IconLogo className="size-5" />
+            ) : (
+              <CurrentUserAvatar />
             )}
           </div>
         </div>
@@ -76,7 +77,14 @@ export function CollapsibleMessage({
           </Collapsible>
         </div>
       ) : (
-        <div className="flex-1 rounded-2xl px-4">{content}</div>
+        <div
+          className={cn(
+            'flex-1 rounded-2xl',
+            role === 'assistant' ? 'px-0' : 'px-3'
+          )}
+        >
+          {content}
+        </div>
       )}
     </div>
   )

--- a/components/current-user-avatar.tsx
+++ b/components/current-user-avatar.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { useCurrentUserImage } from '@/hooks/use-current-user-image'
+import { useCurrentUserName } from '@/hooks/use-current-user-name'
+import { User2 } from 'lucide-react'
+
+export const CurrentUserAvatar = () => {
+  const profileImage = useCurrentUserImage()
+  const name = useCurrentUserName()
+  const initials = name
+    ?.split(' ')
+    ?.map(word => word[0])
+    ?.join('')
+    ?.toUpperCase()
+
+  return (
+    <Avatar className="size-6">
+      {profileImage && <AvatarImage src={profileImage} alt={initials} />}
+      <AvatarFallback>
+        {initials === '?' ? (
+          <User2 size={16} className="text-muted-foreground" />
+        ) : (
+          initials
+        )}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
+import * as React from 'react'
 
-import { cn } from '@/lib/utils'
+import { cn } from '@/lib/utils/index'
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
@@ -47,4 +47,4 @@ const AvatarFallback = React.forwardRef<
 ))
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
 
-export { Avatar, AvatarImage, AvatarFallback }
+export { Avatar, AvatarFallback, AvatarImage }

--- a/hooks/use-current-user-image.ts
+++ b/hooks/use-current-user-image.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@/lib/supabase/client'
+import { useEffect, useState } from 'react'
+
+export const useCurrentUserImage = () => {
+  const [image, setImage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchUserImage = async () => {
+      const { data, error } = await createClient().auth.getSession()
+      if (error) {
+        console.error(error)
+      }
+
+      setImage(data.session?.user.user_metadata.avatar_url ?? null)
+    }
+    fetchUserImage()
+  }, [])
+
+  return image
+}

--- a/hooks/use-current-user-name.ts
+++ b/hooks/use-current-user-name.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@/lib/supabase/client'
+import { useEffect, useState } from 'react'
+
+export const useCurrentUserName = () => {
+  const [name, setName] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchProfileName = async () => {
+      const { data, error } = await createClient().auth.getSession()
+      if (error) {
+        console.error(error)
+      }
+
+      setName(data.session?.user.user_metadata.full_name ?? '?')
+    }
+
+    fetchProfileName()
+  }, [])
+
+  return name || '?'
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@ai-sdk/openai": "^1.3.12",
     "@ai-sdk/xai": "^1.1.10",
     "@radix-ui/react-alert-dialog": "^1.0.5",
-    "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-avatar": "^1.1.9",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.1.11",


### PR DESCRIPTION
This PR implements the display of user avatars in chat messages.

Key changes:
- Integrated Supabase UI's `CurrentUserAvatar` component.
- Modified `CollapsibleMessage` to use `CurrentUserAvatar` for user messages.
- Customized the fallback behavior of `CurrentUserAvatar` to display a `User2` icon when the user's name is not available (resulting in '?').