### PR TITLE
fix: resolve input focus ring persistence after submission

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -81,6 +81,9 @@ export function ChatPanel({
   const handleNewChat = () => {
     setMessages([])
     closeArtifact()
+    // Reset focus state when clearing chat
+    setIsInputFocused(false)
+    inputRef.current?.blur()
     router.push('/')
   }
 
@@ -147,7 +150,12 @@ export function ChatPanel({
         <UploadedFileList files={uploadedFiles} onRemove={handleFileRemove} />
       )}
       <form
-        onSubmit={handleSubmit}
+        onSubmit={e => {
+          handleSubmit(e)
+          // Reset focus state after submission
+          setIsInputFocused(false)
+          inputRef.current?.blur()
+        }}
         className={cn('max-w-3xl w-full mx-auto relative')}
       >
         {/* Scroll to bottom button - only shown when showScrollToBottomButton is true */}
@@ -201,6 +209,9 @@ export function ChatPanel({
                 e.preventDefault()
                 const textarea = e.target as HTMLTextAreaElement
                 textarea.form?.requestSubmit()
+                // Reset focus state after Enter key submission
+                setIsInputFocused(false)
+                textarea.blur()
               }
             }}
           />
@@ -296,6 +307,9 @@ export function ChatPanel({
               // Submit the form after a small delay to ensure the input is updated
               setTimeout(() => {
                 inputRef.current?.form?.requestSubmit()
+                // Reset focus state after action button submission
+                setIsInputFocused(false)
+                inputRef.current?.blur()
               }, INPUT_UPDATE_DELAY_MS)
             }}
             onCategoryClick={category => {


### PR DESCRIPTION
## Summary

Fixed an issue where the input focus ring would persist after form submission, creating a visual inconsistency where the ring remained visible even when the input was no longer focused.

## Problem

The `isInputFocused` state was used to control the focus ring display, but it wasn't properly reset when:
- Form submitted via submit button
- Form submitted via Enter key  
- Action button prompt submitted
- New chat created/cleared

This resulted in the focus ring remaining visible even after submission.

## Solution

Added focus state reset logic to all submission paths:
- `onSubmit` handler: Reset `isInputFocused` and call `blur()`
- `onKeyDown` (Enter): Reset focus state after `requestSubmit()`
- Action button submission: Reset focus state in setTimeout callback
- New chat handler: Reset focus state when clearing messages

## Test plan

- [x] Submit form via submit button - focus ring disappears
- [x] Submit form via Enter key - focus ring disappears  
- [x] Submit via action buttons - focus ring disappears
- [x] Create new chat - focus ring disappears
- [x] Verify normal focus/blur behavior still works
- [x] Run linting and type checks

🤖 Generated with [Claude Code](https://claude.ai/code)