### PR TITLE
feat: skip related questions generation when no tool calls

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -139,7 +139,7 @@ export async function createChatStreamResponse(
         let relatedQuestionsMessage: UIMessage | null = null
 
         // Create a promise to track when research finishes
-        const researchPromise = new Promise<void>((resolve) => {
+        const researchPromise = new Promise<void>(resolve => {
           writer.merge(
             researchResult.toUIMessageStream({
               sendFinish: false,
@@ -218,7 +218,7 @@ export async function createChatStreamResponse(
           })
 
           // Create a promise to track when related questions finish
-          const relatedQuestionsPromise = new Promise<void>((resolve) => {
+          const relatedQuestionsPromise = new Promise<void>(resolve => {
             writer.merge(
               relatedQuestionsResult.toUIMessageStream({
                 sendStart: false,

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -17,7 +17,11 @@ import {
 import { generateRelatedQuestions } from '../agents/generate-related-questions'
 import { generateChatTitle } from '../agents/title-generator'
 import { generateId } from '../db/schema'
-import { getTextFromParts, mergeUIMessages } from '../utils/message-utils'
+import {
+  getTextFromParts,
+  hasToolCalls,
+  mergeUIMessages
+} from '../utils/message-utils'
 
 import { BaseStreamConfig } from './types'
 
@@ -164,16 +168,10 @@ export async function createChatStreamResponse(
         const validResearchMessage: UIMessage = researchMessage
 
         // Check if the research message contains tool calls
-        const hasToolCalls =
-          validResearchMessage.parts &&
-          validResearchMessage.parts.some(
-            (part: any) =>
-              part.type &&
-              (part.type.startsWith('tool-') || part.type === 'tool-call')
-          )
+        const hasToolCallsInMessage = hasToolCalls(validResearchMessage)
 
         // If no tool calls (just answering), skip related questions
-        if (!hasToolCalls) {
+        if (!hasToolCallsInMessage) {
           // Save research message
           await saveMessage(chatId, validResearchMessage)
 

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -24,6 +24,191 @@ import { BaseStreamConfig } from './types'
 // Constants
 const DEFAULT_CHAT_TITLE = 'New Chat'
 
+// Helper function to check if a message contains tool calls
+function hasToolCalls(message: UIMessage | null): boolean {
+  if (!message || !message.parts) return false
+  
+  return message.parts.some(
+    (part: any) =>
+      part.type &&
+      (part.type.startsWith('tool-') || part.type === 'tool-call')
+  )
+}
+
+// Helper function to save chat title
+async function saveChatTitle(
+  chat: any,
+  chatId: string,
+  message: UIMessage | null,
+  modelId: string
+) {
+  if (!chat && message) {
+    const userContent = getTextFromParts(message.parts)
+    const title = await generateChatTitle({
+      userMessageContent: userContent,
+      modelId
+    })
+    const { updateChatTitle } = await import('../db/actions')
+    await updateChatTitle(chatId, title)
+  }
+}
+
+// Helper function to prepare messages for regeneration
+async function prepareMessagesForRegeneration(
+  chatId: string,
+  userId: string,
+  messageId: string,
+  message: UIMessage | null
+): Promise<UIMessage[]> {
+  const currentChat = await getChatAction(chatId, userId)
+  if (!currentChat || !currentChat.messages.length) {
+    throw new Error('No messages found')
+  }
+
+  const messageIndex = currentChat.messages.findIndex(m => m.id === messageId)
+  if (messageIndex === -1) {
+    throw new Error(`Message ${messageId} not found`)
+  }
+
+  const targetMessage = currentChat.messages[messageIndex]
+  
+  if (targetMessage.role === 'assistant') {
+    // Delete from this assistant message onwards
+    await deleteMessagesFromIndex(chatId, messageId)
+    // Use messages up to (but not including) this assistant message
+    return currentChat.messages.slice(0, messageIndex)
+  } else {
+    // If it's a user message that was edited, save the updated message first
+    if (message && message.id === messageId) {
+      await saveMessage(chatId, message)
+    }
+    // Delete everything after this user message
+    const messagesToDelete = currentChat.messages.slice(messageIndex + 1)
+    if (messagesToDelete.length > 0) {
+      await deleteMessagesFromIndex(chatId, messagesToDelete[0].id)
+    }
+    // Get updated messages including the edited one
+    const updatedChat = await getChatAction(chatId, userId)
+    if (updatedChat?.messages) {
+      return updatedChat.messages
+    } else {
+      // Fallback: use current messages up to and including the edited message
+      return currentChat.messages.slice(0, messageIndex + 1)
+    }
+  }
+}
+
+// Helper function to prepare messages for normal submission
+async function prepareMessagesForSubmission(
+  chatId: string,
+  userId: string,
+  message: UIMessage,
+  chat: any
+): Promise<UIMessage[]> {
+  if (!message) {
+    throw new Error('No message provided')
+  }
+
+  // Save the message
+  const messageWithId = {
+    ...message,
+    id: message.id || generateId()
+  }
+
+  // If chat doesn't exist, create it with a temporary title
+  if (!chat) {
+    await createChat(chatId, DEFAULT_CHAT_TITLE)
+  }
+
+  await saveMessage(chatId, messageWithId)
+
+  // Get all messages including the one just saved
+  const updatedChat = await getChatAction(chatId, userId)
+  return updatedChat?.messages || [messageWithId]
+}
+
+// Helper function to handle direct response (no tool calls)
+async function handleDirectResponse(
+  writer: UIMessageStreamWriter,
+  researchMessage: UIMessage,
+  chatId: string,
+  chat: any,
+  message: UIMessage | null,
+  modelId: string
+) {
+  // Save research message
+  await saveMessage(chatId, researchMessage)
+
+  // Generate proper title after conversation starts
+  await saveChatTitle(chat, chatId, message, modelId)
+
+  // Send a finish message to complete the stream
+  writer.write({ type: 'finish' })
+}
+
+// Helper function to generate related questions
+async function generateRelatedQuestionsStream(
+  writer: UIMessageStreamWriter,
+  researchResult: any,
+  messagesToModel: UIMessage[],
+  modelId: string,
+  researchMessage: UIMessage,
+  chatId: string,
+  chat: any,
+  message: UIMessage | null
+) {
+  try {
+    // Get the research data
+    const researchData = await researchResult.response
+
+    // Check if request was aborted
+    if (researchData.messages.length === 0) {
+      return
+    }
+
+    // Prepare messages for related questions agent
+    const allMessages = [
+      ...convertToModelMessages(messagesToModel),
+      ...researchData.messages
+    ]
+
+    // Get related questions agent
+    const relatedQuestionsAgent = generateRelatedQuestions(modelId)
+    const relatedQuestionsResult = relatedQuestionsAgent.stream({
+      messages: allMessages
+    })
+
+    // Merge related questions stream
+    writer.merge(
+      relatedQuestionsResult.toUIMessageStream({
+        sendStart: false,
+        onFinish: async ({ responseMessage }) => {
+          const relatedQuestionsMessage = responseMessage
+
+          // Save the complete message after both agents finish
+          if (researchMessage && relatedQuestionsMessage) {
+            const mergedMessage = mergeUIMessages(
+              researchMessage,
+              relatedQuestionsMessage
+            )
+            await saveMessage(chatId, mergedMessage)
+          } else if (researchMessage) {
+            // Save research message only if related questions failed
+            await saveMessage(chatId, researchMessage)
+          }
+
+          // Generate proper title after conversation starts
+          await saveChatTitle(chat, chatId, message, modelId)
+        }
+      })
+    )
+  } catch (error) {
+    console.error('Error generating related questions:', error)
+    // Save research message even if related questions fail
+    await saveMessage(chatId, researchMessage)
+  }
+}
+
 export async function createChatStreamResponse(
   config: BaseStreamConfig
 ): Promise<Response> {
@@ -54,73 +239,23 @@ export async function createChatStreamResponse(
   const stream = createUIMessageStream({
     execute: async ({ writer }: { writer: UIMessageStreamWriter }) => {
       try {
+        // Prepare messages based on trigger type
         let messagesToModel: UIMessage[]
-
+        
         if (trigger === 'regenerate-assistant-message' && messageId) {
-          // Handle regeneration
-          // Find the message to regenerate from
-          const currentChat = await getChatAction(chatId, userId)
-          if (!currentChat || !currentChat.messages.length) {
-            throw new Error('No messages found')
-          }
-
-          const messageIndex = currentChat.messages.findIndex(
-            m => m.id === messageId
+          messagesToModel = await prepareMessagesForRegeneration(
+            chatId,
+            userId,
+            messageId,
+            message
           )
-          if (messageIndex === -1) {
-            throw new Error(`Message ${messageId} not found`)
-          }
-
-          // Check if it's an assistant message that needs regeneration
-          const targetMessage = currentChat.messages[messageIndex]
-          if (targetMessage.role === 'assistant') {
-            // Delete from this assistant message onwards
-            await deleteMessagesFromIndex(chatId, messageId)
-            // Use messages up to (but not including) this assistant message
-            messagesToModel = currentChat.messages.slice(0, messageIndex)
-          } else {
-            // If it's a user message that was edited, save the updated message first
-            if (message && message.id === messageId) {
-              await saveMessage(chatId, message)
-            }
-            // Delete everything after this user message
-            const messagesToDelete = currentChat.messages.slice(
-              messageIndex + 1
-            )
-            if (messagesToDelete.length > 0) {
-              await deleteMessagesFromIndex(chatId, messagesToDelete[0].id)
-            }
-            // Get updated messages including the edited one
-            const updatedChat = await getChatAction(chatId, userId)
-            if (updatedChat?.messages) {
-              messagesToModel = updatedChat.messages
-            } else {
-              // Fallback: use current messages up to and including the edited message
-              messagesToModel = currentChat.messages.slice(0, messageIndex + 1)
-            }
-          }
         } else {
-          // Handle normal message submission
-          if (!message) {
-            throw new Error('No message provided')
-          }
-
-          // Save the message
-          const messageWithId = {
-            ...message,
-            id: message.id || generateId()
-          }
-
-          // If chat doesn't exist, create it with a temporary title
-          if (!chat) {
-            await createChat(chatId, DEFAULT_CHAT_TITLE)
-          }
-
-          await saveMessage(chatId, messageWithId)
-
-          // Get all messages including the one just saved
-          const updatedChat = await getChatAction(chatId, userId)
-          messagesToModel = updatedChat?.messages || [messageWithId]
+          messagesToModel = await prepareMessagesForSubmission(
+            chatId,
+            userId,
+            message!,
+            chat
+          )
         }
 
         // Get the researcher agent
@@ -134,9 +269,8 @@ export async function createChatStreamResponse(
           messages: convertToModelMessages(messagesToModel)
         })
 
-        // Store messages for merging
+        // Store research message for later use
         let researchMessage: UIMessage | null = null
-        let relatedQuestionsMessage: UIMessage | null = null
 
         // Merge research stream without finishing and capture the message
         writer.merge(
@@ -145,101 +279,30 @@ export async function createChatStreamResponse(
             onFinish: async ({ responseMessage }) => {
               researchMessage = responseMessage
 
-              // Check if the research message contains tool calls
-              const hasToolCalls =
-                responseMessage &&
-                responseMessage.parts &&
-                responseMessage.parts.some(
-                  (part: any) =>
-                    part.type &&
-                    (part.type.startsWith('tool-') || part.type === 'tool-call')
-                )
-
               // If no tool calls (just answering), skip related questions
-              if (!hasToolCalls) {
-                // Save research message
-                await saveMessage(chatId, researchMessage)
-
-                // Generate proper title after conversation starts
-                if (!chat && message) {
-                  const userContent = getTextFromParts(message.parts)
-                  const title = await generateChatTitle({
-                    userMessageContent: userContent,
-                    modelId
-                  })
-                  // Update chat title
-                  const { updateChatTitle } = await import('../db/actions')
-                  await updateChatTitle(chatId, title)
-                }
-
-                // Send a finish message to complete the stream
-                writer.write({ type: 'finish' })
+              if (!hasToolCalls(researchMessage)) {
+                await handleDirectResponse(
+                  writer,
+                  researchMessage!,
+                  chatId,
+                  chat,
+                  message,
+                  modelId
+                )
                 return
               }
 
               // If we have tool calls, proceed with related questions generation
-              try {
-                // Get the research data
-                const researchData = await researchResult.response
-
-                // Check if request was aborted
-                if (researchData.messages.length === 0) {
-                  return
-                }
-
-                // Prepare messages for related questions agent
-                const allMessages = [
-                  ...convertToModelMessages(messagesToModel),
-                  ...researchData.messages
-                ]
-
-                // Get related questions agent
-                const relatedQuestionsAgent = generateRelatedQuestions(modelId)
-                const relatedQuestionsResult = relatedQuestionsAgent.stream({
-                  messages: allMessages
-                })
-
-                // Merge related questions stream
-                writer.merge(
-                  relatedQuestionsResult.toUIMessageStream({
-                    sendStart: false,
-                    onFinish: async ({ responseMessage }) => {
-                      relatedQuestionsMessage = responseMessage
-
-                      // Save the complete message after both agents finish
-                      // Merge and save both messages
-                      if (researchMessage && relatedQuestionsMessage) {
-                        const mergedMessage = mergeUIMessages(
-                          researchMessage,
-                          relatedQuestionsMessage
-                        )
-                        await saveMessage(chatId, mergedMessage)
-                      } else if (researchMessage) {
-                        // Save research message only if related questions failed
-                        await saveMessage(chatId, researchMessage)
-                      }
-
-                      // Generate proper title after conversation starts
-                      if (!chat && message) {
-                        const userContent = getTextFromParts(message.parts)
-                        const title = await generateChatTitle({
-                          userMessageContent: userContent,
-                          modelId
-                        })
-                        // Update chat title
-                        const { updateChatTitle } = await import(
-                          '../db/actions'
-                        )
-                        await updateChatTitle(chatId, title)
-                      }
-                    }
-                  })
-                )
-              } catch (error) {
-                console.error('Error generating related questions:', error)
-                // Save research message even if related questions fail
-                await saveMessage(chatId, researchMessage)
-              }
+              await generateRelatedQuestionsStream(
+                writer,
+                researchResult,
+                messagesToModel,
+                modelId,
+                researchMessage!,
+                chatId,
+                chat,
+                message
+              )
             }
           })
         )

--- a/lib/streaming/message-preparation.ts
+++ b/lib/streaming/message-preparation.ts
@@ -1,0 +1,100 @@
+import type { UIMessage } from 'ai'
+
+import {
+  createChat,
+  deleteMessagesFromIndex,
+  getChat as getChatAction,
+  saveMessage
+} from '@/lib/actions/chat'
+import { generateId } from '@/lib/db/schema'
+
+// Constants
+const DEFAULT_CHAT_TITLE = 'New Chat'
+
+/**
+ * Prepares messages for regeneration by handling message deletion and retrieval
+ * @param chatId The chat ID
+ * @param userId The user ID for authorization
+ * @param messageId The message ID to regenerate from
+ * @param message The new message (if any)
+ * @returns Array of UIMessages to send to the model
+ */
+export async function prepareMessagesForRegeneration(
+  chatId: string,
+  userId: string,
+  messageId: string,
+  message: UIMessage | null
+): Promise<UIMessage[]> {
+  const currentChat = await getChatAction(chatId, userId)
+  if (!currentChat || !currentChat.messages.length) {
+    throw new Error('No messages found')
+  }
+
+  const messageIndex = currentChat.messages.findIndex(m => m.id === messageId)
+  if (messageIndex === -1) {
+    throw new Error(`Message ${messageId} not found`)
+  }
+
+  const targetMessage = currentChat.messages[messageIndex]
+  
+  if (targetMessage.role === 'assistant') {
+    // Delete from this assistant message onwards
+    await deleteMessagesFromIndex(chatId, messageId)
+    // Use messages up to (but not including) this assistant message
+    return currentChat.messages.slice(0, messageIndex)
+  } else {
+    // If it's a user message that was edited, save the updated message first
+    if (message && message.id === messageId) {
+      await saveMessage(chatId, message)
+    }
+    // Delete everything after this user message
+    const messagesToDelete = currentChat.messages.slice(messageIndex + 1)
+    if (messagesToDelete.length > 0) {
+      await deleteMessagesFromIndex(chatId, messagesToDelete[0].id)
+    }
+    // Get updated messages including the edited one
+    const updatedChat = await getChatAction(chatId, userId)
+    if (updatedChat?.messages) {
+      return updatedChat.messages
+    } else {
+      // Fallback: use current messages up to and including the edited message
+      return currentChat.messages.slice(0, messageIndex + 1)
+    }
+  }
+}
+
+/**
+ * Prepares messages for normal submission by saving the new message
+ * @param chatId The chat ID
+ * @param userId The user ID for authorization
+ * @param message The message to submit
+ * @param chat The existing chat (if any)
+ * @returns Array of UIMessages to send to the model
+ */
+export async function prepareMessagesForSubmission(
+  chatId: string,
+  userId: string,
+  message: UIMessage,
+  chat: any
+): Promise<UIMessage[]> {
+  if (!message) {
+    throw new Error('No message provided')
+  }
+
+  // Save the message
+  const messageWithId = {
+    ...message,
+    id: message.id || generateId()
+  }
+
+  // If chat doesn't exist, create it with a temporary title
+  if (!chat) {
+    await createChat(chatId, DEFAULT_CHAT_TITLE)
+  }
+
+  await saveMessage(chatId, messageWithId)
+
+  // Get all messages including the one just saved
+  const updatedChat = await getChatAction(chatId, userId)
+  return updatedChat?.messages || [messageWithId]
+}

--- a/lib/streaming/message-preparation.ts
+++ b/lib/streaming/message-preparation.ts
@@ -6,6 +6,7 @@ import {
   getChat as getChatAction,
   saveMessage
 } from '@/lib/actions/chat'
+import type { Chat } from '@/lib/db/schema'
 import { generateId } from '@/lib/db/schema'
 
 // Constants
@@ -75,7 +76,7 @@ export async function prepareMessagesForSubmission(
   chatId: string,
   userId: string,
   message: UIMessage,
-  chat: any
+  chat: Chat | null
 ): Promise<UIMessage[]> {
   if (!message) {
     throw new Error('No message provided')

--- a/lib/streaming/message-preparation.ts
+++ b/lib/streaming/message-preparation.ts
@@ -36,7 +36,7 @@ export async function prepareMessagesForRegeneration(
   }
 
   const targetMessage = currentChat.messages[messageIndex]
-  
+
   if (targetMessage.role === 'assistant') {
     // Delete from this assistant message onwards
     await deleteMessagesFromIndex(chatId, messageId)

--- a/lib/utils/message-utils.ts
+++ b/lib/utils/message-utils.ts
@@ -115,3 +115,18 @@ export function mergeUIMessages(
     parts: [...primaryMessage.parts, ...secondaryMessage.parts]
   }
 }
+
+/**
+ * Checks if a UIMessage contains tool calls
+ * @param message The message to check for tool calls
+ * @returns true if the message contains tool calls, false otherwise
+ */
+export function hasToolCalls(message: UIMessage | null): boolean {
+  if (!message || !message.parts) return false
+  
+  return message.parts.some(
+    (part: any) =>
+      part.type &&
+      (part.type.startsWith('tool-') || part.type === 'tool-call')
+  )
+}

--- a/lib/utils/message-utils.ts
+++ b/lib/utils/message-utils.ts
@@ -123,10 +123,9 @@ export function mergeUIMessages(
  */
 export function hasToolCalls(message: UIMessage | null): boolean {
   if (!message || !message.parts) return false
-  
+
   return message.parts.some(
     (part: any) =>
-      part.type &&
-      (part.type.startsWith('tool-') || part.type === 'tool-call')
+      part.type && (part.type.startsWith('tool-') || part.type === 'tool-call')
   )
 }

--- a/lib/utils/message-utils.ts
+++ b/lib/utils/message-utils.ts
@@ -125,7 +125,7 @@ export function hasToolCalls(message: UIMessage | null): boolean {
   if (!message || !message.parts) return false
 
   return message.parts.some(
-    (part: any) =>
+    part =>
       part.type && (part.type.startsWith('tool-') || part.type === 'tool-call')
   )
 }


### PR DESCRIPTION
## Summary
- Skip related questions generation when the AI provides direct answers without using any tools
- Improve response time for simple queries that don't require tool usage
- Refactor code to move logic outside of onFinish callback for better readability

## Changes
1. **Feature Implementation**
   - Add logic to detect if response contains tool calls (parts with type 'tool-*' or 'tool-call')
   - Skip related questions and finish stream immediately for direct answers
   - Maintain all existing functionality for responses with tool calls

2. **Code Refactoring**
   - Move helper functions to appropriate modules:
     - `hasToolCalls()` → `/lib/utils/message-utils.ts`
     - `saveChatTitle()` → `/lib/actions/chat.ts`
     - Create `/lib/streaming/message-preparation.ts` for message prep logic
   - Refactor to use Promise wrappers instead of nested callbacks
   - Sequential flow with explicit await statements for better readability

## Benefits
- ✨ Faster response times for simple queries
- 📖 More maintainable code structure
- 🔄 Better code organization and reusability
- 🧪 Easier to test individual functions

## Testing
- Type checking passes ✅
- ESLint passes ✅
- Prettier formatting applied ✅
- Build succeeds ✅