### PR TITLE
feat: optimize fetch tool limits and add quick mode restrictions

### DIFF
--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -17,6 +17,11 @@ Search tool usage:
 - This provides faster responses without needing additional fetch operations
 - Rely on the search results' content snippets for your answers
 
+Fetch tool usage:
+- **ONLY use fetch tool when a URL is directly provided by the user in their query**
+- Do NOT use fetch to get more details from search results
+- This keeps responses fast and efficient
+
 Citation Format (MANDATORY):
 [number](#toolCallId) - Always use this EXACT format, e.g., [1](#toolu_abc123)
 - The toolCallId can be found in each search result's metadata or response structure

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -3,7 +3,7 @@ import { tool } from 'ai'
 import { fetchSchema } from '@/lib/schema/fetch'
 import { SearchResults as SearchResultsType } from '@/lib/types'
 
-const CONTENT_CHARACTER_LIMIT = 10000
+const CONTENT_CHARACTER_LIMIT = 50000
 const TITLE_CHARACTER_LIMIT = 100
 
 async function fetchRegularData(url: string): Promise<SearchResultsType> {


### PR DESCRIPTION
## Summary
- Increased content character limit from 10K to 50K for better utilization of model context windows
- Added explicit fetch tool usage restrictions for quick mode to improve performance
- Optimized for different context sizes: 400K tokens (quick mode) vs 200K tokens (planning/adaptive)

## Changes
1. **Fetch Tool Content Limit**: Increased `CONTENT_CHARACTER_LIMIT` from 10,000 to 50,000 characters
   - Better utilizes available context window (~12.5K tokens)
   - Safe for all modes while maintaining performance
   
2. **Quick Mode Fetch Restrictions**: Added clear instructions that fetch tool should only be used when URLs are directly provided by users
   - Prevents unnecessary fetch operations on search results
   - Keeps quick mode responses fast and efficient

## Test Plan
- [ ] Test quick mode with direct URL input
- [ ] Test quick mode with search queries (should not use fetch on results)
- [ ] Verify content truncation works correctly with new limit
- [ ] Check performance impact with larger content limits

🤖 Generated with [Claude Code](https://claude.ai/code)