### PR TITLE
fix: avoid invisible action row in text parts

### DIFF
--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -44,12 +44,10 @@ export function MessageActions({
   const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false)
   const isLoading = status === 'submitted' || status === 'streaming'
 
-  // Do not render at all when actions should be hidden or while loading.
-  // Previously we rendered with `opacity-0`, which still occupied layout
-  // space and caused an invisible actions row to be placed for the first
-  // text part. Returning null matches the intended behavior of not
-  // rendering at all.
-  if (!visible || isLoading) {
+  // Do not render at all when actions should be hidden.
+  // Rendering while loading is allowed so previous messages keep their actions
+  // visible even during a new message's streaming.
+  if (!visible) {
     return null
   }
 


### PR DESCRIPTION
This PR fixes an issue where the first text part of an assistant message rendered an invisible actions row (alpha 0) even when actions should not be shown.

Root cause
- `AnswerSection` always mounted `MessageActions`.
- `MessageActions` hid itself via `opacity-0` when `visible` was false or while streaming, which still occupied layout space.

Fix
- `MessageActions` now returns `null` only when hidden (`visible === false`).
- Rendering during loading/streaming is allowed so prior messages keep actions visible while a new reply streams.
- Removed the previous opacity gating approach; when hidden it simply does not mount.

Impact
- Prevents layout gap and unwanted alpha-0 actions row for non-final text parts.
- Actions remain visible only on the last text part of a message and only after streaming completes.

Files changed
- `components/message-actions.tsx`

Test plan
1. Ask a question that produces multi-part assistant output (tool invocations + multiple text parts).
2. During streaming, confirm no actions row is present until the final text part completes.
3. After completion, only the last text part shows actions; earlier text parts have no extra spacing.
