### PR TITLE
fix: improve artifact search query and result count display

### DIFF
--- a/components/artifact/search-artifact-content.tsx
+++ b/components/artifact/search-artifact-content.tsx
@@ -28,14 +28,16 @@ export function SearchArtifactContent({ tool }: { tool: ToolPart<'search'> }) {
 
   return (
     <div className="space-y-2">
-      <ToolArgsSection
-        tool="search"
-        number={
-          (searchResults.results?.length || 0) +
-          (searchResults.videos?.length || 0) +
-          (searchResults.images?.length || 0)
-        }
-      >{`${query}`}</ToolArgsSection>
+      <div className="pb-2">
+        <ToolArgsSection
+          tool="search"
+          number={
+            (searchResults.results?.length || 0) +
+            (searchResults.videos?.length || 0) +
+            (searchResults.images?.length || 0)
+          }
+        >{`${query}`}</ToolArgsSection>
+      </div>
 
       {searchResults.images && searchResults.images.length > 0 && (
         <SearchResultsImageSection

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -109,13 +109,17 @@ export function ToolArgsSection({
   return (
     <Section
       size="sm"
-      className="py-0 flex items-center justify-between w-full"
+      className="py-0 flex items-center justify-between w-full gap-2"
     >
-      <ToolBadge tool={tool}>{children}</ToolBadge>
+      <div className="min-w-0 flex-1">
+        <ToolBadge tool={tool}>{children}</ToolBadge>
+      </div>
       {number && number > 0 && (
-        <StatusIndicator icon={Check} iconClassName="text-green-500">
-          {number} results
-        </StatusIndicator>
+        <div className="flex-shrink-0">
+          <StatusIndicator icon={Check} iconClassName="text-green-500">
+            {number} results
+          </StatusIndicator>
+        </div>
       )}
     </Section>
   )

--- a/components/tool-badge.tsx
+++ b/components/tool-badge.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { Link, Search } from 'lucide-react'
 
+import { cn } from '@/lib/utils'
+
 import { Badge } from './ui/badge'
 
 type ToolBadgeProps = {
@@ -22,7 +24,7 @@ export const ToolBadge: React.FC<ToolBadgeProps> = ({
 
   return (
     <Badge
-      className={`inline-flex items-center max-w-full ${className || ''}`}
+      className={cn('inline-flex items-center max-w-full', className)}
       variant={'secondary'}
     >
       <span className="flex-shrink-0">{icon[tool]}</span>

--- a/components/tool-badge.tsx
+++ b/components/tool-badge.tsx
@@ -21,9 +21,9 @@ export const ToolBadge: React.FC<ToolBadgeProps> = ({
   }
 
   return (
-    <Badge className={className} variant={'secondary'}>
-      {icon[tool]}
-      <span className="ml-1">{children}</span>
+    <Badge className={`inline-flex items-center max-w-full ${className || ''}`} variant={'secondary'}>
+      <span className="flex-shrink-0">{icon[tool]}</span>
+      <span className="ml-1 truncate">{children}</span>
     </Badge>
   )
 }

--- a/components/tool-badge.tsx
+++ b/components/tool-badge.tsx
@@ -21,7 +21,10 @@ export const ToolBadge: React.FC<ToolBadgeProps> = ({
   }
 
   return (
-    <Badge className={`inline-flex items-center max-w-full ${className || ''}`} variant={'secondary'}>
+    <Badge
+      className={`inline-flex items-center max-w-full ${className || ''}`}
+      variant={'secondary'}
+    >
       <span className="flex-shrink-0">{icon[tool]}</span>
       <span className="ml-1 truncate">{children}</span>
     </Badge>


### PR DESCRIPTION
## Summary
- Fixed shrinking issues with search query and result count display in artifact search
- Improved spacing between query section and images

## Changes
- Prevent search icon from shrinking by adding `flex-shrink-0`
- Prevent result count from shrinking with `flex-shrink-0` wrapper
- Add `truncate` class to query text for proper ellipsis handling on long queries
- Add padding between query/results section and images below
- Improve layout structure with proper flex containers (`min-w-0 flex-1`)

## Test plan
- [ ] Test with short search queries
- [ ] Test with very long search queries to ensure proper truncation
- [ ] Verify search icon and result count don't shrink
- [ ] Check spacing between sections looks good

🤖 Generated with [Claude Code](https://claude.ai/code)