### PR TITLE
Fix text overflow in search section headers

### DIFF
--- a/components/collapsible-message.tsx
+++ b/components/collapsible-message.tsx
@@ -49,14 +49,16 @@ export function CollapsibleMessage({
       )}
 
       {isCollapsible ? (
-        <div className={cn('flex-1 rounded-lg border bg-card')}>
+        <div className={cn('flex-1 rounded-lg border bg-card overflow-hidden')}>
           <Collapsible
             open={isOpen}
             onOpenChange={onOpenChange}
             className="w-full"
           >
-            <div className="flex items-center justify-between w-full gap-2 px-3 py-2">
-              {header && <div className="text-sm w-full">{header}</div>}
+            <div className="flex items-center justify-between w-full gap-2 px-3 py-2 overflow-hidden">
+              {header && (
+                <div className="text-sm w-full overflow-hidden">{header}</div>
+              )}
               <CollapsibleTrigger asChild>
                 <button
                   type="button"

--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -53,7 +53,7 @@ export function SearchSection({
     <button
       type="button"
       onClick={() => open(tool)}
-      className="flex items-center justify-between w-full text-left rounded-md p-0.5 -ml-0.5 cursor-pointer"
+      className="flex items-center justify-between w-full text-left rounded-md p-0.5 -ml-0.5 cursor-pointer overflow-hidden"
       title="Open details"
     >
       <ToolArgsSection

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -111,9 +111,9 @@ export function ToolArgsSection({
   return (
     <Section
       size="sm"
-      className="py-0 flex items-center justify-between w-full gap-2"
+      className="py-0 flex items-center justify-between w-full gap-2 overflow-hidden"
     >
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 overflow-hidden">
         <ToolBadge tool={tool} isLoading={isLoading}>
           {children}
         </ToolBadge>


### PR DESCRIPTION
## Summary

This PR fixes text overflow issues in search section headers where long query text would break the layout by overflowing beyond container boundaries.

## Changes Made

### Modified Files:
1. **`components/collapsible-message.tsx`** - Added `overflow-hidden` to container and header div to properly constrain content
2. **`components/search-section.tsx`** - Added `overflow-hidden` to the button wrapper
3. **`components/section.tsx`** - Added `overflow-hidden` to ToolArgsSection and its inner div

## Problem Addressed

When users performed searches with very long queries (like "NVIDIA growth drivers AI data center demand 2024 2025 revenue data center GPU market share CUDA ecosystem software..."), the text would overflow beyond its container boundaries, breaking the layout.

## Solution

Added `overflow-hidden` CSS classes to the appropriate container elements. This ensures that long search queries are properly truncated with ellipsis instead of overflowing, maintaining a clean and consistent UI layout.

## Testing

- All lint checks passed (`bun lint`)
- TypeScript type checking passed (`bun typecheck`)  
- Code formatting verified (`bun format:check`)
- Tested with long query text to confirm overflow is properly handled

## Visual Impact

- Long search queries now properly truncate with ellipsis
- Layout remains consistent regardless of query length
- No breaking changes to existing functionality