### PR TITLE
Reorder search modes and set quick as default

### DIFF
--- a/components/search-mode-selector.tsx
+++ b/components/search-mode-selector.tsx
@@ -19,7 +19,7 @@ import {
 import { HoverCard, HoverCardContent, HoverCardTrigger } from './ui/hover-card'
 
 export function SearchModeSelector() {
-  const [value, setValue] = useState<SearchMode>('adaptive')
+  const [value, setValue] = useState<SearchMode>('quick')
   const [indicatorStyle, setIndicatorStyle] = useState<React.CSSProperties>({})
   const [openHoverCard, setOpenHoverCard] = useState<string | null>(null)
   const [justSelected, setJustSelected] = useState(false)

--- a/lib/config/search-modes.ts
+++ b/lib/config/search-modes.ts
@@ -15,6 +15,13 @@ export interface SearchModeConfig {
 // Centralized search mode configuration
 export const SEARCH_MODE_CONFIGS: SearchModeConfig[] = [
   {
+    value: 'quick',
+    label: 'Quick',
+    description: 'Streamlined search for fast, concise responses',
+    icon: Search,
+    color: 'text-amber-500'
+  },
+  {
     value: 'adaptive',
     label: 'Adaptive',
     description: 'Adaptive agentic search with intelligent query understanding',
@@ -27,13 +34,6 @@ export const SEARCH_MODE_CONFIGS: SearchModeConfig[] = [
     description: 'Structured multi-step approach for comprehensive research',
     icon: ListTodo,
     color: 'text-blue-500'
-  },
-  {
-    value: 'quick',
-    label: 'Quick',
-    description: 'Streamlined search for fast, concise responses',
-    icon: Search,
-    color: 'text-amber-500'
   }
 ]
 


### PR DESCRIPTION
## Summary

This PR reorders the search modes in the UI and changes the default search mode to prioritize speed and user experience.

## Changes Made

1. **Reordered search modes**: Changed from `adaptive/planning/quick` to `quick/adaptive/planning` order
   - Updated `SEARCH_MODE_CONFIGS` array in `/lib/config/search-modes.ts`
   - Quick mode now appears first in the search mode selector

2. **Changed default search mode**: Updated default from `adaptive` to `quick`
   - Modified initial state value in `SearchModeSelector` component
   - Users will now start with the fastest search option by default

## Why These Changes?

- **Better UX**: Quick mode provides faster responses, making it ideal as the default for most users
- **Progressive enhancement**: Users can still choose adaptive or planning modes when they need more comprehensive results
- **Logical ordering**: Quick → Adaptive → Planning follows a natural progression from fast to comprehensive

## Files Modified

- `/lib/config/search-modes.ts` - Reordered the search mode configuration array
- `/components/search-mode-selector.tsx` - Changed default state from 'adaptive' to 'quick'

## Testing

- [x] Search mode selector displays modes in the new order (quick, adaptive, planning)
- [x] Default selection is now 'quick' when component loads
- [x] All search modes function correctly
- [x] UI remains responsive and accessible