### PR TITLE
Update OpenAI models to GPT-5 series

### DIFF
--- a/lib/config/default-models.json
+++ b/lib/config/default-models.json
@@ -19,8 +19,20 @@
       "providerId": "gateway"
     },
     {
-      "id": "gpt-4.1",
-      "name": "GPT-4.1",
+      "id": "gpt-5-2025-08-07",
+      "name": "GPT-5",
+      "provider": "OpenAI",
+      "providerId": "openai"
+    },
+    {
+      "id": "gpt-5-mini-2025-08-07",
+      "name": "GPT-5 Mini",
+      "provider": "OpenAI",
+      "providerId": "openai"
+    },
+    {
+      "id": "gpt-5-nano-2025-08-07",
+      "name": "GPT-5 Nano",
       "provider": "OpenAI",
       "providerId": "openai"
     },

--- a/public/config/models.json
+++ b/public/config/models.json
@@ -19,8 +19,20 @@
       "providerId": "gateway"
     },
     {
-      "id": "gpt-4.1",
-      "name": "GPT-4.1",
+      "id": "gpt-5-2025-08-07",
+      "name": "GPT-5",
+      "provider": "OpenAI",
+      "providerId": "openai"
+    },
+    {
+      "id": "gpt-5-mini-2025-08-07",
+      "name": "GPT-5 mini",
+      "provider": "OpenAI",
+      "providerId": "openai"
+    },
+    {
+      "id": "gpt-5-nano-2025-08-07",
+      "name": "GPT-5 nano",
       "provider": "OpenAI",
       "providerId": "openai"
     },


### PR DESCRIPTION
This PR updates the model configurations to include the newly released GPT-5 series models from OpenAI.

## Changes Made

- Replaced GPT-4.1 with three new GPT-5 models in both `/public/config/models.json` and `/lib/config/default-models.json`:
  - `gpt-5-2025-08-07` (GPT-5)
  - `gpt-5-mini-2025-08-07` (GPT-5 Mini)  
  - `gpt-5-nano-2025-08-07` (GPT-5 Nano)

## Known Issues

There is a known issue with reasoning display for these new GPT-5 models. This issue is already being tracked in the Vercel AI SDK repository: https://github.com/vercel/ai/issues/7861

## Testing

The model configurations have been updated consistently across both configuration files to ensure proper functionality.