### PR TITLE
Fix: Prevent Supabase client initialization errors when env vars are missing

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -48,10 +48,17 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const supabase = await createClient()
-  const {
-    data: { user }
-  } = await supabase.auth.getUser()
+  let user = null
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (supabaseUrl && supabaseAnonKey) {
+    const supabase = await createClient()
+    const {
+      data: { user: supabaseUser }
+    } = await supabase.auth.getUser()
+    user = supabaseUser
+  }
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/lib/auth/get-current-user.ts
+++ b/lib/auth/get-current-user.ts
@@ -1,6 +1,13 @@
 import { createClient } from '@/lib/supabase/server'
 
 export async function getCurrentUser() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return null // Supabase is not configured
+  }
+
   const supabase = await createClient()
   const { data } = await supabase.auth.getUser()
   return data.user ?? null

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,18 @@
 import { updateSession } from '@/lib/supabase/middleware'
-import { type NextRequest } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request)
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (supabaseUrl && supabaseAnonKey) {
+    return await updateSession(request)
+  }
+
+  // If Supabase is not configured, just pass the request through
+  return NextResponse.next({
+    request
+  })
 }
 
 export const config = {
@@ -14,6 +24,6 @@ export const config = {
      * - favicon.ico (favicon file)
      * Feel free to modify this pattern to include more paths.
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
-  ],
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
+  ]
 }


### PR DESCRIPTION
This PR addresses issue #518 by preventing the application from attempting to initialize the Supabase client when the necessary environment variables (NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY) are not defined.

Changes were made in:
- `middleware.ts`: Conditionally calls `updateSession`.
- `app/layout.tsx`: Conditionally creates a Supabase client and fetches user data.
- `lib/auth/get-current-user.ts`: The `getCurrentUser` function now checks for Supabase environment variables before attempting to create a client, returning `null` if they are not set. This allows `getCurrentUserId` to return 'anonymous' and dependent components like `ChatHistorySection` to handle this state gracefully.