### PR TITLE
Improve uploaded file component layout and rename to kebab-case

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -16,7 +16,7 @@ import { ModelSelector } from './model-selector'
 import { SearchModeToggle } from './search-mode-toggle'
 import { Button } from './ui/button'
 import { IconLogo } from './ui/icons'
-import { UploadedFileList } from './uploaded-fileList'
+import { UploadedFileList } from './uploaded-file-list'
 
 interface ChatPanelProps {
   chatId: string

--- a/components/uploaded-file-list.tsx
+++ b/components/uploaded-file-list.tsx
@@ -15,14 +15,14 @@ export const UploadedFileList = React.memo(function UploadedFileList({
   onRemove
 }: UploadedFileListProps) {
   return (
-    <div className="w-full flex justify-center py-4">
+    <div className="w-full flex p-4 max-w-3xl mx-auto">
       <div className="flex gap-6 overflow-x-auto">
         {files.map((it, index) => (
           <div
             key={index}
-            className="relative w-28 flex-shrink-0 flex flex-col items-center"
+            className="relative w-20 flex-shrink-0 flex flex-col items-center"
           >
-            <div className="relative w-28 h-20 rounded-lg overflow-hidden shadow border bg-muted/20 dark:bg-muted/10">
+            <div className="relative w-20 aspect-[7/5] rounded-lg overflow-hidden shadow border bg-muted/20 dark:bg-muted/10">
               {it.file.type.startsWith('image/') ? (
                 <Image
                   src={URL.createObjectURL(it.file)}


### PR DESCRIPTION
This PR improves the uploaded file component layout with the following changes:

1. Renamed the component file from `uploaded-fileList.tsx` to `uploaded-file-list.tsx` following kebab-case convention
2. Modified layout styling:
   - Changed container from `justify-center` to centered with `max-w-3xl mx-auto`
   - Adjusted the width of file items from `w-28` to `w-20`
   - Changed container padding from `py-4` to `p-4`
   - Modified aspect ratio for thumbnails using `aspect-[7/5]` instead of fixed height

These changes improve the overall appearance and consistency of the uploaded file list.