### PR TITLE
fix: model selection to use cloud.json configuration properly

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -164,18 +164,20 @@ export async function createChatStreamResponse(
         const result = researchAgent.stream({ messages: modelMessages })
         result.consumeStream()
         // Stream with the research agent, including metadata
-        writer.merge(result.toUIMessageStream({
-          messageMetadata: ({ part }) => {
-            // Send metadata when streaming starts
-            if (part.type === 'start') {
-              return {
-                traceId: parentTraceId,
-                searchMode,
-                modelId: context.modelId
+        writer.merge(
+          result.toUIMessageStream({
+            messageMetadata: ({ part }) => {
+              // Send metadata when streaming starts
+              if (part.type === 'start') {
+                return {
+                  traceId: parentTraceId,
+                  searchMode,
+                  modelId: context.modelId
+                }
               }
             }
-          }
-        }))
+          })
+        )
 
         const responseMessages = (await result.response).messages
         // Generate related questions

--- a/lib/utils/model-selection.ts
+++ b/lib/utils/model-selection.ts
@@ -5,10 +5,16 @@ import { ModelType } from '@/lib/types/model-type'
 import { Model } from '@/lib/types/models'
 
 const DEFAULT_MODEL: Model = {
-  id: 'gpt-4o-mini',
-  name: 'GPT-4o mini',
+  id: 'gpt-5-mini',
+  name: 'GPT-5 mini',
   provider: 'OpenAI',
-  providerId: 'openai'
+  providerId: 'openai',
+  providerOptions: {
+    openai: {
+      reasoningEffort: 'low',
+      reasoningSummary: 'auto'
+    }
+  }
 }
 
 interface ModelSelectionParams {
@@ -19,20 +25,30 @@ interface ModelSelectionParams {
  * Determines which model to use based on the model type preference
  *
  * Priority order:
- * 1. If model type is in cookie -> use corresponding model
- * 2. Otherwise -> use DEFAULT_MODEL
+ * 1. If model type is in cookie -> use corresponding model from config
+ * 2. Otherwise -> use default 'speed' model from config
+ * 3. If config loading fails -> use DEFAULT_MODEL as fallback
  */
 export function selectModel({ cookieStore }: ModelSelectionParams): Model {
   const modelTypeCookie = cookieStore.get('modelType')?.value as
     | ModelType
     | undefined
 
-  // If model type is set, use the corresponding model
-  if (modelTypeCookie && ['speed', 'quality'].includes(modelTypeCookie)) {
-    return getModelForType(modelTypeCookie)
+  try {
+    // If model type is set in cookie, use it
+    if (modelTypeCookie && ['speed', 'quality'].includes(modelTypeCookie)) {
+      const model = getModelForType(modelTypeCookie)
+      if (model) return model
+    }
+
+    // Default to 'speed' model from config when no cookie is set
+    const defaultModel = getModelForType('speed')
+    if (defaultModel) return defaultModel
+  } catch (error) {
+    console.error('Error loading model from config:', error)
   }
 
-  // Default model
+  // Fallback to hardcoded DEFAULT_MODEL if config loading fails
   return DEFAULT_MODEL
 }
 


### PR DESCRIPTION
## Summary
- Fixed model selection logic to properly use models from `cloud.json` when `MORPHIC_MODELS_PROFILE=cloud` is set
- Resolved issue where `speed` and `quality` models were falling back to `DEFAULT_MODEL` instead of using configured models
- Updated default behavior to use the `speed` model from config when no `modelType` cookie is present

## Problem
The application was not using the models defined in `cloud.json` even when `MORPHIC_MODELS_PROFILE=cloud` was set. Instead, it was falling back to the hardcoded `DEFAULT_MODEL` (gpt-4o-mini) for `speed` and `quality` model types, while `relatedQuestions` worked correctly.

## Root Cause
The `selectModel` function was checking for a `modelType` cookie, and when it wasn't set, it immediately returned `DEFAULT_MODEL` without attempting to load models from the configuration file.

## Solution
Modified the `selectModel` function to:
1. Check for `modelType` cookie and use it if present
2. If no cookie, default to the `speed` model from the current config (`cloud.json` or `default.json`)
3. Only fall back to `DEFAULT_MODEL` if config loading fails

## Changes
- Updated `lib/utils/model-selection.ts` to implement proper fallback chain
- Updated `DEFAULT_MODEL` to use `gpt-5-mini` with provider options for consistency
- Added proper error handling for config loading failures

## Test Plan
- [x] Verified that with `MORPHIC_MODELS_PROFILE=cloud`, the app uses models from `cloud.json`
- [x] Verified that without the environment variable, it uses models from `default.json`
- [x] Confirmed all lint, format, and typecheck tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)