### PR TITLE
feat(cache): implement selective caching for individual chat loading

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers'
+import { revalidateTag } from 'next/cache'
 
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'
@@ -102,6 +103,13 @@ export async function POST(req: Request) {
       isNewChat,
       searchMode
     })
+
+    // Invalidate the cache for this specific chat after creating the response
+    // This ensures the next load will get fresh data
+    if (chatId) {
+      revalidateTag(`chat-${chatId}`)
+      revalidateTag('chat')
+    }
 
     const totalTime = performance.now() - startTime
     perfLog(`Total API route time: ${totalTime.toFixed(2)}ms`)

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -108,7 +108,6 @@ export async function POST(req: Request) {
     // This ensures the next load will get fresh data
     if (chatId) {
       revalidateTag(`chat-${chatId}`)
-      revalidateTag('chat')
     }
 
     const totalTime = performance.now() - startTime

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,5 @@
-import { cookies } from 'next/headers'
 import { revalidateTag } from 'next/cache'
+import { cookies } from 'next/headers'
 
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -14,7 +14,10 @@ import { getTextFromParts } from '@/lib/utils/message-utils'
 const DEFAULT_CHAT_TITLE = 'Untitled'
 
 // Create cached version of loadChatWithMessages with dynamic tags per chat
-const getCachedChatWithMessages = (chatId: string, requestingUserId?: string) => {
+const getCachedChatWithMessages = (
+  chatId: string,
+  requestingUserId?: string
+) => {
   // Create a unique cache instance for each chat
   const cachedFunction = unstable_cache(
     async () => {
@@ -26,7 +29,7 @@ const getCachedChatWithMessages = (chatId: string, requestingUserId?: string) =>
       revalidate: 60 // revalidate after 60 seconds
     }
   )
-  
+
   return cachedFunction()
 }
 

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -232,6 +232,7 @@ export async function clearChats() {
     await dbActions.deleteChat(chat.id, userId)
   }
 
+  // Clear all chat caches since we deleted all chats
   revalidateTag('chat')
   return { success: true }
 }

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -13,18 +13,21 @@ import { getTextFromParts } from '@/lib/utils/message-utils'
 // Constants
 const DEFAULT_CHAT_TITLE = 'Untitled'
 
-// Create a wrapper function for dynamic cache tags per chat
+// Create cached version of loadChatWithMessages with dynamic tags per chat
 const getCachedChatWithMessages = (chatId: string, requestingUserId?: string) => {
-  return unstable_cache(
+  // Create a unique cache instance for each chat
+  const cachedFunction = unstable_cache(
     async () => {
       return dbActions.loadChatWithMessages(chatId, requestingUserId)
     },
-    ['chat-with-messages', chatId, requestingUserId || 'anonymous'],
+    ['chat-with-messages', chatId, requestingUserId || 'anonymous'], // cache key
     {
-      tags: [`chat-${chatId}`],
-      revalidate: 60
+      tags: [`chat-${chatId}`, 'chat'], // both specific and general tags
+      revalidate: 60 // revalidate after 60 seconds
     }
-  )()
+  )
+  
+  return cachedFunction()
 }
 
 /**

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -13,17 +13,19 @@ import { getTextFromParts } from '@/lib/utils/message-utils'
 // Constants
 const DEFAULT_CHAT_TITLE = 'Untitled'
 
-// Cache individual chat loading for 60 seconds
-const getCachedChatWithMessages = unstable_cache(
-  async (chatId: string, requestingUserId?: string) => {
-    return dbActions.loadChatWithMessages(chatId, requestingUserId)
-  },
-  ['chat-with-messages'],
-  {
-    tags: (chatId) => [`chat-${chatId}`],
-    revalidate: 60
-  }
-)
+// Create a wrapper function for dynamic cache tags per chat
+const getCachedChatWithMessages = (chatId: string, requestingUserId?: string) => {
+  return unstable_cache(
+    async () => {
+      return dbActions.loadChatWithMessages(chatId, requestingUserId)
+    },
+    ['chat-with-messages', chatId, requestingUserId || 'anonymous'],
+    {
+      tags: [`chat-${chatId}`],
+      revalidate: 60
+    }
+  )()
+}
 
 /**
  * Get all chats for the current user

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -90,7 +90,6 @@ export async function createChat(
 
   // Revalidate cache
   revalidateTag(`chat-${chatId}`)
-  revalidateTag('chat')
 
   return chat
 }
@@ -161,7 +160,6 @@ export async function createChatWithFirstMessage(
 
   // Revalidate cache
   revalidateTag(`chat-${chatId}`)
-  revalidateTag('chat')
 
   return result
 }
@@ -214,7 +212,6 @@ export async function deleteChat(chatId: string) {
 
   if (result.success) {
     revalidateTag(`chat-${chatId}`)
-    revalidateTag('chat')
   }
 
   return result

--- a/lib/streaming/helpers/persist-stream-results.ts
+++ b/lib/streaming/helpers/persist-stream-results.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from 'next/cache'
 import { UIMessage } from 'ai'
 
 import { upsertMessage } from '@/lib/actions/chat'
@@ -33,6 +34,8 @@ export async function persistStreamResults(
   try {
     await upsertMessage(chatId, responseMessage, userId)
     perfTime('upsertMessage (AI response) completed', saveStart)
+    // Invalidate cache after saving message
+    revalidateTag(`chat-${chatId}`)
   } catch (error) {
     console.error('Error saving message:', error)
     try {
@@ -41,6 +44,8 @@ export async function persistStreamResults(
         'save message'
       )
       perfTime('upsertMessage (AI response) completed after retry', saveStart)
+      // Invalidate cache after saving message
+      revalidateTag(`chat-${chatId}`)
     } catch (retryError) {
       console.error('Failed to save after retries:', retryError)
       // Don't throw here to avoid breaking the stream
@@ -51,6 +56,8 @@ export async function persistStreamResults(
   if (chatTitle && chatTitle !== DEFAULT_CHAT_TITLE) {
     try {
       await updateChatTitle(chatId, chatTitle, userId)
+      // Invalidate cache after updating title
+      revalidateTag(`chat-${chatId}`)
     } catch (error) {
       console.error('Error updating title:', error)
       // Don't throw here as title update is not critical

--- a/lib/streaming/helpers/persist-stream-results.ts
+++ b/lib/streaming/helpers/persist-stream-results.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from 'next/cache'
 import { UIMessage } from 'ai'
 
 import { upsertMessage } from '@/lib/actions/chat'
@@ -34,8 +33,6 @@ export async function persistStreamResults(
   try {
     await upsertMessage(chatId, responseMessage, userId)
     perfTime('upsertMessage (AI response) completed', saveStart)
-    // Invalidate cache after saving message
-    revalidateTag(`chat-${chatId}`)
   } catch (error) {
     console.error('Error saving message:', error)
     try {
@@ -44,8 +41,6 @@ export async function persistStreamResults(
         'save message'
       )
       perfTime('upsertMessage (AI response) completed after retry', saveStart)
-      // Invalidate cache after saving message
-      revalidateTag(`chat-${chatId}`)
     } catch (retryError) {
       console.error('Failed to save after retries:', retryError)
       // Don't throw here to avoid breaking the stream
@@ -56,8 +51,6 @@ export async function persistStreamResults(
   if (chatTitle && chatTitle !== DEFAULT_CHAT_TITLE) {
     try {
       await updateChatTitle(chatId, chatTitle, userId)
-      // Invalidate cache after updating title
-      revalidateTag(`chat-${chatId}`)
     } catch (error) {
       console.error('Error updating title:', error)
       // Don't throw here as title update is not critical


### PR DESCRIPTION
## Summary
- Implement caching for individual chat loading (`loadChat`) using Next.js `unstable_cache`
- Keep chat history (`getChatsPage`) uncached due to frequent updates
- Add proper cache invalidation in Route Handler context

## Implementation Details

### Caching Strategy
- **Individual chats**: Cached with 60-second TTL using dynamic tags (`chat-${chatId}`)
- **Chat history**: No caching - remains fresh for frequently updated lists
- **Cache keys**: Include both chatId and userId for proper user isolation

### Cache Invalidation
- Moved `revalidateTag` to Route Handler context (`POST /api/chat`) for proper execution
- Removed ineffective calls from streaming callbacks
- Optimized to only invalidate affected chat, not all caches

### Changes
- Added wrapper function pattern for `unstable_cache` with dynamic tags
- Each chat gets its own cache entry that can be invalidated independently
- Removed unnecessary general tag invalidations except for `clearChats`

## Benefits
- Reduces database queries for individual chat loads
- Maintains fresh data for chat history
- Granular cache invalidation prevents unnecessary cache clears
- Better performance for chat navigation

## Test Plan
- [x] Test chat loading performance
- [x] Verify cache invalidation after message generation
- [x] Confirm chat history remains uncached
- [x] Check proper user isolation in cache keys

🤖 Generated with [Claude Code](https://claude.ai/code)