### PR TITLE
feat: start chat streaming optimistically

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -92,6 +92,11 @@ export async function POST(req: Request) {
       )
     }
 
+    const streamStart = performance.now()
+    perfLog(
+      `createChatStreamResponse - Start: model=${selectedModel.providerId}:${selectedModel.id}, searchMode=${searchMode}`
+    )
+
     const response = await createChatStreamResponse({
       message,
       model: selectedModel,
@@ -103,6 +108,8 @@ export async function POST(req: Request) {
       isNewChat,
       searchMode
     })
+
+    perfTime('createChatStreamResponse resolved', streamStart)
 
     // Invalidate the cache for this specific chat after creating the response
     // This ensures the next load will get fresh data

--- a/lib/agents/title-generator.ts
+++ b/lib/agents/title-generator.ts
@@ -59,8 +59,17 @@ export async function generateChatTitle({
     // Remove any surrounding quotes that the model might have added
     return cleanedTitle.replace(/^[\"']|[\"']$/g, '')
   } catch (error) {
-    console.error('Error generating chat title with LLM:', error)
-    // If LLM generation fails, return the fallback title.
+    if (
+      error instanceof Error &&
+      (error.name === 'AbortError' || error.name === 'ResponseAborted')
+    ) {
+      if (process.env.NODE_ENV === 'development') {
+        console.info('Title generation aborted; using fallback title.')
+      }
+    } else {
+      console.error('Error generating chat title with LLM:', error)
+    }
+    // If LLM generation fails or is aborted, return the fallback title.
     return fallbackTitle
   }
 }

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -232,7 +232,9 @@ export async function createChatStreamResponse(
         titlePromise,
         parentTraceId,
         searchMode,
-        context.modelId
+        context.modelId,
+        context.pendingInitialSave,
+        context.pendingInitialUserMessage
       )
     }
   })

--- a/lib/streaming/helpers/persist-stream-results.ts
+++ b/lib/streaming/helpers/persist-stream-results.ts
@@ -16,7 +16,9 @@ export async function persistStreamResults(
   parentTraceId?: string,
   searchMode?: SearchMode,
   modelId?: string,
-  initialSavePromise?: Promise<Awaited<ReturnType<typeof createChatWithFirstMessage>>>,
+  initialSavePromise?: Promise<
+    Awaited<ReturnType<typeof createChatWithFirstMessage>>
+  >,
   initialUserMessage?: UIMessage
 ) {
   // Attach metadata to the response message

--- a/lib/streaming/helpers/types.ts
+++ b/lib/streaming/helpers/types.ts
@@ -1,4 +1,4 @@
-import type { Chat } from '@/lib/db/schema'
+import type { Chat, Message } from '@/lib/db/schema'
 import type { UIMessage } from '@/lib/types/ai'
 
 export interface StreamContext {
@@ -11,4 +11,6 @@ export interface StreamContext {
   abortSignal?: AbortSignal
   parentTraceId?: string
   isNewChat?: boolean
+  pendingInitialSave?: Promise<{ chat: Chat; message: Message }>
+  pendingInitialUserMessage?: UIMessage
 }


### PR DESCRIPTION
## Summary
- start chat streaming without waiting for initial chat persistence by running createChatWithFirstMessage in the background
- pipe pending persistence context through the streaming stack and await it before persisting the assistant response, including fallback handling
- soften title-generation logging when aborting to avoid noisy errors

## Testing
- bun lint
