### PR TITLE
docs: add missing migration step and auth requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,23 @@ Fill in the required environment variables in `.env.local`:
 OPENAI_API_KEY=     # Get from https://platform.openai.com/api-keys
 TAVILY_API_KEY=     # Get from https://app.tavily.com/home
 DATABASE_URL=       # PostgreSQL connection string (Neon recommended)
+
+# Required for Authentication (Beta)
+NEXT_PUBLIC_SUPABASE_URL=     # Your Supabase project URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY= # Your Supabase anonymous key
 ```
 
 For optional features configuration (SearXNG, alternative AI providers, etc.), see [CONFIGURATION.md](./docs/CONFIGURATION.md)
 
-### 4. Run app locally
+### 4. Run database migrations
+
+```bash
+bun run migrate
+```
+
+This command will create the necessary database tables.
+
+### 5. Run app locally
 
 #### Using Bun
 


### PR DESCRIPTION
## Summary
- Added database migration step (`bun run migrate`) after environment setup
- Added required Supabase authentication variables for beta version
- Fixes #530 where users encounter "relation 'chats' does not exist" error

## Context
Based on issue #530, users were experiencing database errors because:
1. The migration step was missing from the setup instructions
2. The beta version requires Supabase authentication to be configured

## Changes
- Added step 4 in README to run database migrations before starting the app
- Added Supabase URL and anonymous key as required environment variables for the beta version

🤖 Generated with [Claude Code](https://claude.ai/code)