### PR TITLE
fix: prevent displaying '0' during search loading state

### DIFF
--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -43,6 +43,12 @@ export function SearchSection({
     : ''
 
   const { open } = useArtifact()
+
+  const totalResults =
+    (searchResults?.results?.length || 0) +
+    (searchResults?.videos?.length || 0) +
+    (searchResults?.images?.length || 0)
+
   const header = (
     <button
       type="button"
@@ -52,11 +58,7 @@ export function SearchSection({
     >
       <ToolArgsSection
         tool="search"
-        number={
-          (searchResults?.results?.length || 0) +
-          (searchResults?.videos?.length || 0) +
-          (searchResults?.images?.length || 0)
-        }
+        number={searchResults ? totalResults : undefined}
       >{`${query}${includeDomainsString}`}</ToolArgsSection>
     </button>
   )


### PR DESCRIPTION
## Summary
- Fixed issue where "0" was displayed in search section during loading
- Pass `undefined` instead of `0` when searchResults is not available
- This ensures the number badge only appears when there are actual results

## Problem
The search section was showing "0" during loading states even though the condition `number && number > 0` was in place. This was because we were always calculating `totalResults` as `0` when `searchResults` was undefined due to the `|| 0` fallback operators.

## Solution
Changed the number prop to pass `undefined` when searchResults is not available:
```tsx
number={searchResults ? totalResults : undefined}
```

## Test plan
1. Start a new search
2. Observe that no "0" appears during the loading state
3. Once results load, the correct count appears

🤖 Generated with [Claude Code](https://claude.ai/code)