### PR TITLE
Fix feedback button not showing after streaming completes

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -163,8 +163,19 @@ export async function createChatStreamResponse(
 
         const result = researchAgent.stream({ messages: modelMessages })
         result.consumeStream()
-        // Stream with the research agent
-        writer.merge(result.toUIMessageStream())
+        // Stream with the research agent, including metadata
+        writer.merge(result.toUIMessageStream({
+          messageMetadata: ({ part }) => {
+            // Send metadata when streaming starts
+            if (part.type === 'start') {
+              return {
+                traceId: parentTraceId,
+                searchMode,
+                modelId: context.modelId
+              }
+            }
+          }
+        }))
 
         const responseMessages = (await result.response).messages
         // Generate related questions


### PR DESCRIPTION
## Summary

This PR fixes an issue where the feedback button (thumbs up/down) was not appearing immediately after message generation completed. Users had to reload the page to see the feedback buttons.

## Problem

The metadata containing `traceId` (required for the feedback button to show) was only being set in the `onFinish` callback and saved to the database, but not propagated to the client-side UI during streaming.

## Solution

Added `messageMetadata` callback to `result.toUIMessageStream()` to send metadata when streaming starts. This ensures the metadata (including `traceId`, `searchMode`, and `modelId`) is immediately available in the client-side message object.

## Changes

- Modified `lib/streaming/create-chat-stream-response.ts` to include metadata in the streaming response
- Metadata is sent at the start of streaming (`part.type === 'start'`)

## Testing

- Create a new chat and send a message
- The feedback buttons should appear immediately after the response completes
- No page reload should be required

Fixes the feedback button display issue reported for chat ID: `zqa0lpolryxrd1nhg9yvksnn`