### PR TITLE
fix: resolve code block rendering issues

### DIFF
--- a/components/collapsible-message.tsx
+++ b/components/collapsible-message.tsx
@@ -123,7 +123,7 @@ export function CollapsibleMessage({
       ) : (
         <div
           className={cn(
-            'flex-1 rounded-2xl',
+            'flex-1 rounded-2xl w-full',
             role === 'assistant' ? 'px-0' : 'px-3'
           )}
         >

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -40,7 +40,10 @@ export function MarkdownMessage({
   const customComponents = {
     code(props: any) {
       const { children, className, ...rest } = props
-      const inline = !('data-language' in props)
+      // Check if it's inline code or code block based on className presence
+      // Code blocks have className like "language-javascript", inline code has no className
+      const match = /language-(\w+)/.exec(className || '')
+      const inline = !match
 
       if (children && typeof children === 'string') {
         if (children === '▍') {
@@ -48,7 +51,6 @@ export function MarkdownMessage({
         }
 
         const processedChildren = children.replace('`▍`', '▍')
-        const match = /language-(\w+)/.exec(className || '')
 
         if (inline) {
           return (


### PR DESCRIPTION
## Summary
- Fixed inline code vs code block detection logic in markdown rendering
- Added proper width constraints to prevent code blocks from overflowing
- Simplified overflow handling in CodeBlock component

## Related Issue
Fixes #642

## Changes Made
1. **Fixed code block detection logic** (`components/message.tsx`)
   - Changed detection from `data-language` attribute to `language-` className pattern
   - This properly distinguishes between inline code and code blocks

2. **Added width constraint** (`components/collapsible-message.tsx`) 
   - Confirmed `w-full` class is present on `flex-1` container
   - Ensures proper width inheritance in flexbox layouts

3. **Simplified CodeBlock styles** (`components/ui/codeblock.tsx`)
   - Removed unnecessary overflow wrappers
   - Restored original simple structure

## Test Plan
- [x] Inline code renders correctly without code block styling
- [x] Code blocks display with proper syntax highlighting
- [x] Long lines in code blocks scroll horizontally without breaking layout
- [x] ESLint checks pass
- [x] TypeScript type checking passes
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.ai/code)