### PR TITLE
Fix: Display message actions only on last text part

### DIFF
--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -110,19 +110,19 @@ export function RenderMessage({
               />
             )
           case 'text':
-            // Show actions if:
-            // 1. This is the last part and streaming is complete
-            // 2. Next part is data-relatedQuestions
-            const nextMessagePart = message.parts?.[index + 1]
+            // Find if this is the last text part in this message
+            const remainingParts = message.parts?.slice(index + 1) || []
+            const hasMoreTextParts = remainingParts.some(p => p.type === 'text')
+            const isLastTextPart = !hasMoreTextParts
+
+            // Check if streaming is complete
             const isStreamingComplete =
               status !== 'streaming' && status !== 'submitted'
-            const isLastPart = !hasNextPart
-            // For non-latest messages, always show actions
-            // For latest message, show actions only when streaming is complete
-            const shouldShowActions = isLatestMessage
-              ? (isLastPart && isStreamingComplete) || // Last part and streaming done for latest message
-                nextMessagePart?.type === 'data-relatedQuestions' // Next part is related questions
-              : true // Always show actions for non-latest messages
+
+            // Show actions only on the last text part of each message
+            // For the latest message, also check if streaming is complete
+            const shouldShowActions =
+              isLastTextPart && (isLatestMessage ? isStreamingComplete : true)
             return (
               <AnswerSection
                 key={`${messageId}-text-${index}`}


### PR DESCRIPTION
## Summary

This PR fixes the message actions display logic to ensure actions (copy, thumbs up/down, share) appear only on the last text part of each assistant message.

## Problem

Previously, message actions were appearing on all assistant messages in a conversation thread, even during streaming. The logic was based on whether a message was the latest in the entire conversation, rather than checking individual message parts.

## Solution

- Modified the logic to detect the last text part within each message
- Actions now appear only on the last text part of each assistant message
- For the latest message, actions are hidden during streaming and shown only after completion
- For completed messages, actions are always visible on their last text part

## Changes

- Updated  to check for the last text part within each message using 
- Refined  condition to respect both part position and streaming status

## Testing

- Verified actions appear only on the last text part of each message
- Confirmed actions are hidden during streaming for the latest message
- Tested with multiple assistant messages in a conversation thread