### PR TITLE
Fix assistant message deletion under RLS

### DIFF
--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -286,9 +286,10 @@ export async function shareChat(chatId: string) {
  */
 export async function deleteMessagesFromIndex(
   chatId: string,
-  messageId: string
+  messageId: string,
+  userIdOverride?: string
 ) {
-  const userId = await getCurrentUserId()
+  const userId = userIdOverride ?? (await getCurrentUserId())
   if (!userId) {
     return { success: false, error: 'User not authenticated' }
   }
@@ -299,7 +300,11 @@ export async function deleteMessagesFromIndex(
     return { success: false, error: 'Unauthorized' }
   }
 
-  const result = await dbActions.deleteMessagesFromIndex(chatId, messageId)
+  const result = await dbActions.deleteMessagesFromIndex(
+    chatId,
+    messageId,
+    userId
+  )
 
   revalidateTag(`chat-${chatId}`)
 

--- a/lib/streaming/helpers/prepare-messages.ts
+++ b/lib/streaming/helpers/prepare-messages.ts
@@ -56,7 +56,7 @@ export async function prepareMessages(
 
     const targetMessage = currentChat.messages[messageIndex]
     if (targetMessage.role === 'assistant') {
-      await deleteMessagesFromIndex(chatId, messageId)
+      await deleteMessagesFromIndex(chatId, messageId, userId)
       return currentChat.messages.slice(0, messageIndex)
     } else {
       // User message edit
@@ -65,7 +65,7 @@ export async function prepareMessages(
       }
       const messagesToDelete = currentChat.messages.slice(messageIndex + 1)
       if (messagesToDelete.length > 0) {
-        await deleteMessagesFromIndex(chatId, messagesToDelete[0].id)
+        await deleteMessagesFromIndex(chatId, messagesToDelete[0].id, userId)
       }
       const updatedChat = await loadChat(chatId, userId)
       return (

--- a/lib/streaming/message-preparation.ts
+++ b/lib/streaming/message-preparation.ts
@@ -40,7 +40,7 @@ export async function prepareMessagesForRegeneration(
 
   if (targetMessage.role === 'assistant') {
     // Delete from this assistant message onwards
-    await deleteMessagesFromIndex(chatId, messageId)
+    await deleteMessagesFromIndex(chatId, messageId, userId)
     // Use messages up to (but not including) this assistant message
     return currentChat.messages.slice(0, messageIndex)
   } else {
@@ -51,7 +51,7 @@ export async function prepareMessagesForRegeneration(
     // Delete everything after this user message
     const messagesToDelete = currentChat.messages.slice(messageIndex + 1)
     if (messagesToDelete.length > 0) {
-      await deleteMessagesFromIndex(chatId, messagesToDelete[0].id)
+      await deleteMessagesFromIndex(chatId, messagesToDelete[0].id, userId)
     }
     // Get updated messages including the edited one
     const updatedChat = await loadChat(chatId, userId)


### PR DESCRIPTION
## Summary
- ensure deleteMessagesFromIndex always runs with the current user context so RLS queries succeed
- allow streaming regenerate flow to pass through the user id when removing stale assistant replies

## Testing
- regenerate assistant messages in browser without encountering "No messages deleted" errors