### PR TITLE
Enhance chat title generation using LLM

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -111,8 +111,6 @@ export function ChatMessages({
     }))
   }
 
-  console.log(allMessages)
-
   return (
     <div
       id="scroll-container"

--- a/lib/agents/title-generator.ts
+++ b/lib/agents/title-generator.ts
@@ -1,0 +1,46 @@
+import { generateText, LanguageModel } from 'ai'
+
+interface GenerateChatTitleParams {
+  userMessageContent: string
+  model: LanguageModel
+}
+
+/**
+ * Generates a concise chat title using an LLM.
+ * @param userMessageContent The content of the user's first message.
+ * @param model The language model instance to use for generation.
+ * @returns A promise that resolves to the generated title string.
+ */
+export async function generateChatTitle({
+  userMessageContent,
+  model
+}: GenerateChatTitleParams): Promise<string> {
+  // Fallback title uses the first 75 characters of the message or a default string.
+  const fallbackTitle = userMessageContent.substring(0, 75).trim() || 'New Chat'
+
+  try {
+    const systemPrompt = `System: You are an AI assistant specialized in creating very short, concise, and informative titles for chat conversations based on the user's first message. The title should ideally be 3-5 words long, and no more than 10 words. Only output the title itself, with no prefixes, labels, or quotation marks.`
+
+    const { text: generatedTitle } = await generateText({
+      model: model,
+      system: systemPrompt,
+      prompt: userMessageContent,
+      maxTokens: 25 // A bit more tokens for safety, but prompt guides length.
+    })
+
+    const cleanedTitle = generatedTitle.trim()
+
+    // If the model returns an empty string, use the fallback.
+    if (!cleanedTitle) {
+      console.warn('LLM generated an empty title, using fallback.')
+      return fallbackTitle
+    }
+
+    // Remove any surrounding quotes that the model might have added
+    return cleanedTitle.replace(/^[\"']|[\"']$/g, '')
+  } catch (error) {
+    console.error('Error generating chat title with LLM:', error)
+    // If LLM generation fails, return the fallback title.
+    return fallbackTitle
+  }
+}

--- a/lib/streaming/create-tool-calling-stream.ts
+++ b/lib/streaming/create-tool-calling-stream.ts
@@ -7,8 +7,11 @@ import {
   streamText
 } from 'ai'
 import { saveChatMessage, saveSingleMessage } from '../actions/chat-db'
+import { generateChatTitle } from '../agents/title-generator'
 import { getChat, getChatMessages } from '../db/chat'
 import { generateUUID } from '../utils'
+import { getTextFromParts } from '../utils/message-utils'
+import { getModel } from '../utils/registry'
 import { BaseStreamConfig } from './types'
 
 export function createToolCallingStreamResponse(config: BaseStreamConfig) {
@@ -20,8 +23,10 @@ export function createToolCallingStreamResponse(config: BaseStreamConfig) {
       try {
         const chat = await getChat(chatId, userId)
         if (!chat) {
-          // Extract title from message content
-          const title = message.content
+          const title = await generateChatTitle({
+            userMessageContent: getTextFromParts(message.parts),
+            model: getModel(modelId)
+          })
 
           // Save the chat and user message to the database using server action
           await saveChatMessage(

--- a/lib/utils/message-utils.ts
+++ b/lib/utils/message-utils.ts
@@ -1,5 +1,5 @@
 import { type Message as DBMessage } from '@/lib/db/schema'
-import { CoreMessage as SDKCoreMessage } from 'ai'
+import { CoreMessage as SDKCoreMessage, UIMessage } from 'ai'
 
 // Type definition for the CoreMessage from AI SDK
 interface CoreMessage {
@@ -90,4 +90,23 @@ export function extractTitleFromMessage(
   }
 
   return 'New Chat'
+}
+
+/**
+ * Extracts and concatenates text content from a message's 'parts' array.
+ *
+ * This function mimics the behavior of the expression:
+ * `message?.parts?.filter(part => part.type === 'text').map(part => part.text).join(' ') ?? '';`
+ *
+ * @param message - An object that may contain a 'parts' array. Can be undefined.
+ * @returns A string of concatenated text from text parts, or an empty string
+ *          if 'message' or 'message.parts' is undefined, or if 'parts' is empty or contains no text parts.
+ */
+export function getTextFromParts(parts?: UIMessage['parts']): string {
+  return (
+    parts
+      ?.filter(part => part.type === 'text')
+      .map(part => part.text)
+      .join(' ') ?? ''
+  )
 }


### PR DESCRIPTION
## Description
This PR enhances the chat title generation by using an LLM instead of simply taking the user's first message as the title. The feature creates concise, descriptive titles for new chat sessions.

## Implementation
- Created a new `generateChatTitle` function in `lib/agents/title-generator.ts` that uses the Vercel AI SDK's `generateText` function to generate chat titles.
- The function takes the user's message content and a language model, then returns a concise (3-5 words) title.
- Updated `lib/streaming/create-tool-calling-stream.ts` to use this new function for title generation when creating new chats.
- Modified the `getTextFromParts` function usage to correctly extract text content from message parts.

## Benefits
- More meaningful and concise chat titles
- Better organization of chat history
- Improved user experience by providing context-aware titles

## Testing
The title generation has been tested with several types of user messages, ensuring it creates appropriate titles while handling edge cases gracefully (empty messages, errors, etc.).