### PR TITLE
Fix Anthropic model message structure for tool-call/tool-result separation

### DIFF
--- a/lib/agents/generate-related-questions.ts
+++ b/lib/agents/generate-related-questions.ts
@@ -1,6 +1,7 @@
 import { convertToModelMessages, generateObject, type UIMessage } from 'ai'
 import { z } from 'zod'
 
+import { convertMessagesForAnthropic } from '../utils/anthropic-message-conversion'
 import { getModel } from '../utils/registry'
 
 const relatedQuestionsSchema = z.object({
@@ -19,7 +20,13 @@ export async function generateRelatedQuestions(
   abortSignal?: AbortSignal
 ) {
   // Convert UIMessages to ModelMessages
-  const modelMessages = convertToModelMessages(messages)
+  let modelMessages = convertToModelMessages(messages)
+
+  // Apply Anthropic-specific conversion if needed
+  if (model.startsWith('anthropic:')) {
+    modelMessages = convertMessagesForAnthropic(modelMessages)
+  }
+
   const systemPrompt = `You are a professional web researcher tasked with generating follow-up questions. Based on the conversation history and search results, create 3 DIFFERENT related questions that:
 
 1. Explore NEW aspects not covered in the original query

--- a/lib/agents/generate-related-questions.ts
+++ b/lib/agents/generate-related-questions.ts
@@ -2,6 +2,7 @@ import { convertToModelMessages, generateObject, type UIMessage } from 'ai'
 import { z } from 'zod'
 
 import { convertMessagesForAnthropic } from '../utils/anthropic-message-conversion'
+import { isAnthropicModel } from '../utils/model-detection'
 import { getModel } from '../utils/registry'
 
 const relatedQuestionsSchema = z.object({
@@ -23,7 +24,7 @@ export async function generateRelatedQuestions(
   let modelMessages = convertToModelMessages(messages)
 
   // Apply Anthropic-specific conversion if needed
-  if (model.startsWith('anthropic:')) {
+  if (isAnthropicModel(model)) {
     modelMessages = convertMessagesForAnthropic(modelMessages)
   }
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -178,6 +178,7 @@ export async function loadChatWithMessages(
   const uiMessages = messagesResult.map(msg =>
     buildUIMessageFromDB(msg, msg.parts)
   )
+
   const result = { ...chat, messages: uiMessages }
   chatCache.set(cacheKey, result)
   return result

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -11,6 +11,7 @@ import { researcher } from '@/lib/agents/researcher'
 
 import { getChat as getChatAction } from '../actions/chat'
 import { generateChatTitle } from '../agents/title-generator'
+import { convertMessagesForAnthropic } from '../utils/anthropic-message-conversion'
 import {
   getMaxAllowedTokens,
   shouldTruncateMessages,
@@ -87,6 +88,11 @@ export async function createChatStreamResponse(
 
         // Convert to model messages and apply context window management
         let modelMessages = convertToModelMessages(messagesToModel)
+
+        // Apply Anthropic-specific conversion if needed
+        if (model.providerId === 'anthropic') {
+          modelMessages = convertMessagesForAnthropic(modelMessages)
+        }
 
         if (shouldTruncateMessages(modelMessages, model)) {
           const maxTokens = getMaxAllowedTokens(model)

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -18,6 +18,7 @@ import {
   truncateMessages
 } from '../utils/context-window'
 import { getTextFromParts } from '../utils/message-utils'
+import { isAnthropicModel } from '../utils/model-detection'
 
 import { handleStreamFinish } from './helpers/handle-stream-finish'
 import { prepareMessages } from './helpers/prepare-messages'
@@ -90,7 +91,7 @@ export async function createChatStreamResponse(
         let modelMessages = convertToModelMessages(messagesToModel)
 
         // Apply Anthropic-specific conversion if needed
-        if (model.providerId === 'anthropic') {
+        if (isAnthropicModel(model)) {
           modelMessages = convertMessagesForAnthropic(modelMessages)
         }
 

--- a/lib/utils/__tests__/anthropic-message-conversion.test.ts
+++ b/lib/utils/__tests__/anthropic-message-conversion.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import type { ModelMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
 
 import { convertMessagesForAnthropic } from '../anthropic-message-conversion'
 
@@ -34,7 +34,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-call',
             toolCallId: 'call_123',
             toolName: 'search',
-            args: { query: 'test' }
+            input: { query: 'search query' }
           },
           { type: 'text', text: 'Based on the results...' }
         ]
@@ -46,7 +46,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-result',
             toolCallId: 'call_123',
             toolName: 'search',
-            result: { data: 'results' }
+            output: { type: 'json', value: { data: 'results' } }
           }
         ]
       }
@@ -64,7 +64,7 @@ describe('convertMessagesForAnthropic', () => {
           type: 'tool-call',
           toolCallId: 'call_123',
           toolName: 'search',
-          args: { query: 'test' }
+          input: { query: 'search query' }
         }
       ]
     })
@@ -85,7 +85,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-call',
             toolCallId: 'call_123',
             toolName: 'search',
-            args: { query: 'test' }
+            input: { query: 'search query' }
           }
         ]
       },
@@ -96,7 +96,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-result',
             toolCallId: 'call_123',
             toolName: 'search',
-            result: { data: 'results' }
+            output: { type: 'json', value: { data: 'results' } }
           }
         ]
       }
@@ -116,13 +116,13 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-call',
             toolCallId: 'call_123',
             toolName: 'search',
-            args: { query: 'test' }
+            input: { query: 'search query' }
           },
           {
             type: 'tool-call',
             toolCallId: 'call_456',
             toolName: 'fetch',
-            args: { url: 'http://example.com' }
+            input: { url: 'https://example.com' }
           },
           { type: 'text', text: 'Here are the results...' }
         ]
@@ -134,7 +134,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-result',
             toolCallId: 'call_123',
             toolName: 'search',
-            result: { data: 'search results' }
+            output: { type: 'json', value: { data: 'search results' } }
           }
         ]
       }
@@ -160,7 +160,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-call',
             toolCallId: 'call_123',
             toolName: 'search',
-            args: { query: 'test' }
+            input: { query: 'search query' }
           }
         ]
       },
@@ -171,7 +171,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-result',
             toolCallId: 'call_123',
             toolName: 'search',
-            result: { data: 'results' }
+            output: { type: 'json', value: { data: 'results' } }
           }
         ]
       }
@@ -188,17 +188,13 @@ describe('convertMessagesForAnthropic', () => {
         content: [{ type: 'text', text: 'Hello' }]
       },
       {
-        role: 'system',
-        content: [{ type: 'text', text: 'You are a helpful assistant' }]
-      },
-      {
         role: 'tool',
         content: [
           {
             type: 'tool-result',
             toolCallId: 'call_123',
             toolName: 'search',
-            result: { data: 'results' }
+            output: { type: 'json', value: { data: 'results' } }
           }
         ]
       }
@@ -230,7 +226,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-call',
             toolCallId: 'call_123',
             toolName: 'search',
-            args: { query: 'test' }
+            input: { query: 'search query' }
           },
           { type: 'text', text: 'Based on the results...' }
         ]
@@ -263,7 +259,7 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-call',
             toolCallId: 'call_123',
             toolName: 'search',
-            args: { query: 'test' }
+            input: { query: 'search query' }
           },
           { type: 'text', text: '   \n\t   ' } // Only whitespace
         ]
@@ -275,14 +271,14 @@ describe('convertMessagesForAnthropic', () => {
             type: 'tool-result',
             toolCallId: 'call_123',
             toolName: 'search',
-            result: { data: 'results' }
+            output: { type: 'json', value: { data: 'results' } }
           }
         ]
       }
     ]
 
     const result = convertMessagesForAnthropic(messages)
-    
+
     // Should not split because text after tool-call is whitespace only
     expect(result).toEqual(messages)
   })

--- a/lib/utils/__tests__/anthropic-message-conversion.test.ts
+++ b/lib/utils/__tests__/anthropic-message-conversion.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelMessage } from 'ai'
+
+import { convertMessagesForAnthropic } from '../anthropic-message-conversion'
+
+describe('convertMessagesForAnthropic', () => {
+  it('should handle messages without tool-calls', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }]
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi there!' }]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+    expect(result).toEqual(messages)
+  })
+
+  it('should split assistant message with text after tool-call', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Search for something' }]
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me search for that.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            args: { query: 'test' }
+          },
+          { type: 'text', text: 'Based on the results...' }
+        ]
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            result: { data: 'results' }
+          }
+        ]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+
+    expect(result).toHaveLength(4)
+    expect(result[0]).toEqual(messages[0]) // User message unchanged
+    expect(result[1]).toEqual({
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Let me search for that.' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_123',
+          toolName: 'search',
+          args: { query: 'test' }
+        }
+      ]
+    })
+    expect(result[2]).toEqual(messages[2]) // Tool result
+    expect(result[3]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Based on the results...' }]
+    })
+  })
+
+  it('should handle tool-call at the end of message (no text after)', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me search.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            args: { query: 'test' }
+          }
+        ]
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            result: { data: 'results' }
+          }
+        ]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+    expect(result).toEqual(messages) // No changes needed
+  })
+
+  it('should handle multiple tool-calls in a single message', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me search and fetch.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            args: { query: 'test' }
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_456',
+            toolName: 'fetch',
+            args: { url: 'http://example.com' }
+          },
+          { type: 'text', text: 'Here are the results...' }
+        ]
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            result: { data: 'search results' }
+          }
+        ]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+
+    // Should split at the first tool-call
+    expect(result).toHaveLength(3)
+    expect(result[0].content).toHaveLength(3) // text + 2 tool-calls
+    expect(result[2]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Here are the results...' }]
+    })
+  })
+
+  it('should handle messages with only tool-calls (no text)', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            args: { query: 'test' }
+          }
+        ]
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            result: { data: 'results' }
+          }
+        ]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+    expect(result).toEqual(messages) // No changes needed
+  })
+
+  it('should handle non-assistant messages', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }]
+      },
+      {
+        role: 'system',
+        content: [{ type: 'text', text: 'You are a helpful assistant' }]
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            result: { data: 'results' }
+          }
+        ]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+    expect(result).toEqual(messages) // No changes to non-assistant messages
+  })
+
+  it('should handle empty content arrays', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: []
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+    expect(result).toEqual(messages)
+  })
+
+  it('should handle missing tool-result message gracefully', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me search.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            args: { query: 'test' }
+          },
+          { type: 'text', text: 'Based on the results...' }
+        ]
+      },
+      {
+        role: 'user', // Not a tool message
+        content: [{ type: 'text', text: 'What did you find?' }]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+
+    // Should still split but won't include the tool message after splitting
+    expect(result).toHaveLength(3)
+    expect(result[0].content).toHaveLength(2) // text + tool-call
+    expect(result[1]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Based on the results...' }]
+    })
+    expect(result[2]).toEqual(messages[1]) // User message comes after
+  })
+
+  it('should handle whitespace-only text after tool-call', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Searching...' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            args: { query: 'test' }
+          },
+          { type: 'text', text: '   \n\t   ' } // Only whitespace
+        ]
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_123',
+            toolName: 'search',
+            result: { data: 'results' }
+          }
+        ]
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+    
+    // Should not split because text after tool-call is whitespace only
+    expect(result).toEqual(messages)
+  })
+
+  it('should handle string content (not array)', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: 'This is a simple string message'
+      }
+    ]
+
+    const result = convertMessagesForAnthropic(messages)
+    expect(result).toEqual(messages)
+  })
+})

--- a/lib/utils/anthropic-message-conversion.ts
+++ b/lib/utils/anthropic-message-conversion.ts
@@ -1,0 +1,72 @@
+import type { ModelMessage } from 'ai'
+
+/**
+ * Fix message structure after convertToModelMessages for proper tool-call/tool-result separation.
+ *
+ * convertToModelMessages creates a single assistant message containing all parts (text, tool-call, text),
+ * but the expected structure requires tool-call to be immediately followed by tool-result in separate messages.
+ * This function splits assistant messages that contain text after tool-call parts.
+ */
+export function convertMessagesForAnthropic(
+  messages: ModelMessage[]
+): ModelMessage[] {
+  const result: ModelMessage[] = []
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      // Check if this assistant message contains both tool-call and text after it
+      let toolCallIndex = -1
+      let hasContentAfterToolCall = false
+
+      for (let j = 0; j < message.content.length; j++) {
+        const part = message.content[j]
+        if (part.type === 'tool-call') {
+          toolCallIndex = j
+        } else if (
+          toolCallIndex !== -1 &&
+          part.type === 'text' &&
+          part.text?.trim()
+        ) {
+          hasContentAfterToolCall = true
+          break
+        }
+      }
+
+      if (hasContentAfterToolCall && toolCallIndex !== -1) {
+        // Split the message: content before and including tool-call stays
+        const beforeToolCall = message.content.slice(0, toolCallIndex + 1)
+        const afterToolCall = message.content.slice(toolCallIndex + 1)
+
+        // Add the first part (up to and including tool-call)
+        result.push({
+          ...message,
+          content: beforeToolCall
+        })
+
+        // Add the tool-result message (should be the next message)
+        if (i + 1 < messages.length && messages[i + 1].role === 'tool') {
+          result.push(messages[i + 1])
+          i++ // Skip the tool message since we've already added it
+        }
+
+        // Add the remaining content as a new assistant message
+        if (afterToolCall.length > 0) {
+          result.push({
+            role: 'assistant',
+            content: afterToolCall
+          })
+        }
+      } else {
+        // No splitting needed
+        result.push(message)
+      }
+    } else {
+      // Not an assistant message, add as-is
+      result.push(message)
+    }
+  }
+
+  return result
+}

--- a/lib/utils/message-mapping.ts
+++ b/lib/utils/message-mapping.ts
@@ -369,7 +369,7 @@ export function mapDBPartToUIMessagePart(
         // Special handling for tool parts that maintain their type
         if (['search', 'fetch', 'question'].includes(toolName)) {
           if (!part.tool_state) {
-            throw new Error(`${toolName}_state is undefined`)
+            throw new Error(`tool_state is undefined for ${toolName}`)
           }
 
           switch (part.tool_state) {

--- a/lib/utils/message-mapping.ts
+++ b/lib/utils/message-mapping.ts
@@ -368,13 +368,43 @@ export function mapDBPartToUIMessagePart(
 
         // Special handling for tool parts that maintain their type
         if (['search', 'fetch', 'question'].includes(toolName)) {
-          return {
-            type: part.type as any,
-            toolCallId: part.tool_toolCallId || '',
-            state: part.tool_state || 'input-available',
-            input: part[inputColumn],
-            output: part[outputColumn],
-            errorText: part.tool_errorText
+          if (!part.tool_state) {
+            throw new Error(`${toolName}_state is undefined`)
+          }
+
+          switch (part.tool_state) {
+            case 'input-streaming':
+              return {
+                type: part.type as any,
+                state: 'input-streaming',
+                toolCallId: part.tool_toolCallId || '',
+                input: part[inputColumn]
+              }
+            case 'input-available':
+              return {
+                type: part.type as any,
+                state: 'input-available',
+                toolCallId: part.tool_toolCallId || '',
+                input: part[inputColumn]
+              }
+            case 'output-available':
+              return {
+                type: part.type as any,
+                state: 'output-available',
+                toolCallId: part.tool_toolCallId || '',
+                input: part[inputColumn],
+                output: part[outputColumn]
+              }
+            case 'output-error':
+              return {
+                type: part.type as any,
+                state: 'output-error',
+                toolCallId: part.tool_toolCallId || '',
+                input: part[inputColumn],
+                errorText: part.tool_errorText
+              }
+            default:
+              throw new Error(`Unknown tool state: ${part.tool_state}`)
           }
         }
 

--- a/lib/utils/model-detection.ts
+++ b/lib/utils/model-detection.ts
@@ -1,0 +1,15 @@
+import type { Model } from '@/lib/types/models'
+
+/**
+ * Check if a model is an Anthropic model
+ * @param model - Either a Model object or a model ID string
+ * @returns true if the model is from Anthropic provider
+ */
+export function isAnthropicModel(model: Model | string): boolean {
+  if (typeof model === 'string') {
+    // Handle model ID string format (e.g., 'anthropic:claude-3-opus')
+    return model.startsWith('anthropic:')
+  }
+  // Handle Model object
+  return model.providerId === 'anthropic'
+}


### PR DESCRIPTION
This PR fixes an issue where Anthropic models would fail on the second chat message with the error: "tool_use ids were found without tool_result blocks immediately after".

## Problem
When messages were loaded from the database, the `convertToModelMessages` function was creating a single assistant message containing all parts (text, tool-call, text). However, the AI SDK expects tool-call to be immediately followed by tool-result in separate messages.

## Solution
1. Updated `mapDBPartToUIMessagePart` in `message-mapping.ts` to properly handle tool parts according to their state, following the official AI SDK sample pattern
2. Created `convertMessagesForAnthropic` helper function that fixes message structure after `convertToModelMessages` by splitting assistant messages that contain text after tool-call parts
3. Applied the conversion in `create-chat-stream-response.ts` and `generate-related-questions.ts` when using Anthropic models
4. Added comprehensive unit tests for the conversion function

## Changes
- `lib/utils/message-mapping.ts`: Fixed tool part handling to include proper state-based properties
- `lib/utils/anthropic-message-conversion.ts`: New helper function for message structure conversion
- `lib/streaming/create-chat-stream-response.ts`: Apply conversion for Anthropic models
- `lib/agents/generate-related-questions.ts`: Apply conversion for Anthropic models
- `lib/utils/__tests__/anthropic-message-conversion.test.ts`: Comprehensive unit tests

## Testing
- All existing tests pass
- New unit tests cover various edge cases including:
  - Messages with/without tool-calls
  - Multiple tool-calls
  - Missing tool-result messages
  - Empty content arrays
  - Whitespace-only text after tool-calls

The changes ensure proper compatibility with Anthropic's API requirements while maintaining backward compatibility with other providers.