### PR TITLE
feat: Use image from search results for OG tag

### DIFF
--- a/app/search/[id]/page.tsx
+++ b/app/search/[id]/page.tsx
@@ -4,7 +4,7 @@ import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import { getModels } from '@/lib/config/models'
 import { convertToUIMessages } from '@/lib/utils'
 import { notFound, redirect } from 'next/navigation'
-import { ExtendedCoreMessage, SearchResults, SearchResultImage } from '@/lib/types'; // Added SearchResults and SearchResultImage
+import { ExtendedCoreMessage, SearchResults } from '@/lib/types'; // Added SearchResults
 
 export const maxDuration = 60
 

--- a/app/search/[id]/page.tsx
+++ b/app/search/[id]/page.tsx
@@ -4,20 +4,53 @@ import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import { getModels } from '@/lib/config/models'
 import { convertToUIMessages } from '@/lib/utils'
 import { notFound, redirect } from 'next/navigation'
+import { ExtendedCoreMessage, SearchResults, SearchResultImage } from '@/lib/types'; // Added SearchResults and SearchResultImage
 
 export const maxDuration = 60
 
 export async function generateMetadata(props: {
-  params: Promise<{ id: string }>
+  params: Promise<{ id: string }>;
 }) {
-  const { id } = await props.params
-  const userId = await getCurrentUserId()
-  const chat = await getChat(id, userId)
-  return {
-    title: chat?.title.toString().slice(0, 50) || 'Search'
+  const { id } = await props.params;
+  const userId = await getCurrentUserId();
+  const chat = await getChat(id, userId || 'anonymous'); // Ensure fallback for userId
+
+  let metadata: { title: string; openGraph?: { images?: { url: string; width?: number; height?: number }[] } } = {
+    title: chat?.title?.toString().slice(0, 50) || 'Search',
+  };
+
+  if (chat && chat.messages) {
+    const dataMessage = chat.messages.find(
+      (msg: ExtendedCoreMessage) => msg.role === 'data'
+    );
+
+    if (dataMessage && dataMessage.content) {
+      // Assuming dataMessage.content is of type SearchResults or a compatible structure
+      const searchData = dataMessage.content as SearchResults;
+      if (searchData.images && searchData.images.length > 0) {
+        const firstImage = searchData.images[0];
+        let imageUrl: string | undefined = undefined;
+
+        if (typeof firstImage === 'string') {
+          imageUrl = firstImage;
+        } else if (typeof firstImage === 'object' && firstImage.url) {
+          imageUrl = firstImage.url;
+        }
+
+        if (imageUrl) {
+          metadata.openGraph = {
+            images: [{ url: imageUrl, width: 1200, height: 630 }], // Standard OG image dimensions
+          };
+        }
+      }
+    }
   }
+  // If no image is found, metadata.openGraph.images will remain undefined,
+  // allowing fallback to parent or global OG image settings.
+  return metadata;
 }
 
+// ... rest of the file (default export SearchPage) remains the same
 export default async function SearchPage(props: {
   params: Promise<{ id: string }>
 }) {


### PR DESCRIPTION
This corrects the implementation for dynamic Open Graph (OG) images for your search result pages (`/search/[id]`) as per issue #536 and your subsequent feedback.

The `og:image` meta tag will now point to an actual image URL retrieved from the search results, rather than generating a new image card.

Key changes:
- I modified the `generateMetadata` function in `app/search/[id]/page.tsx`:
  - It now fetches chat data, looking for a 'data' message containing search results (images and web results).
  - It extracts the first image URL from the `images` array within the search results.
  - This URL is set as the `og:image` in the page's metadata, including standard width (1200) and height (630).
  - If no image is found in the search data or an error occurs, the `og:image` tag is not set by this function, allowing Next.js to fall back to the global `app/opengraph-image.png`.
- I removed the `app/search/[id]/opengraph-image.tsx` file, as it was based on the previous approach of generating a new image.

Manual testing is required to confirm that:
- Searches with images use an image from the results as `og:image`.
- Searches without images, or invalid searches, fall back to the global `app/opengraph-image.png`.