### PR TITLE
ci(release): add tag-driven release workflow (pre-release gating by base version)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,4 +115,3 @@ jobs:
           generateReleaseNotes: true
           prerelease: ${{ needs.gate.outputs.prerelease }}
           # artifacts: next-build.tar.gz
-


### PR DESCRIPTION
## Summary

This adds a tag-driven release workflow for automated GitHub releases.

## Key Features

### Trigger
- Push of tags matching `v*` pattern (e.g., `v1.0.0`, `v1.0.0-beta.5`)

### Release Types
- **Pre-releases**: Allowed only when tag commit is in a matching release branch (`vX.Y.Z`, `release/vX.Y.Z`, or `vX.Y` as fallback)
- **Stable releases**: Allowed only when tag commit is on `main` branch

### Workflow Steps
1. Bun install
2. TypeScript type checking
3. ESLint linting
4. Build verification
5. Create GitHub Release (with auto-generated notes and appropriate prerelease flag)

## Release Strategy Support

This workflow supports the planned release strategy:
- Use base-version branches (e.g., `v1.0.0`) for beta/RC releases
- Use `main` branch for stable releases after beta phase ends