### PR TITLE
Fix: Standardize AI SDK trigger and regenerate usage

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -33,15 +33,15 @@ export async function POST(req: Request) {
       `API Route - Start: chatId=${chatId}, trigger=${trigger}, isNewChat=${isNewChat}`
     )
 
-    // Handle different triggers
-    if (trigger === 'regenerate-assistant-message') {
+    // Handle different triggers using AI SDK standard values
+    if (trigger === 'regenerate-message') {
       if (!messageId) {
         return new Response('messageId is required for regeneration', {
           status: 400,
           statusText: 'Bad Request'
         })
       }
-    } else if (trigger === 'submit-user-message') {
+    } else if (trigger === 'submit-message') {
       if (!message) {
         return new Response('message is required for submission', {
           status: 400,

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -75,35 +75,27 @@ export function Chat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
       prepareSendMessagesRequest: ({ messages, trigger, messageId }) => {
-        switch (trigger) {
-          case 'regenerate-message':
-            // Find the message being regenerated
-            const messageToRegenerate = messages.find(m => m.id === messageId)
-            return {
-              body: {
-                trigger: 'regenerate-assistant-message',
-                chatId: id,
-                messageId,
-                // Include the message if it's a user message (for edit cases)
-                message:
-                  messageToRegenerate?.role === 'user'
-                    ? messageToRegenerate
-                    : undefined
-              }
-            }
+        // Simplify by passing AI SDK's default trigger values directly
+        const lastMessage = messages[messages.length - 1]
+        const messageToRegenerate =
+          trigger === 'regenerate-message'
+            ? messages.find(m => m.id === messageId)
+            : undefined
 
-          case 'submit-message':
-          default:
-            // Only send the last message
-            return {
-              body: {
-                trigger: 'submit-user-message',
-                chatId: id,
-                message: messages[messages.length - 1],
-                messageId,
-                isNewChat: messages.length === 1
-              }
-            }
+        return {
+          body: {
+            trigger, // Use AI SDK's default trigger value directly
+            chatId: id,
+            messageId,
+            message:
+              trigger === 'regenerate-message' &&
+              messageToRegenerate?.role === 'user'
+                ? messageToRegenerate
+                : trigger === 'submit-message'
+                  ? lastMessage
+                  : undefined,
+            isNewChat: trigger === 'submit-message' && messages.length === 1
+          }
         }
       }
     }),

--- a/lib/streaming/helpers/prepare-messages.ts
+++ b/lib/streaming/helpers/prepare-messages.ts
@@ -22,7 +22,7 @@ export async function prepareMessages(
   const startTime = performance.now()
   perfLog(`prepareMessages - Start: trigger=${trigger}, isNewChat=${isNewChat}`)
 
-  if (trigger === 'regenerate-assistant-message' && messageId) {
+  if (trigger === 'regenerate-message' && messageId) {
     // Handle regeneration - use initialChat if available to avoid DB call
     let currentChat = initialChat
     if (!currentChat) {


### PR DESCRIPTION
## Summary
- Simplified trigger handling to use AI SDK's native values ('regenerate-message', 'submit-message')
- Removed unnecessary custom trigger transformations
- Improved code maintainability and AI SDK compatibility

## Changes
- Updated `prepareSendMessagesRequest` in chat.tsx to pass trigger values directly
- Modified API route to handle standard trigger values
- Updated prepare-messages.ts to use 'regenerate-message' instead of custom value

## Testing
- TypeScript check passes
- ESLint passes with no errors
- Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)