### PR TITLE
docs(prompt): enforce TODO completion via prompts (Refs #682)

### DIFF
--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -91,11 +91,14 @@ Tool preamble and progress updates:
 - Before calling tools, restate the user's goal and outline a short plan (2–4 bullets) that lists the key steps you will take.
 - As you execute tools, emit compact progress updates only when meaningful (avoid verbose commentary).
 - At the end, include a one-line "What was done vs. plan" summary.
+ - Before the final answer, run a todoRead verification (completedCount == totalCount). If not all tasks are completed, keep working and updating tasks with todoWrite, then verify again.
 
 Task Management:
 - Use todoWrite to create and track tasks for complex research
 - Update task status as you progress (pending → in_progress → completed)
 - Ensure all tasks are completed before finishing
+ - While working on a task, set its status to in_progress; once done, set it to completed. Update via todoWrite after each meaningful step.
+ - After completing all tasks, call todoRead and confirm completedCount equals totalCount before composing the final answer.
 
 Search strategy:
 - Use type="optimized" for most research queries (provides content snippets)
@@ -259,6 +262,8 @@ TASK MANAGEMENT (todoWrite tool):
 - Include both research tasks AND synthesis tasks
 - Update status: pending → in_progress → completed
 - This provides transparency and ensures nothing is missed
+ - For each task: set status to in_progress while working; when complete, set to completed via todoWrite. Keep statuses current.
+ - Do not produce the final answer until you have called todoRead and verified completedCount equals totalCount. If not, continue executing or adjust the plan with todoWrite and verify again.
 
 Example task patterns:
 - "Research [topic] from multiple sources"


### PR DESCRIPTION
This PR addresses #682 by strengthening prompt instructions (no system-level enforcement):

Changes:
- Planning mode: require a todoRead verification (completedCount == totalCount) before composing the final answer.
- Adaptive mode: add an explicit task loop (pending → in_progress → completed) and verification step.
- Clarify progress updates and status transitions using todoWrite during execution.

Rationale:
- Keeps control at the prompt level as requested; avoids hard-coded stop conditions.
- Encourages the model to maintain and verify the TODO list it creates, reducing early finalization.

Notes:
- Quick mode is unchanged (still optimized for speed without task tracking).
- Behavior still depends on model capabilities; this improves compliance without over-constraining.

Refs #682
