### PR TITLE
Fix Vercel deployment error by adding transpilePackages configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  transpilePackages: [
+    'react-markdown',
+    'remark-gfm',
+    'remark-math',
+    'rehype-katex',
+    'rehype-external-links',
+    'decode-named-character-reference'
+  ],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fixes Vercel deployment error caused by ESM module import issues
- Adds `transpilePackages` configuration to `next.config.mjs` to properly handle react-markdown and its dependencies

## Problem
The deployment was failing with Webpack errors related to importing `decode-named-character-reference` and other ESM modules used by react-markdown. This is a common issue when Next.js encounters ESM packages that need to be transpiled for proper bundling.

## Solution
Added minimal set of packages to `transpilePackages` in Next.js configuration to ensure proper transpilation of ESM modules during build:

- `react-markdown` - Main markdown rendering library
- `remark-gfm` - GitHub Flavored Markdown support
- `remark-math` - Math expression support
- `rehype-katex` - KaTeX math rendering
- `rehype-external-links` - External link handling
- `decode-named-character-reference` - Character reference decoding (the specific module causing the error)

## Test plan
- [x] Run `bun run build` locally to verify build succeeds
- [ ] Deploy to Vercel and confirm deployment completes successfully
- [ ] Verify markdown rendering still works correctly in the application

## Files changed
- `next.config.mjs` - Added transpilePackages configuration

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)