### PR TITLE
fix: Improve tool error handling for AI SDK v5

### DIFF
--- a/components/fetch-preview.tsx
+++ b/components/fetch-preview.tsx
@@ -59,11 +59,11 @@ export function FetchPreview({
 
   if (status === 'error') {
     return (
-      <div className="p-3 bg-card border border-destructive rounded-lg">
+      <div className="p-3 bg-card border border-border rounded-lg">
         <div className="flex items-center gap-2 w-full">
           <Globe className="w-4 h-4 text-muted-foreground shrink-0" />
           <span className="text-sm text-destructive block flex-1 truncate min-w-0">
-            Failed to retrieve: {error}
+            {error}
           </span>
         </div>
       </div>

--- a/components/fetch-section.tsx
+++ b/components/fetch-section.tsx
@@ -27,14 +27,14 @@ export function FetchSection({ tool }: FetchSectionProps) {
   let title: string | undefined
   let contentLength: number | undefined
 
-  // Check if output is available
-  if (!tool.output) {
-    // Still fetching
-    displayStatus = 'fetching'
-  } else if (tool.state === 'output-error') {
+  // Check tool state first
+  if (tool.state === 'output-error') {
     // Error state
     displayStatus = 'error'
     error = tool.errorText || 'Failed to retrieve content'
+  } else if (!tool.output) {
+    // Still fetching
+    displayStatus = 'fetching'
   } else {
     // Success state - we have output
     const data = tool.output as SearchResultsType

--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -36,6 +36,8 @@ export function SearchSection({
     tool.state === 'input-streaming' || tool.state === 'input-available'
   const searchResults: TypeSearchResults | undefined =
     tool.state === 'output-available' ? tool.output : undefined
+  const isError = tool.state === 'output-error'
+  const errorMessage = tool.errorText || 'Search failed'
   const query = tool.input?.query || ''
   const includeDomains = tool.input?.include_domains
   const includeDomainsString = includeDomains
@@ -92,7 +94,17 @@ export function SearchSection({
             />
           </Section>
         )}
-      {isLoading && isToolLoading ? (
+      {isError ? (
+        <Section>
+          <div className="p-3 bg-card border border-destructive rounded-lg">
+            <div className="flex items-center gap-2 w-full">
+              <span className="text-sm text-destructive block flex-1 min-w-0">
+                {errorMessage}
+              </span>
+            </div>
+          </div>
+        </Section>
+      ) : isLoading && isToolLoading ? (
         <SearchSkeleton />
       ) : searchResults?.results && searchResults.results.length > 0 ? (
         <Section title="Sources">

--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -96,7 +96,7 @@ export function SearchSection({
         )}
       {isError ? (
         <Section>
-          <div className="p-3 bg-card border border-destructive rounded-lg">
+          <div className="bg-card rounded-lg">
             <div className="flex items-center gap-2 w-full">
               <span className="text-sm text-destructive block flex-1 min-w-0">
                 {errorMessage}

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -83,9 +83,7 @@ async function fetchRegularData(url: string): Promise<SearchResultsType> {
       throw new Error('Request timeout after 10 seconds')
     }
     console.error('Regular fetch error:', error)
-    throw new Error(
-      `Failed to fetch URL: ${error instanceof Error ? error.message : 'Unknown error'}`
-    )
+    throw error instanceof Error ? error : new Error('Unknown fetch error')
   }
 }
 
@@ -118,9 +116,7 @@ async function fetchJinaReaderData(url: string): Promise<SearchResultsType> {
     }
   } catch (error) {
     console.error('Jina Reader API error:', error)
-    throw new Error(
-      `Jina Reader API failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-    )
+    throw error instanceof Error ? error : new Error('Jina Reader API failed')
   }
 }
 
@@ -155,9 +151,9 @@ async function fetchTavilyExtractData(url: string): Promise<SearchResultsType> {
     }
   } catch (error) {
     console.error('Tavily Extract API error:', error)
-    throw new Error(
-      `Tavily Extract API failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-    )
+    throw error instanceof Error
+      ? error
+      : new Error('Tavily Extract API failed')
   }
 }
 

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -8,7 +8,7 @@ const TITLE_CHARACTER_LIMIT = 100
 
 async function fetchRegularData(
   url: string
-): Promise<SearchResultsType | null> {
+): Promise<SearchResultsType> {
   try {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
@@ -82,17 +82,18 @@ async function fetchRegularData(
     }
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
-      console.error('Request timeout after 10 seconds')
-      return null
+      throw new Error('Request timeout after 10 seconds')
     }
     console.error('Regular fetch error:', error)
-    return null
+    throw new Error(
+      `Failed to fetch URL: ${error instanceof Error ? error.message : 'Unknown error'}`
+    )
   }
 }
 
 async function fetchJinaReaderData(
   url: string
-): Promise<SearchResultsType | null> {
+): Promise<SearchResultsType> {
   try {
     const response = await fetch(`https://r.jina.ai/${url}`, {
       method: 'GET',
@@ -103,7 +104,7 @@ async function fetchJinaReaderData(
     })
     const json = await response.json()
     if (!json.data || json.data.length === 0) {
-      return null
+      throw new Error('No data returned from Jina Reader API')
     }
 
     const content = json.data.content.slice(0, CONTENT_CHARACTER_LIMIT)
@@ -121,13 +122,15 @@ async function fetchJinaReaderData(
     }
   } catch (error) {
     console.error('Jina Reader API error:', error)
-    return null
+    throw new Error(
+      `Jina Reader API failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+    )
   }
 }
 
 async function fetchTavilyExtractData(
   url: string
-): Promise<SearchResultsType | null> {
+): Promise<SearchResultsType> {
   try {
     const apiKey = process.env.TAVILY_API_KEY
     const response = await fetch('https://api.tavily.com/extract', {
@@ -139,7 +142,7 @@ async function fetchTavilyExtractData(
     })
     const json = await response.json()
     if (!json.results || json.results.length === 0) {
-      return null
+      throw new Error('No results returned from Tavily Extract API')
     }
 
     const result = json.results[0]
@@ -158,7 +161,9 @@ async function fetchTavilyExtractData(
     }
   } catch (error) {
     console.error('Tavily Extract API error:', error)
-    return null
+    throw new Error(
+      `Tavily Extract API failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+    )
   }
 }
 
@@ -167,7 +172,7 @@ export const fetchTool = tool({
     'Fetch content from any URL. By default uses "regular" type which performs fast, direct HTML fetching without external APIs - ideal for most websites. Only use "api" type when you need: 1) PDF content extraction, 2) Complex JavaScript-rendered pages, 3) Better markdown formatting, 4) Table extraction. The "api" type requires Jina or Tavily API keys.',
   inputSchema: fetchSchema,
   execute: async ({ url, type = 'regular' }) => {
-    let results: SearchResultsType | null
+    let results: SearchResultsType
 
     if (type === 'regular') {
       // Use regular fetch for direct HTML retrieval
@@ -180,10 +185,6 @@ export const fetchTool = tool({
       } else {
         results = await fetchTavilyExtractData(url)
       }
-    }
-
-    if (!results) {
-      return null
     }
 
     return results

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -6,9 +6,7 @@ import { SearchResults as SearchResultsType } from '@/lib/types'
 const CONTENT_CHARACTER_LIMIT = 10000
 const TITLE_CHARACTER_LIMIT = 100
 
-async function fetchRegularData(
-  url: string
-): Promise<SearchResultsType> {
+async function fetchRegularData(url: string): Promise<SearchResultsType> {
   try {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
@@ -91,9 +89,7 @@ async function fetchRegularData(
   }
 }
 
-async function fetchJinaReaderData(
-  url: string
-): Promise<SearchResultsType> {
+async function fetchJinaReaderData(url: string): Promise<SearchResultsType> {
   try {
     const response = await fetch(`https://r.jina.ai/${url}`, {
       method: 'GET',
@@ -128,9 +124,7 @@ async function fetchJinaReaderData(
   }
 }
 
-async function fetchTavilyExtractData(
-  url: string
-): Promise<SearchResultsType> {
+async function fetchTavilyExtractData(url: string): Promise<SearchResultsType> {
   try {
     const apiKey = process.env.TAVILY_API_KEY
     const response = await fetch('https://api.tavily.com/extract', {

--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -119,9 +119,7 @@ export function createSearchTool(fullModel: string) {
       } catch (error) {
         console.error('Search API error:', error)
         // Re-throw the error to let AI SDK handle it properly
-        throw new Error(
-          `Search failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-        )
+        throw error instanceof Error ? error : new Error('Unknown search error')
       }
 
       // Add citation mapping and toolCallId to search results

--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -118,12 +118,10 @@ export function createSearchTool(fullModel: string) {
         }
       } catch (error) {
         console.error('Search API error:', error)
-        searchResult = {
-          results: [],
-          query: filledQuery,
-          images: [],
-          number_of_results: 0
-        }
+        // Re-throw the error to let AI SDK handle it properly
+        throw new Error(
+          `Search failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+        )
       }
 
       // Add citation mapping and toolCallId to search results


### PR DESCRIPTION
## Summary

This PR improves error handling for AI SDK v5 tools by properly propagating errors and displaying them in the UI.

## Changes

### 1. Tool Error Propagation
- Modified `search.ts` and `fetch.ts` to throw errors instead of suppressing them
- Removed null returns in favor of proper error throwing
- Ensures AI SDK v5 can properly handle and display tool execution errors

### 2. UI Error Display
- Added error state handling in `SearchSection` component
- Fixed error detection in `FetchSection` by checking state before output
- Consistent error display pattern across both tools

### 3. Error Message Improvements
- Removed redundant prefixes ("Search failed:", "Failed to fetch URL:")
- Simplified error messages for better clarity
- Removed "Failed to retrieve:" prefix from fetch preview display

## Testing

The changes were tested by temporarily adding debug code to force errors:
- Search tool: queries containing "test error" triggered errors
- Fetch tool: URLs containing "test-error" triggered errors

Both tools now properly display error messages in the UI when failures occur.

## Related Issue

Fixes the issue where tool execution errors were not being displayed in the UI, as errors were being caught and suppressed instead of being propagated to AI SDK's error handling mechanism.

🤖 Generated with [Claude Code](https://claude.ai/code)