### PR TITLE
refactor: streamline search image filtering

### DIFF
--- a/components/search-results-image.tsx
+++ b/components/search-results-image.tsx
@@ -1,7 +1,14 @@
 /* eslint-disable @next/next/no-img-element */
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
 
 import { PlusCircle } from 'lucide-react'
 
@@ -30,188 +37,234 @@ interface SearchResultsImageSectionProps {
   displayMode?: 'preview' | 'full'
 }
 
-type NormalizedImage = { url: string; description: string }
+type NormalizedImage = { id: string; url: string; description: string }
+
+type FilterStatus = 'loading' | 'ready' | 'empty'
+
+interface FilteredImagesState {
+  status: FilterStatus
+  images: NormalizedImage[]
+}
+
+const normalizeImages = (images: SearchResultImage[]): NormalizedImage[] => {
+  if (!images || images.length === 0) {
+    return []
+  }
+
+  return images.map((image, index) => {
+    if (typeof image === 'string') {
+      return {
+        id: `${index}-${image}`,
+        url: image,
+        description: ''
+      }
+    }
+
+    const url = image.url ?? ''
+    return {
+      id: `${index}-${url}`,
+      url,
+      description: image.description ?? ''
+    }
+  })
+}
+
+const useFilteredImages = (images: SearchResultImage[]) => {
+  const normalizedImages = useMemo(() => normalizeImages(images), [images])
+
+  const [state, setState] = useState<FilteredImagesState>(() => ({
+    status: normalizedImages.length === 0 ? 'empty' : 'loading',
+    images: []
+  }))
+
+  useEffect(() => {
+    if (normalizedImages.length === 0) {
+      setState({ status: 'empty', images: [] })
+      return
+    }
+
+    if (typeof window === 'undefined') {
+      setState({ status: 'ready', images: normalizedImages })
+      return
+    }
+
+    let cancelled = false
+    setState({ status: 'loading', images: [] })
+
+    const preloadImage = (image: NormalizedImage) =>
+      new Promise<NormalizedImage | null>(resolve => {
+        if (!image.url) {
+          resolve(null)
+          return
+        }
+
+        const img = new window.Image()
+        img.onload = () => resolve(image)
+        img.onerror = () => resolve(null)
+        img.src = image.url
+      })
+
+    Promise.all(normalizedImages.map(preloadImage)).then(results => {
+      if (cancelled) {
+        return
+      }
+
+      const validImages = results.filter(Boolean) as NormalizedImage[]
+      if (validImages.length === 0) {
+        setState({ status: 'empty', images: [] })
+        return
+      }
+
+      setState({ status: 'ready', images: validImages })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [normalizedImages])
+
+  const removeImage = useCallback((id: string) => {
+    setState(prevState => {
+      if (prevState.status === 'loading') {
+        return prevState
+      }
+
+      const remaining = prevState.images.filter(image => image.id !== id)
+      return {
+        status: remaining.length === 0 ? 'empty' : 'ready',
+        images: remaining
+      }
+    })
+  }, [])
+
+  const displayImages =
+    state.status === 'loading' ? normalizedImages : state.images
+
+  return {
+    status: state.status,
+    filteredImages: state.images,
+    displayImages,
+    removeImage
+  }
+}
+
+const useCarouselMetrics = ({
+  api,
+  imageCount,
+  selectedIndex,
+  setSelectedIndex
+}: {
+  api: CarouselApi | undefined
+  imageCount: number
+  selectedIndex: number
+  setSelectedIndex: Dispatch<SetStateAction<number>>
+}) => {
+  const [current, setCurrent] = useState(() =>
+    imageCount > 0 ? Math.min(selectedIndex + 1, imageCount) : 0
+  )
+
+  useEffect(() => {
+    if (!api) {
+      if (imageCount === 0) {
+        setCurrent(0)
+      } else {
+        setCurrent(Math.min(selectedIndex + 1, imageCount))
+      }
+      return
+    }
+
+    const handleSelect = () => {
+      setCurrent(api.selectedScrollSnap() + 1)
+    }
+
+    handleSelect()
+    api.on('select', handleSelect)
+
+    return () => {
+      api.off('select', handleSelect)
+    }
+  }, [api, imageCount, selectedIndex])
+
+  useEffect(() => {
+    setSelectedIndex(prevIndex => {
+      if (imageCount === 0) {
+        return 0
+      }
+      return Math.min(prevIndex, imageCount - 1)
+    })
+  }, [imageCount, setSelectedIndex])
+
+  useEffect(() => {
+    if (!api || imageCount === 0) {
+      if (imageCount === 0) {
+        setCurrent(0)
+      }
+      return
+    }
+
+    const clampedIndex = Math.min(selectedIndex, imageCount - 1)
+    api.scrollTo(clampedIndex, false)
+  }, [api, selectedIndex, imageCount])
+
+  return { current }
+}
+
+const cornerClassForIndex = (actualIndex: number, isFullMode: boolean) => {
+  if (!isFullMode) {
+    return 'rounded-lg'
+  }
+
+  if (actualIndex === 0) return 'rounded-tl-lg'
+  if (actualIndex === 1) return 'rounded-tr-lg'
+  if (actualIndex === 2) return 'rounded-bl-lg'
+  if (actualIndex === 4) return 'rounded-br-lg'
+
+  return ''
+}
 
 export const SearchResultsImageSection: React.FC<
   SearchResultsImageSectionProps
 > = ({ images, query, displayMode = 'preview' }) => {
   const [api, setApi] = useState<CarouselApi>()
-  const [current, setCurrent] = useState(0)
-  const [count, setCount] = useState(0)
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [filteredImages, setFilteredImages] = useState<NormalizedImage[]>([])
-  const [isCheckingImages, setIsCheckingImages] = useState(true)
 
-  const convertedImages = useMemo(() => {
-    if (!images || images.length === 0) {
-      return [] as NormalizedImage[]
-    }
+  const { status, filteredImages, displayImages, removeImage } =
+    useFilteredImages(images)
 
-    if (typeof images[0] === 'string') {
-      return (images as string[]).map(image => ({
-        url: image,
-        description: ''
-      }))
-    }
+  const filteredCount = filteredImages.length
+  const isLoading = status === 'loading'
 
-    return images as NormalizedImage[]
-  }, [images])
+  const { current } = useCarouselMetrics({
+    api,
+    imageCount: filteredCount,
+    selectedIndex,
+    setSelectedIndex
+  })
 
-  useEffect(() => {
-    let isMounted = true
-
-    if (typeof window === 'undefined') {
-      setFilteredImages(convertedImages)
-      setIsCheckingImages(false)
-      return
-    }
-
-    if (convertedImages.length === 0) {
-      setFilteredImages([])
-      setIsCheckingImages(false)
-      return
-    }
-
-    setIsCheckingImages(true)
-    setFilteredImages([])
-
-    const preloadResults: (NormalizedImage | null)[] = Array(
-      convertedImages.length
-    ).fill(null)
-    let completedChecks = 0
-
-    const markComplete = () => {
-      completedChecks += 1
-      if (!isMounted) {
-        return
-      }
-      if (completedChecks === convertedImages.length) {
-        setFilteredImages(preloadResults.filter(Boolean) as NormalizedImage[])
-        setIsCheckingImages(false)
-      }
-    }
-
-    convertedImages.forEach((image, index) => {
-      if (!image?.url) {
-        markComplete()
-        return
-      }
-
-      const preloader = new window.Image()
-      preloader.onload = () => {
-        if (!isMounted) {
-          return
-        }
-        preloadResults[index] = image
-        markComplete()
-      }
-      preloader.onerror = markComplete
-      preloader.src = image.url
-    })
-
-    return () => {
-      isMounted = false
-    }
-  }, [convertedImages])
-
-  useEffect(() => {
-    setSelectedIndex(prevIndex => {
-      if (filteredImages.length === 0) {
-        return 0
-      }
-      return Math.min(prevIndex, filteredImages.length - 1)
-    })
-  }, [filteredImages.length])
-
-  // Update the current and count state when the carousel api is available
-  useEffect(() => {
-    if (!api) {
-      return
-    }
-
-    // Set initial count from scroll snaps, current from selected snap
-    setCount(api.scrollSnapList().length)
-    setCurrent(api.selectedScrollSnap() + 1)
-
-    const handleSelect = () => {
-      setCurrent(api.selectedScrollSnap() + 1)
-    }
-    api.on('select', handleSelect)
-
-    // Cleanup listener on unmount or when api changes
-    return () => {
-      api.off('select', handleSelect)
-    }
-  }, [api])
-
-  // Update count based on the actual number of converted images
-  // This ensures the count reflects the data, even if the carousel API is slow
-  useEffect(() => {
-    setCount(filteredImages.length)
-  }, [filteredImages.length])
-
-  useEffect(() => {
-    if (filteredImages.length === 0) {
-      setCurrent(0)
-    }
-  }, [filteredImages.length])
-
-  // Scroll to the selected index when it changes or api becomes available
-  useEffect(() => {
-    if (api && filteredImages.length > 0) {
-      const actualIndex = Math.min(
-        selectedIndex,
-        Math.max(0, filteredImages.length - 1) // Ensure index is not negative
-      )
-      api.scrollTo(actualIndex, false) // Use false for instant scroll on open
-    }
-    // Add convertedImages.length as dep: scroll might need adjustment if images load async
-  }, [api, selectedIndex, filteredImages.length])
-
-  // Early return AFTER all hooks if there are no images to display
-  if (!isCheckingImages && filteredImages.length === 0) {
+  if (status === 'empty') {
     return <div className="text-muted-foreground">No images found</div>
   }
 
-  const handleImageError = (indexToRemove: number) => {
-    setFilteredImages(prevImages =>
-      prevImages.filter((_, imageIndex) => imageIndex !== indexToRemove)
-    )
+  const handleSelect = (index: number) => {
+    if (!isLoading) {
+      setSelectedIndex(index)
+    }
   }
-
-  const baseImages = isCheckingImages ? convertedImages : filteredImages
 
   const renderImageGrid = (
     imageSubset: NormalizedImage[],
     gridClasses: string,
     startIndex: number = 0,
-    isFullMode: boolean = false, // Add flag to indicate full mode for corner rounding
-    isLoading: boolean = false
+    isFullMode: boolean = false
   ) => (
     <div className={gridClasses}>
       {imageSubset.map((image, index) => {
         const actualIndex = startIndex + index
-        // Determine corner rounding based on index in full mode 2x3 layout
-        let cornerClasses = '' // Default to no rounding
-        if (isFullMode) {
-          if (actualIndex === 0)
-            cornerClasses = 'rounded-tl-lg' // Top-left
-          else if (actualIndex === 1)
-            cornerClasses = 'rounded-tr-lg' // Top-right
-          else if (actualIndex === 2)
-            cornerClasses = 'rounded-bl-lg' // Bottom-left
-          // Index 3 (bottom-middle) gets no rounding
-          else if (actualIndex === 4) cornerClasses = 'rounded-br-lg' // Bottom-right
-        } else {
-          cornerClasses = 'rounded-lg' // Default for preview mode
-        }
+        const cornerClasses = cornerClassForIndex(actualIndex, isFullMode)
 
-        if (isLoading || !image?.url) {
+        if (isLoading || !image.url) {
           return (
-            <div
-              key={`placeholder-${startIndex}-${index}`}
-              className="aspect-video"
-            >
+            <div key={image.id} className="aspect-video">
               <div
                 className={`h-full w-full bg-muted animate-pulse shadow-sm ${cornerClasses}`}
               />
@@ -219,36 +272,31 @@ export const SearchResultsImageSection: React.FC<
           )
         }
 
+        const showPreviewOverlay =
+          displayMode === 'preview' && actualIndex === 3 && filteredCount > 4
+
         return (
-          <Dialog key={actualIndex}>
+          <Dialog key={image.id}>
             <DialogTrigger asChild>
               <div
                 className="aspect-video cursor-pointer relative"
-                onClick={() => setSelectedIndex(actualIndex)}
+                onClick={() => handleSelect(actualIndex)}
               >
                 <div className="flex-1 h-full">
                   <div className="h-full w-full">
-                    {image?.url ? (
-                      <img
-                        src={image.url}
-                        alt={`Image ${actualIndex + 1}`}
-                        // Apply specific or default rounding
-                        className={`h-full w-full object-cover shadow-sm ${cornerClasses}`}
-                        onError={() => handleImageError(actualIndex)}
-                      />
-                    ) : (
-                      <div className="w-full h-full bg-muted animate-pulse rounded-sm" />
-                    )}
+                    <img
+                      src={image.url}
+                      alt={`Image ${actualIndex + 1}`}
+                      className={`h-full w-full object-cover shadow-sm ${cornerClasses}`}
+                      onError={() => removeImage(image.id)}
+                    />
                   </div>
                 </div>
-                {displayMode === 'preview' &&
-                  actualIndex === 3 &&
-                  !isLoading &&
-                  filteredImages.length > 4 && (
-                    <div className="absolute inset-0 bg-black/30 rounded-md flex items-center justify-center text-white/80 text-sm">
-                      <PlusCircle size={24} />
-                    </div>
-                  )}
+                {!isLoading && showPreviewOverlay && (
+                  <div className="absolute inset-0 bg-black/30 rounded-md flex items-center justify-center text-white/80 text-sm">
+                    <PlusCircle size={24} />
+                  </div>
+                )}
               </div>
             </DialogTrigger>
             <DialogContent className="sm:max-w-3xl max-h-[80vh] overflow-auto">
@@ -263,25 +311,25 @@ export const SearchResultsImageSection: React.FC<
                   setApi={setApi}
                   opts={{
                     startIndex: selectedIndex,
-                    loop: filteredImages.length > 1
+                    loop: filteredCount > 1
                   }}
                   className="w-full bg-muted max-h-[60vh]"
                 >
                   <CarouselContent>
                     {filteredImages.map((img, idx) => (
-                      <CarouselItem key={`${img.url}-${idx}`}>
+                      <CarouselItem key={img.id}>
                         <div className="p-1 flex items-center justify-center h-full">
                           <img
                             src={img.url}
                             alt={`Image ${idx + 1}`}
                             className="h-auto w-full object-contain max-h-[60vh]"
-                            onError={() => handleImageError(idx)}
+                            onError={() => removeImage(img.id)}
                           />
                         </div>
                       </CarouselItem>
                     ))}
                   </CarouselContent>
-                  {filteredImages.length > 1 && (
+                  {filteredCount > 1 && (
                     <div className="absolute inset-8 flex items-center justify-between p-4">
                       <CarouselPrevious className="w-10 h-10 rounded-full shadow-sm focus:outline-hidden">
                         <span className="sr-only">Previous</span>
@@ -293,7 +341,7 @@ export const SearchResultsImageSection: React.FC<
                   )}
                 </Carousel>
                 <div className="py-2 text-center text-sm text-muted-foreground">
-                  {current} of {count}
+                  {current} of {filteredCount}
                 </div>
               </div>
             </DialogContent>
@@ -304,40 +352,18 @@ export const SearchResultsImageSection: React.FC<
   )
 
   if (displayMode === 'full') {
-    // Original 2 rows: 2 images + 3 images
-    const firstRowImages = baseImages.slice(0, 2)
-    const secondRowImages = baseImages.slice(2, 5)
+    const firstRowImages = displayImages.slice(0, 2)
+    const secondRowImages = displayImages.slice(2, 5)
 
-    // Render two rows, passing isFullMode=true to apply specific rounding
     return (
       <div className="flex flex-col gap-2">
-        {renderImageGrid(
-          firstRowImages,
-          'grid grid-cols-2 gap-2',
-          0,
-          true, // Pass true for isFullMode
-          isCheckingImages
-        )}
-        {secondRowImages.length > 0 && // Only render second row if images exist
-          renderImageGrid(
-            secondRowImages,
-            'grid grid-cols-3 gap-2',
-            2,
-            true, // Pass true for isFullMode
-            isCheckingImages
-          )}
+        {renderImageGrid(firstRowImages, 'grid grid-cols-2 gap-2', 0, true)}
+        {secondRowImages.length > 0 &&
+          renderImageGrid(secondRowImages, 'grid grid-cols-3 gap-2', 2, true)}
       </div>
     )
   }
 
-  // Default to preview mode (2x2 or 4 wide grid)
-  const previewImages = baseImages.slice(0, 4)
-  // Preview mode uses default rounding (rounded-lg), so isFullMode=false
-  return renderImageGrid(
-    previewImages,
-    'grid grid-cols-2 md:grid-cols-4 gap-2',
-    0,
-    false,
-    isCheckingImages
-  )
+  const previewImages = displayImages.slice(0, 4)
+  return renderImageGrid(previewImages, 'grid grid-cols-2 md:grid-cols-4 gap-2')
 }


### PR DESCRIPTION
## Summary
- normalize incoming search images and preload them on the client
- expose `useFilteredImages` to drop invalid URLs and keep placeholders scoped to loading state
- centralize embla bookkeeping in `useCarouselMetrics` for cleaner current/count handling