### PR TITLE
refactor: improve reasoning auto-collapse logic in chat messages

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -113,7 +113,6 @@ export function ChatMessages({
                 addToolResult={addToolResult}
                 onUpdateMessage={onUpdateMessage}
                 reload={reload}
-                sectionIndex={sectionIndex}
               />
               {showLoading && <DefaultSkeleton />}
             </div>
@@ -132,7 +131,6 @@ export function ChatMessages({
                   addToolResult={addToolResult}
                   onUpdateMessage={onUpdateMessage}
                   reload={reload}
-                  sectionIndex={sectionIndex}
                 />
               </div>
             ))}

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -29,8 +29,6 @@ export function MessageActions({
 }: MessageActionsProps) {
   const isLoading = status === 'submitted' || status === 'streaming'
 
-  console.log('isLoading', status)
-
   async function handleCopy() {
     await navigator.clipboard.writeText(message)
     toast.success('Message copied to clipboard')

--- a/components/related-questions.tsx
+++ b/components/related-questions.tsx
@@ -31,7 +31,6 @@ export const RelatedQuestions: React.FC<RelatedQuestionsProps> = ({
   const data: Related | undefined =
     tool.state === 'result' ? tool.result : undefined
 
-  console.log('data', data)
   if (!data && isLoading) {
     return (
       <CollapsibleMessage

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -16,7 +16,6 @@ interface RenderMessageProps {
   addToolResult?: (params: { toolCallId: string; result: any }) => void
   onUpdateMessage?: (messageId: string, newContent: string) => Promise<void>
   reload?: (messageId: string) => Promise<void | string | null | undefined>
-  sectionIndex: number
 }
 
 export function RenderMessage({
@@ -29,8 +28,7 @@ export function RenderMessage({
   status,
   addToolResult,
   onUpdateMessage,
-  reload,
-  sectionIndex
+  reload
 }: RenderMessageProps) {
   if (message.role === 'user') {
     return (

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -101,7 +101,7 @@ export function RenderMessage({
               <AnswerSection
                 key={`${messageId}-text-${index}`}
                 content={part.text}
-                isOpen={getIsOpen(messageId, 'text', hasNextPart)}
+                isOpen={getIsOpen(messageId, part.type, hasNextPart)}
                 onOpenChange={open => onOpenChange(messageId, open)}
                 chatId={chatId}
                 showActions={isLastTextPart}
@@ -118,7 +118,7 @@ export function RenderMessage({
                   reasoning: part.text,
                   isDone: index !== (message.parts?.length ?? 0) - 1
                 }}
-                isOpen={getIsOpen(messageId, 'reasoning', hasNextPart)}
+                isOpen={getIsOpen(messageId, part.type, hasNextPart)}
                 onOpenChange={open => onOpenChange(messageId, open)}
               />
             )


### PR DESCRIPTION
## Summary

Refactored the chat messages component to implement improved auto-collapse behavior for reasoning components.

## Changes

### 🔧 Core Logic Changes
- Reasoning components now auto-collapse when there's a next part in the same message
- Preserve user-modified states when users explicitly open/close components
- Replace `openStates` management with `userModifiedStates` for better state tracking

### 🧹 Code Cleanup
- Simplify `getIsOpen` function parameters and remove unused `sectionIndex`
- Clean up prop passing and function references
- Remove debugging console.log statements

### 📝 Behavior
- **Reasoning**: Auto-collapses when there's a next part in the same message, but respects user's explicit open/close actions
- **Tool invocations**: Default to open state
- **Text**: Default to open state

## Technical Details

- Updated `getIsOpen` function signature to accept `partType` and `hasNextPart` parameters
- Modified `RenderMessage` component to calculate `hasNextPart` based on current part index within the same message
- Streamlined state management to only track user-modified states

## Testing

- [x] Reasoning components auto-collapse when followed by other parts in the same message
- [x] User-modified states are preserved across re-renders
- [x] Tool invocations and text components maintain expected behavior