### PR TITLE
fix: stabilize message height and improve chat scroll position

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -78,8 +78,9 @@ export function ChatMessages({
       const headerHeight = 56 // pt-14 padding top
       const chatPanelEstimatedHeight = 120 // ChatPanel with input area
       const additionalPadding = 32 // Safety margin for better visibility
-      
-      const totalOffset = headerHeight + chatPanelEstimatedHeight + additionalPadding
+
+      const totalOffset =
+        headerHeight + chatPanelEstimatedHeight + additionalPadding
       setOffsetHeight(totalOffset)
     }
 
@@ -202,24 +203,32 @@ export function ChatMessages({
             </div>
 
             {/* Assistant messages */}
-            {section.assistantMessages.map(assistantMessage => (
-              <div key={assistantMessage.id} className="flex flex-col gap-4">
-                <RenderMessage
-                  message={assistantMessage}
-                  messageId={assistantMessage.id}
-                  getIsOpen={(id, partType, hasNextPart) =>
-                    getIsOpen(id, partType, hasNextPart, assistantMessage)
-                  }
-                  onOpenChange={handleOpenChange}
-                  onQuerySelect={onQuerySelect}
-                  chatId={chatId}
-                  status={status}
-                  addToolResult={addToolResult}
-                  onUpdateMessage={onUpdateMessage}
-                  reload={reload}
-                />
-              </div>
-            ))}
+            {section.assistantMessages.map((assistantMessage, messageIndex) => {
+              // Check if this is the latest assistant message in the latest section
+              const isLatestMessage =
+                sectionIndex === sections.length - 1 &&
+                messageIndex === section.assistantMessages.length - 1
+
+              return (
+                <div key={assistantMessage.id} className="flex flex-col gap-4">
+                  <RenderMessage
+                    message={assistantMessage}
+                    messageId={assistantMessage.id}
+                    getIsOpen={(id, partType, hasNextPart) =>
+                      getIsOpen(id, partType, hasNextPart, assistantMessage)
+                    }
+                    onOpenChange={handleOpenChange}
+                    onQuerySelect={onQuerySelect}
+                    chatId={chatId}
+                    status={status}
+                    addToolResult={addToolResult}
+                    onUpdateMessage={onUpdateMessage}
+                    reload={reload}
+                    isLatestMessage={isLatestMessage}
+                  />
+                </div>
+              )
+            })}
             {/* Show loading after assistant messages */}
             {showLoading && sectionIndex === sections.length - 1 && (
               <div className="flex justify-start py-4">

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -28,6 +28,7 @@ interface RenderMessageProps {
   addToolResult?: (params: { toolCallId: string; result: any }) => void
   onUpdateMessage?: (messageId: string, newContent: string) => Promise<void>
   reload?: (messageId: string) => Promise<void | string | null | undefined>
+  isLatestMessage?: boolean
 }
 
 export function RenderMessage({
@@ -40,7 +41,8 @@ export function RenderMessage({
   status,
   addToolResult,
   onUpdateMessage,
-  reload
+  reload,
+  isLatestMessage = false
 }: RenderMessageProps) {
   // Extract citation maps from the message's tool outputs
   const citationMaps = extractCitationMaps(message)
@@ -115,9 +117,12 @@ export function RenderMessage({
             const isStreamingComplete =
               status !== 'streaming' && status !== 'submitted'
             const isLastPart = !hasNextPart
-            const shouldShowActions =
-              (isLastPart && isStreamingComplete) || // Last part and streaming done
-              nextMessagePart?.type === 'data-relatedQuestions' // Next part is related questions
+            // For non-latest messages, always show actions
+            // For latest message, show actions only when streaming is complete
+            const shouldShowActions = isLatestMessage
+              ? (isLastPart && isStreamingComplete) || // Last part and streaming done for latest message
+                nextMessagePart?.type === 'data-relatedQuestions' // Next part is related questions
+              : true // Always show actions for non-latest messages
             return (
               <AnswerSection
                 key={`${messageId}-text-${index}`}


### PR DESCRIPTION
## Summary
- Improved chat message position adjustment for better visibility
- Stabilized message height by always showing actions for non-latest messages
- Prevents layout shift when viewing chat history

## Changes
1. **Dynamic minHeight calculation**: Replaced fixed -228px offset with dynamic calculation based on viewport elements (header: 56px, chat panel: 120px, padding: 32px)
2. **Message actions visibility**: Always render MessageActions for non-latest assistant messages to maintain consistent height
3. **Latest message behavior**: Keep dynamic behavior only for the latest message during streaming

## Test plan
- [x] Verify user messages scroll to top without cutting off assistant messages
- [x] Check that past messages maintain consistent height
- [x] Confirm latest message streaming behavior remains unchanged
- [x] Test on different viewport sizes with resize listener

🤖 Generated with [Claude Code](https://claude.ai/code)