### PR TITLE
Standardize Model References Using getModel Function

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,6 @@
         "next": "^15.2.3",
         "next-themes": "^0.3.0",
         "node-html-parser": "^6.1.13",
-        "ollama-ai-provider": "^1.2.0",
         "postgres": "^3.4.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1348,8 +1347,6 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
-    "ollama-ai-provider": ["ollama-ai-provider@1.2.0", "", { "dependencies": { "@ai-sdk/provider": "^1.0.0", "@ai-sdk/provider-utils": "^2.0.0", "partial-json": "0.1.7" }, "peerDependencies": { "zod": "^3.0.0" }, "optionalPeers": ["zod"] }, "sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww=="],
-
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -1367,8 +1364,6 @@
     "parse-entities": ["parse-entities@2.0.0", "", { "dependencies": { "character-entities": "^1.0.0", "character-entities-legacy": "^1.0.0", "character-reference-invalid": "^1.0.0", "is-alphanumerical": "^1.0.0", "is-decimal": "^1.0.0", "is-hexadecimal": "^1.0.0" } }, "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -1527,8 +1522,6 @@
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
-
-    "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1879,10 +1872,6 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
-
-    "ollama-ai-provider/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "ollama-ai-provider/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.7", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-kM0xS3GWg3aMChh9zfeM+80vEZfXzR3JEUBdycZLtbRZ2TRT8xOj3WodGHPb06sUK5yD7pAXC/P7ctsi2fvUGQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/lib/agents/generate-related-questions.ts
+++ b/lib/agents/generate-related-questions.ts
@@ -1,11 +1,6 @@
 import { relatedSchema } from '@/lib/schema/related'
-import { openai } from '@ai-sdk/openai'
 import { ModelMessage, generateObject } from 'ai'
-import {
-  getModel,
-  getToolCallModel,
-  isToolCallSupported
-} from '../utils/registry'
+import { getModel } from '../utils/registry'
 
 export async function generateRelatedQuestions(
   messages: ModelMessage[],
@@ -16,14 +11,8 @@ export async function generateRelatedQuestions(
     role: 'user'
   })) as ModelMessage[]
 
-  const supportedModel = isToolCallSupported(model)
-  const currentModel = supportedModel
-    ? getModel(model)
-    : getToolCallModel(model)
-
   const result = await generateObject({
-    // model: currentModel, //
-    model: openai('gpt-4o-mini'),
+    model: getModel(model),
     system: `As a professional web researcher, your task is to generate a set of three queries that explore the subject matter more deeply, building upon the initial query and the information uncovered in its search results.
 
     For instance, if the original query was "Starship's third test flight key milestones", your output should follow this format:

--- a/lib/agents/researcher.ts
+++ b/lib/agents/researcher.ts
@@ -1,9 +1,9 @@
-import { openai } from '@ai-sdk/openai'
 import { ModelMessage, smoothStream, streamText } from 'ai'
 import { createQuestionTool } from '../tools/question'
 import { retrieveTool } from '../tools/retrieve'
 import { createSearchTool } from '../tools/search'
 import { createVideoSearchTool } from '../tools/video-search'
+import { getModel } from '../utils/registry'
 
 const SYSTEM_PROMPT = `
 Instructions:
@@ -51,7 +51,7 @@ export function researcher({
     const askQuestionTool = createQuestionTool(model)
 
     const config = {
-      model: openai('gpt-4o-mini'), // TODO: Make this configurable
+      model: getModel(model),
       system: `${SYSTEM_PROMPT}\nCurrent date and time: ${currentDate}`,
       messages,
       tools: {

--- a/lib/agents/title-generator.ts
+++ b/lib/agents/title-generator.ts
@@ -3,7 +3,7 @@ import { getModel } from '../utils/registry'
 
 interface GenerateChatTitleParams {
   userMessageContent: string
-  model: string
+  modelId: string
 }
 
 /**
@@ -14,7 +14,7 @@ interface GenerateChatTitleParams {
  */
 export async function generateChatTitle({
   userMessageContent,
-  model
+  modelId
 }: GenerateChatTitleParams): Promise<string> {
   // Fallback title uses the first 75 characters of the message or a default string.
   const fallbackTitle = userMessageContent.substring(0, 75).trim() || 'New Chat'
@@ -23,7 +23,7 @@ export async function generateChatTitle({
     const systemPrompt = `System: You are an AI assistant specialized in creating very short, concise, and informative titles for chat conversations based on the user's first message. The title should ideally be 3-5 words long, and no more than 10 words. Only output the title itself, with no prefixes, labels, or quotation marks.`
 
     const { text: generatedTitle } = await generateText({
-      model: getModel(model),
+      model: getModel(modelId),
       system: systemPrompt,
       prompt: userMessageContent
     })

--- a/lib/agents/title-generator.ts
+++ b/lib/agents/title-generator.ts
@@ -1,9 +1,9 @@
-import { openai } from '@ai-sdk/openai'
-import { generateText, LanguageModel } from 'ai'
+import { generateText } from 'ai'
+import { getModel } from '../utils/registry'
 
 interface GenerateChatTitleParams {
   userMessageContent: string
-  model: LanguageModel
+  model: string
 }
 
 /**
@@ -23,7 +23,7 @@ export async function generateChatTitle({
     const systemPrompt = `System: You are an AI assistant specialized in creating very short, concise, and informative titles for chat conversations based on the user's first message. The title should ideally be 3-5 words long, and no more than 10 words. Only output the title itself, with no prefixes, labels, or quotation marks.`
 
     const { text: generatedTitle } = await generateText({
-      model: openai('gpt-4o-mini'), // TODO: Make this configurable
+      model: getModel(model),
       system: systemPrompt,
       prompt: userMessageContent
     })

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -1,5 +1,4 @@
 import { researcher } from '@/lib/agents/researcher'
-import { openai } from '@ai-sdk/openai'
 import {
   appendClientMessage,
   convertToModelMessages,
@@ -41,7 +40,7 @@ export async function createChatStreamResponse(
           const userContent = getTextFromParts(message.parts)
           const title = await generateChatTitle({
             userMessageContent: userContent,
-            model: openai('gpt-4o-mini') // TODO: Consider making this model configurable
+            modelId
           })
           await saveChatMessage(chatId, message, userId, title)
         } else {

--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -9,9 +9,9 @@ import { xai } from '@ai-sdk/xai'
 import {
   createProviderRegistry,
   extractReasoningMiddleware,
+  LanguageModel,
   wrapLanguageModel
 } from 'ai'
-import { createOllama } from 'ollama-ai-provider'
 
 export const registry = createProviderRegistry({
   openai,
@@ -37,19 +37,9 @@ export const registry = createProviderRegistry({
   xai
 })
 
-export function getModel(model: string) {
+export function getModel(model: string): LanguageModel {
   const [provider, ...modelNameParts] = model.split(':') ?? []
   const modelName = modelNameParts.join(':')
-  if (model.includes('ollama')) {
-    const ollama = createOllama({
-      baseURL: `${process.env.OLLAMA_BASE_URL}/api`
-    })
-
-    // if ollama provider, set simulateStreaming to true
-    return ollama(modelName, {
-      simulateStreaming: true
-    })
-  }
 
   // if model is groq and includes deepseek-r1, add reasoning middleware
   if (model.includes('groq') && model.includes('deepseek-r1')) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "next": "^15.2.3",
     "next-themes": "^0.3.0",
     "node-html-parser": "^6.1.13",
-    "ollama-ai-provider": "^1.2.0",
     "postgres": "^3.4.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Changes

This PR standardizes model references across agent files to use the `getModel` function consistently. As part of this change, the Ollama AI provider has been removed since it does not support languageModelV2.

### Details

- Updated agent files to consistently use `getModel` function instead of direct model references:
  - Updated `lib/agents/researcher.ts`
  - Updated `lib/agents/generate-related-questions.ts`
  - Updated `lib/agents/title-generator.ts`
- Removed Ollama-specific code from `lib/utils/registry.ts`
- Removed `ollama-ai-provider` package from dependencies

These changes ensure consistency in how models are accessed throughout the application while supporting the transition to languageModelV2.