### PR TITLE
Redesign reasoning section UI for improved visual hierarchy

### DIFF
--- a/components/collapsible-message.tsx
+++ b/components/collapsible-message.tsx
@@ -20,6 +20,8 @@ interface CollapsibleMessageProps {
   onOpenChange?: (open: boolean) => void
   showBorder?: boolean
   showIcon?: boolean
+  variant?: 'default' | 'minimal'
+  showSeparator?: boolean
 }
 
 export function CollapsibleMessage({
@@ -30,7 +32,9 @@ export function CollapsibleMessage({
   header,
   onOpenChange,
   showBorder = true,
-  showIcon = true
+  showIcon = true,
+  variant = 'default',
+  showSeparator = true
 }: CollapsibleMessageProps) {
   const content = children
 
@@ -49,29 +53,70 @@ export function CollapsibleMessage({
       )}
 
       {isCollapsible ? (
-        <div className={cn('flex-1 rounded-lg border bg-card overflow-hidden')}>
+        <div
+          className={cn(
+            'flex-1 overflow-hidden',
+            variant === 'default' && 'rounded-lg border bg-card'
+          )}
+        >
           <Collapsible
             open={isOpen}
             onOpenChange={onOpenChange}
             className="w-full"
           >
-            <div className="flex items-center justify-between w-full gap-2 px-3 py-2 overflow-hidden">
-              {header && (
-                <div className="text-sm w-full overflow-hidden">{header}</div>
+            <div
+              className={cn(
+                'flex items-center w-full gap-2 overflow-hidden',
+                variant === 'default' && 'justify-between px-3 py-2',
+                variant === 'minimal' && 'py-1'
               )}
-              <CollapsibleTrigger asChild>
-                <button
-                  type="button"
-                  className="rounded-md p-1 hover:bg-accent group"
-                  aria-label={isOpen ? 'Collapse' : 'Expand'}
+            >
+              {header && (
+                <div
+                  className={cn(
+                    'overflow-hidden',
+                    variant === 'default' && 'text-sm flex-1',
+                    variant === 'minimal' && 'text-sm flex items-center gap-1'
+                  )}
                 >
-                  <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
-                </button>
-              </CollapsibleTrigger>
+                  {header}
+                </div>
+              )}
+              {variant === 'minimal' && (
+                <CollapsibleTrigger asChild>
+                  <button
+                    type="button"
+                    className="p-0.5 rounded-md group cursor-pointer hover:bg-accent/50"
+                    aria-label={isOpen ? 'Collapse' : 'Expand'}
+                  >
+                    <ChevronDown className="h-3 w-3 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
+                  </button>
+                </CollapsibleTrigger>
+              )}
+              {variant === 'default' && (
+                <CollapsibleTrigger asChild>
+                  <button
+                    type="button"
+                    className="p-1 hover:bg-accent rounded-md transition-transform duration-200 group"
+                    aria-label={isOpen ? 'Collapse' : 'Expand'}
+                  >
+                    <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
+                  </button>
+                </CollapsibleTrigger>
+              )}
             </div>
             <CollapsibleContent className="data-[state=closed]:animate-collapse-up data-[state=open]:animate-collapse-down">
-              <Separator className="mb-2 border-border/50" />
-              <div className="px-3 pb-2">{content}</div>
+              {showSeparator && variant === 'default' && (
+                <Separator className="mb-2 border-border/50" />
+              )}
+              <div
+                className={cn(
+                  variant === 'default' && 'px-3 pb-2',
+                  variant === 'minimal' && 'pt-2'
+                )}
+              >
+                {content}
+              </div>
             </CollapsibleContent>
           </Collapsible>
         </div>

--- a/components/reasoning-section.tsx
+++ b/components/reasoning-section.tsx
@@ -3,8 +3,6 @@
 import type { ReasoningPart } from '@ai-sdk/provider-utils'
 import { Lightbulb, Loader2 } from 'lucide-react'
 
-import { Badge } from '@/components/ui/badge'
-
 import { useArtifact } from '@/components/artifact/artifact-context'
 
 import { CollapsibleMessage } from './collapsible-message'
@@ -34,43 +32,37 @@ export function ReasoningSection({
       onClick={() =>
         open({ type: 'reasoning', text: content.reasoning } as ReasoningPart)
       }
-      className="flex items-center gap-2 w-full text-left rounded-md p-0.5 -ml-0.5 cursor-pointer"
+      className="flex items-center gap-1 w-full text-left text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
       title="Open details"
     >
-      <div className="w-full flex flex-col">
-        <div className="flex items-center justify-between">
-          <Badge className="flex items-center gap-0.5" variant="secondary">
-            <Lightbulb size={16} />
-            {!content.isDone ? 'Thinking...' : 'Thoughts'}
-          </Badge>
-          {!content.isDone && (
-            <Loader2
-              size={16}
-              className="animate-spin text-muted-foreground/50"
-            />
-          )}
-        </div>
-      </div>
+      <Lightbulb size={14} />
+      <span>{!content.isDone ? 'Thinking...' : 'Thoughts'}</span>
+      {!content.isDone && (
+        <Loader2
+          size={14}
+          className="animate-spin text-muted-foreground/50 ml-auto"
+        />
+      )}
     </button>
   )
 
   if (!content) return <DefaultSkeleton />
 
   return (
-    <div className="flex flex-col gap-4">
-      <CollapsibleMessage
-        role="assistant"
-        isCollapsible={true}
-        header={reasoningHeader}
-        isOpen={isOpen}
-        onOpenChange={onOpenChange}
-        showBorder={true}
-        showIcon={false}
-      >
-        <div className="[&_p]:text-sm [&_p]:text-muted-foreground">
-          <MarkdownMessage message={content.reasoning} />
-        </div>
-      </CollapsibleMessage>
-    </div>
+    <CollapsibleMessage
+      role="assistant"
+      isCollapsible={true}
+      header={reasoningHeader}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      showBorder={false}
+      showIcon={false}
+      variant="minimal"
+      showSeparator={false}
+    >
+      <div className="[&_p]:text-xs [&_p]:text-muted-foreground/80">
+        <MarkdownMessage message={content.reasoning} />
+      </div>
+    </CollapsibleMessage>
   )
 }


### PR DESCRIPTION
## Summary

This PR redesigns the reasoning section UI to have a more subtle, secondary appearance while maintaining full functionality. The changes improve the visual hierarchy by making the reasoning section less prominent compared to main chat messages.

## Changes Made

### 1. Reasoning Section Component (`components/reasoning-section.tsx`)
- Removed Badge component dependency and simplified to a clean icon + text layout
- Reduced text size from default to `text-sm` with `text-muted-foreground` styling
- Added hover effects (`hover:text-foreground`) for better UX
- Positioned loading spinner on the right side using `ml-auto`
- Removed card borders and padding for cleaner appearance
- Applied `showBorder={false}` and `variant="minimal"` to CollapsibleMessage

### 2. Collapsible Message Component (`components/collapsible-message.tsx`)
- Added new `minimal` variant option alongside existing `default` variant
- Added `showSeparator` prop to control separator visibility
- Implemented conditional styling based on variant:
  - **Default variant**: Maintains existing card styling with borders and padding
  - **Minimal variant**: Clean layout without borders, reduced padding, smaller chevron icon
- Positioned chevron arrow appropriately for each variant
- Enhanced hover states for better interaction feedback

## Visual Improvements

- **Reduced prominence**: Reasoning section now appears as a secondary element
- **Cleaner layout**: No card borders or excessive padding in minimal mode
- **Better spacing**: Optimized gap and padding for improved readability
- **Enhanced interactivity**: Added hover effects and proper cursor states
- **Consistent typography**: Smaller text sizes for secondary content hierarchy

## Testing

The changes maintain backward compatibility:
- Existing CollapsibleMessage components continue to work with default styling
- Only reasoning section uses the new minimal variant
- All interactive functionality remains intact (collapse/expand, loading states)

## Screenshots

The reasoning section now appears as a subtle, secondary element with:
- Simple icon + text layout instead of prominent badges
- Smaller text and reduced visual weight
- Clean hover interactions
- Properly positioned expand/collapse controls