### PR TITLE
Refactor chat streaming and researcher logic

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
-import { createToolCallingStreamResponse } from '@/lib/streaming/create-tool-calling-stream'
+import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'
 import { Model } from '@/lib/types/models'
 import { isProviderEnabled } from '@/lib/utils/registry'
 import { cookies } from 'next/headers'
@@ -56,7 +56,7 @@ export async function POST(req: Request) {
       )
     }
 
-    return createToolCallingStreamResponse({
+    return await createChatStreamResponse({
       message,
       model: selectedModel,
       chatId,

--- a/lib/agents/researcher.ts
+++ b/lib/agents/researcher.ts
@@ -33,8 +33,6 @@ Citation Format:
 [number](url)
 `
 
-type ResearcherReturn = Parameters<typeof streamText>[0]
-
 export function researcher({
   messages,
   model,
@@ -43,7 +41,7 @@ export function researcher({
   messages: ModelMessage[]
   model: string
   searchMode: boolean
-}): ResearcherReturn {
+}) {
   try {
     const currentDate = new Date().toLocaleString()
 
@@ -52,7 +50,7 @@ export function researcher({
     const videoSearchTool = createVideoSearchTool(model)
     const askQuestionTool = createQuestionTool(model)
 
-    return {
+    const config = {
       model: openai('gpt-4o-mini'), // TODO: Make this configurable
       system: `${SYSTEM_PROMPT}\nCurrent date and time: ${currentDate}`,
       messages,
@@ -68,6 +66,8 @@ export function researcher({
       maxSteps: searchMode ? 5 : 1,
       experimental_transform: smoothStream()
     }
+
+    return streamText(config)
   } catch (error) {
     console.error('Error in chatResearcher:', error)
     throw error

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -14,44 +14,50 @@ import { generateUUID } from '../utils'
 import { getTextFromParts } from '../utils/message-utils'
 import { BaseStreamConfig } from './types'
 
-export function createToolCallingStreamResponse(config: BaseStreamConfig) {
+export async function createChatStreamResponse(
+  config: BaseStreamConfig
+): Promise<Response> {
+  const { message, model, chatId, searchMode, userId } = config
+  const modelId = `${model.providerId}:${model.id}`
+
+  // Fetch chat data for authorization check before stream creation
+  const chatForAuth = await getChat(chatId, userId)
+
+  // Authorization check: if chat exists and does not belong to the user
+  if (chatForAuth && chatForAuth.userId !== userId) {
+    return new Response('You are not allowed to access this chat', {
+      status: 403,
+      statusText: 'Forbidden'
+    })
+  }
+
+  // If authorized or it's a new chat, proceed to create the stream
   const stream = createUIMessageStream({
     execute: async (writer: UIMessageStreamWriter) => {
-      const { message, model, chatId, searchMode, userId } = config
-      const modelId = `${model.providerId}:${model.id}`
-
       try {
-        const chat = await getChat(chatId, userId)
-        if (!chat) {
+        // Use chatForAuth (from outer scope) to decide new/existing path
+        if (!chatForAuth) {
+          // New chat
           const userContent = getTextFromParts(message.parts)
           const title = await generateChatTitle({
             userMessageContent: userContent,
-            model: openai('gpt-4o-mini')
+            model: openai('gpt-4o-mini') // TODO: Consider making this model configurable
           })
-
           await saveChatMessage(chatId, message, userId, title)
         } else {
-          if (chat.userId !== userId) {
-            // TODO: Handle this
-            // return new Response('You are not allowed to access this chat', {
-            //   status: 403,
-            //   statusText: 'Forbidden'
-            // })
-          }
-
-          // Save just the user message to an existing chat
+          // Existing chat, and user is authorized (auth check done outside)
           await saveSingleMessage(chatId, message)
         }
 
         const previousMessages = await getChatMessages(chatId)
-        const messages = appendClientMessage({
+        const messagesToModel = appendClientMessage({
           // @ts-ignore
           messages: previousMessages,
           message
         })
 
         const result = await researcher({
-          messages: convertToModelMessages(messages),
+          messages: convertToModelMessages(messagesToModel),
           model: modelId,
           searchMode
         })
@@ -59,9 +65,9 @@ export function createToolCallingStreamResponse(config: BaseStreamConfig) {
         writer.merge(
           result.toUIMessageStream({
             newMessageId: generateUUID(),
-            onFinish({ messages }) {
-              const assistantMessage = messages.find(
-                message => message.role === 'assistant'
+            onFinish({ messages: resultingMessages }) {
+              const assistantMessage = resultingMessages.find(
+                m => m.role === 'assistant'
               )
               if (assistantMessage) {
                 saveSingleMessage(chatId, assistantMessage)
@@ -71,7 +77,7 @@ export function createToolCallingStreamResponse(config: BaseStreamConfig) {
         )
       } catch (error) {
         console.error('Stream execution error:', error)
-        throw error
+        throw error // This error will be handled by the onError callback
       }
     },
     onError: (error: any) => {

--- a/lib/streaming/create-tool-calling-stream.ts
+++ b/lib/streaming/create-tool-calling-stream.ts
@@ -5,7 +5,6 @@ import {
   convertToModelMessages,
   createUIMessageStream,
   createUIMessageStreamResponse,
-  streamText,
   UIMessageStreamWriter
 } from 'ai'
 import { saveChatMessage, saveSingleMessage } from '../actions/chat-db'
@@ -51,14 +50,10 @@ export function createToolCallingStreamResponse(config: BaseStreamConfig) {
           message
         })
 
-        let researcherConfig = await researcher({
+        const result = await researcher({
           messages: convertToModelMessages(messages),
           model: modelId,
           searchMode
-        })
-
-        const result = streamText({
-          ...researcherConfig
         })
 
         writer.merge(


### PR DESCRIPTION
This PR includes the following refactorings:
- Renamed `createToolCallingStreamResponse` to `createChatStreamResponse`.
- Updated authentication logic in `createChatStreamResponse` to return a 403 error for unauthorized access.
- Modified the `researcher` function to return the `streamText` result directly, simplifying its usage.