### PR TITLE
fix: resolve hydration mismatch in chat artifact container

### DIFF
--- a/components/artifact/chat-artifact-container.tsx
+++ b/components/artifact/chat-artifact-container.tsx
@@ -32,7 +32,11 @@ export function ChatArtifactContainer({
     const savedWidth = localStorage.getItem('artifactPanelWidth')
     if (savedWidth) {
       const parsedWidth = parseInt(savedWidth, 10)
-      if (!isNaN(parsedWidth) && parsedWidth >= MIN_WIDTH && parsedWidth <= MAX_WIDTH) {
+      if (
+        !isNaN(parsedWidth) &&
+        parsedWidth >= MIN_WIDTH &&
+        parsedWidth <= MAX_WIDTH
+      ) {
         setWidth(parsedWidth)
       }
     }

--- a/components/artifact/chat-artifact-container.tsx
+++ b/components/artifact/chat-artifact-container.tsx
@@ -23,15 +23,20 @@ export function ChatArtifactContainer({
 }) {
   const { state } = useArtifact()
   const containerRef = useRef<HTMLDivElement>(null)
-  const [width, setWidth] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const savedWidth = localStorage.getItem('artifactPanelWidth')
-      return savedWidth ? parseInt(savedWidth, 10) : DEFAULT_WIDTH
-    }
-    return DEFAULT_WIDTH
-  })
+  const [width, setWidth] = useState(DEFAULT_WIDTH)
   const [isResizing, setIsResizing] = useState(false)
   const { open, isMobile: isMobileSidebar } = useSidebar()
+
+  // Load saved width after hydration
+  useEffect(() => {
+    const savedWidth = localStorage.getItem('artifactPanelWidth')
+    if (savedWidth) {
+      const parsedWidth = parseInt(savedWidth, 10)
+      if (!isNaN(parsedWidth) && parsedWidth >= MIN_WIDTH && parsedWidth <= MAX_WIDTH) {
+        setWidth(parsedWidth)
+      }
+    }
+  }, [])
 
   const startResize = useCallback((e: React.MouseEvent) => {
     e.preventDefault()


### PR DESCRIPTION
## Summary

This PR fixes a React hydration mismatch error occurring in the chat artifact container component.

## Problem

The application was experiencing a hydration mismatch error due to reading from `localStorage` during the initial render. This caused different width values between server-side rendering (500px default) and client-side hydration (487px from stored value), leading to React hydration failures.

The error manifested as:
- Warning: Text content did not match between server and client
- Inconsistent UI rendering on initial page load
- Potential layout shifts during hydration

## Solution

- **Moved localStorage access to useEffect**: The `localStorage.getItem('artifactPanelWidth')` call is now executed in a `useEffect` hook that runs after the component has hydrated
- **Preserved functionality**: The width persistence feature continues to work as expected, loading saved widths after the initial render
- **Maintained performance**: No performance impact as the localStorage read happens asynchronously after hydration

## Changes Made

- Modified `/components/artifact/chat-artifact-container.tsx`:
  - Removed localStorage access from initial state
  - Added useEffect hook to load saved width after hydration
  - Ensured proper bounds checking and validation remain intact

## Testing

- Verified that the hydration mismatch error no longer occurs
- Confirmed that width persistence functionality still works correctly
- Tested that the artifact panel opens and resizes as expected
- Validated that the default width (500px) is properly applied on first load

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>