### PR TITLE
Fix right panel gap when panel is hidden

### DIFF
--- a/components/artifact/chat-artifact-container.tsx
+++ b/components/artifact/chat-artifact-container.tsx
@@ -87,18 +87,17 @@ export function ChatArtifactContainer({
         <div className="flex-1 flex flex-col">{children}</div>
 
         {/* Resize Handle */}
-        <div
-          className={cn(
-            'w-1 mx-0.5 my-6 hover:bg-border transition-colors duration-200 cursor-col-resize select-none relative',
-            state.isOpen && state.part
-              ? 'opacity-100'
-              : 'opacity-0 pointer-events-none',
-            isResizing && 'bg-border/50'
-          )}
-          onMouseDown={startResize}
-        >
-          <div className="absolute inset-0 -left-2 -right-2" />
-        </div>
+        {state.isOpen && state.part && (
+          <div
+            className={cn(
+              'w-1 mx-0.5 my-6 hover:bg-border transition-colors duration-200 cursor-col-resize select-none relative',
+              isResizing && 'bg-border/50'
+            )}
+            onMouseDown={startResize}
+          >
+            <div className="absolute inset-0 -left-2 -right-2" />
+          </div>
+        )}
 
         {/* Right Panel - Independent with own animation */}
         <div


### PR DESCRIPTION
## Problem

The right panel had a visible gap even when the panel was hidden. This was caused by the resize handle element taking up space with its `w-1` width and `mx-0.5` margin, even when it was set to `opacity-0` and `pointer-events-none`.

## Solution

Conditionally render the resize handle only when the right panel is actually open (`state.isOpen && state.part`). This completely removes the element from the DOM when the panel is hidden, eliminating the gap.

## Changes

- **File**: `components/artifact/chat-artifact-container.tsx`
- **Change**: Wrapped the resize handle div in a conditional render
- **Before**: Handle was always rendered but made invisible with CSS
- **After**: Handle is only rendered when panel is open

## Testing

- ✅ Right panel opens and closes properly
- ✅ Resize functionality works when panel is open
- ✅ No gap when panel is hidden
- ✅ Smooth transitions maintained

This is a small but important UI fix that improves the visual consistency of the interface.