### PR TITLE
A middleware-based approach for base URL determination

### DIFF
--- a/lib/config/models.ts
+++ b/lib/config/models.ts
@@ -17,8 +17,8 @@ export function validateModel(model: any): model is Model {
 
 export async function getModels(): Promise<Model[]> {
   try {
-    // Check for BASE_URL environment variable first
-    const baseUrlEnv = process.env.BASE_URL
+    // Check for NEXT_PUBLIC_BASE_URL environment variable first
+    const baseUrlEnv = process.env.NEXT_PUBLIC_BASE_URL || process.env.BASE_URL
     let baseUrlObj: URL
 
     if (baseUrlEnv) {
@@ -93,7 +93,7 @@ export async function getModels(): Promise<Model[]> {
 }
 
 // Helper function to get base URL from headers
-async function getBaseUrlFromHeaders(): Promise<URL> {
+export async function getBaseUrlFromHeaders(): Promise<URL> {
   const headersList = await headers()
   const baseUrl = headersList.get('x-base-url')
   const url = headersList.get('x-url')

--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -1,3 +1,4 @@
+import { getBaseUrlFromHeaders } from '@/lib/config/models'
 import { getSearchSchemaForModel } from '@/lib/schema/search'
 import {
   SearchResultImage,
@@ -54,8 +55,16 @@ export function createSearchTool(fullModel: string) {
           searchAPI === 'searxng' &&
           effectiveSearchDepthForAPI === 'advanced'
         ) {
-          const baseUrl =
-            process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
+          // Check for NEXT_PUBLIC_BASE_URL first as an override
+          let baseUrl: string
+          if (process.env.NEXT_PUBLIC_BASE_URL) {
+            baseUrl = process.env.NEXT_PUBLIC_BASE_URL
+          } else {
+            // Use the base URL from headers
+            const baseUrlObj = await getBaseUrlFromHeaders()
+            baseUrl = baseUrlObj.toString()
+          }
+          
           const response = await fetch(`${baseUrl}/api/advanced-search`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,17 +2,40 @@ import { updateSession } from '@/lib/supabase/middleware'
 import { type NextRequest, NextResponse } from 'next/server'
 
 export async function middleware(request: NextRequest) {
+  // Get the protocol from X-Forwarded-Proto header or request protocol
+  const protocol =
+    request.headers.get('x-forwarded-proto') || request.nextUrl.protocol
+
+  // Get the host from X-Forwarded-Host header or request host
+  const host =
+    request.headers.get('x-forwarded-host') || request.headers.get('host') || ''
+
+  // Construct the base URL - ensure protocol has :// format
+  const baseUrl = `${protocol}${protocol.endsWith(':') ? '//' : '://'}${host}`
+
+  // Create a response
+  let response: NextResponse
+
+  // Handle Supabase session if configured
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
   if (supabaseUrl && supabaseAnonKey) {
-    return await updateSession(request)
+    response = await updateSession(request)
+  } else {
+    // If Supabase is not configured, just pass the request through
+    response = NextResponse.next({
+      request
+    })
   }
 
-  // If Supabase is not configured, just pass the request through
-  return NextResponse.next({
-    request
-  })
+  // Add request information to response headers
+  response.headers.set('x-url', request.url)
+  response.headers.set('x-host', host)
+  response.headers.set('x-protocol', protocol)
+  response.headers.set('x-base-url', baseUrl)
+
+  return response
 }
 
 export const config = {


### PR DESCRIPTION
Make baseUrl dynamic.

Updated middleware.ts to:

- Extract protocol and host from request headers
- Construct a dynamic base URL
- Add this information to response headers
- Preserve existing Supabase session functionality

Modified lib/config/models.ts to:

- Export the getBaseUrlFromHeaders() function
- Check for NEXT_PUBLIC_BASE_URL first as an override
- Fall back to dynamically determined base URL from headers

Updated lib/tools/search.ts to:

- Import and use the getBaseUrlFromHeaders() function
- Dynamically determine the base URL when NEXT_PUBLIC_BASE_URL isn't set

The development server can now run on any port (eg. 3001), confirming that the system can automatically adapt to different ports without manual configuration. This makes the application more flexible when deployed in various environments.