### PR TITLE
Fix reload and edit functionality with messageId-based operations

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -22,18 +22,20 @@ export async function POST(req: Request) {
     const { message, chatId, trigger, messageId } = body
 
     // Handle different triggers
-    if (trigger === 'regenerate-assistant-message' && !messageId) {
-      return new Response('messageId is required for regeneration', {
-        status: 400,
-        statusText: 'Bad Request'
-      })
-    }
-
-    if (trigger === 'submit-user-message' && !message) {
-      return new Response('message is required for submission', {
-        status: 400,
-        statusText: 'Bad Request'
-      })
+    if (trigger === 'regenerate-assistant-message') {
+      if (!messageId) {
+        return new Response('messageId is required for regeneration', {
+          status: 400,
+          statusText: 'Bad Request'
+        })
+      }
+    } else if (trigger === 'submit-user-message') {
+      if (!message) {
+        return new Response('message is required for submission', {
+          status: 400,
+          statusText: 'Bad Request'
+        })
+      }
     }
 
     const referer = req.headers.get('referer')

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -19,25 +19,21 @@ const DEFAULT_MODEL: Model = {
 export async function POST(req: Request) {
   try {
     const body = await req.json()
-    const { messages, chatId, trigger, messageId } = body
+    const { message, chatId, trigger, messageId } = body
 
     // Handle different triggers
-    let message
+    if (trigger === 'regenerate-assistant-message' && !messageId) {
+      return new Response('messageId is required for regeneration', {
+        status: 400,
+        statusText: 'Bad Request'
+      })
+    }
 
-    if (trigger === 'regenerate-assistant-message') {
-      // For regeneration, we'll fetch the messages from DB and use the last user message
-      // This will be handled in createChatStreamResponse
-      message = null
-    } else {
-      // Get the last message from the messages array (the new user message)
-      message = messages?.[messages.length - 1]
-
-      if (!message) {
-        return new Response('No message provided', {
-          status: 400,
-          statusText: 'Bad Request'
-        })
-      }
+    if (trigger === 'submit-user-message' && !message) {
+      return new Response('message is required for submission', {
+        status: 400,
+        statusText: 'Bad Request'
+      })
     }
 
     const referer = req.headers.get('referer')

--- a/app/search/loading.tsx
+++ b/app/search/loading.tsx
@@ -4,7 +4,7 @@ import { DefaultSkeleton } from '../../components/default-skeleton'
 
 export default function Loading() {
   return (
-    <div className="flex h-full min-w-0 flex-1 flex-col items-center justify-center">
+    <div className="flex min-w-0 flex-1 flex-col items-center justify-center">
       <div className="w-full max-w-3xl px-4 pt-12">
         <DefaultSkeleton />
       </div>

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -65,7 +65,10 @@ export function Chat({
                 chatId: id,
                 messageId,
                 // Include the message if it's a user message (for edit cases)
-                message: messageToRegenerate?.role === 'user' ? messageToRegenerate : undefined
+                message:
+                  messageToRegenerate?.role === 'user'
+                    ? messageToRegenerate
+                    : undefined
               }
             }
 

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -84,13 +84,17 @@ export async function createChatStreamResponse(
               await saveMessage(chatId, message)
             }
             // Delete everything after this user message
-            const messagesToDelete = currentChat.messages.slice(messageIndex + 1)
+            const messagesToDelete = currentChat.messages.slice(
+              messageIndex + 1
+            )
             if (messagesToDelete.length > 0) {
               await deleteMessagesFromIndex(chatId, messagesToDelete[0].id)
             }
             // Get updated messages including the edited one
             const updatedChat = await getChatAction(chatId, userId)
-            messagesToModel = updatedChat?.messages || currentChat.messages.slice(0, messageIndex + 1)
+            messagesToModel =
+              updatedChat?.messages ||
+              currentChat.messages.slice(0, messageIndex + 1)
           }
         } else {
           // Handle normal message submission

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -92,9 +92,12 @@ export async function createChatStreamResponse(
             }
             // Get updated messages including the edited one
             const updatedChat = await getChatAction(chatId, userId)
-            messagesToModel =
-              updatedChat?.messages ||
-              currentChat.messages.slice(0, messageIndex + 1)
+            if (updatedChat?.messages) {
+              messagesToModel = updatedChat.messages
+            } else {
+              // Fallback: use current messages up to and including the edited message
+              messagesToModel = currentChat.messages.slice(0, messageIndex + 1)
+            }
           }
         } else {
           // Handle normal message submission


### PR DESCRIPTION
## Overview
This PR fixes the reload and edit functionality to use messageId-based operations instead of timestamp-based operations, making the implementation more reliable and aligned with Vercel AI SDK v5 patterns.

## Changes

### Client-side (chat.tsx)
- Updated `handleUpdateAndReloadMessage` to edit messages in-place without creating duplicates
- Simplified `handleReloadFrom` to use the SDK's built-in `regenerate` function
- Modified `prepareSendMessagesRequest` to include edited user messages during regeneration

### Server-side
- Updated API route to properly handle message objects instead of arrays
- Enhanced stream handler to save edited messages before regeneration
- Improved regeneration logic to handle both assistant and user message regeneration

## Key Improvements
- **No more createdAt dependency**: All operations now use messageId for precision
- **Fixed message duplication**: Edit functionality now updates existing messages instead of creating new ones
- **Cleaner implementation**: Leverages SDK's built-in functionality for regeneration
- **Better error handling**: More robust error messages and validation

## Testing
- Tested reload functionality for both user and assistant messages
- Verified edit functionality properly updates messages without duplication
- Confirmed messageId-based deletion works correctly