### PR TITLE
Stream related questions incrementally

### DIFF
--- a/components/related-questions.tsx
+++ b/components/related-questions.tsx
@@ -20,6 +20,23 @@ export const RelatedQuestions: React.FC<RelatedQuestionsProps> = ({
   data,
   onQuerySelect
 }) => {
+  const renderQuestionButtons = (questions: Array<{ question: string }>) =>
+    questions.map((item, index) => (
+      <div className="flex items-start w-full" key={index}>
+        <ArrowRight className="h-4 w-4 mr-2 mt-0.5 shrink-0 text-accent-foreground/50" />
+        <Button
+          variant="link"
+          className="flex-1 justify-start px-0 py-0 h-fit font-semibold text-accent-foreground/50 whitespace-normal text-left"
+          type="submit"
+          name={'related_query'}
+          value={item.question}
+          onClick={() => onQuerySelect(item.question)}
+        >
+          {item.question}
+        </Button>
+      </div>
+    ))
+
   return (
     <CollapsibleMessage
       role="assistant"
@@ -31,6 +48,24 @@ export const RelatedQuestions: React.FC<RelatedQuestionsProps> = ({
     >
       <Section title="Related" className="pt-0 pb-4">
         <div className="flex flex-col gap-2">
+          {data.status === 'streaming' && data.questions && (
+            // Show received questions immediately while the rest stream
+            <>
+              {renderQuestionButtons(data.questions)}
+              {Array.from({
+                length: Math.max(0, 3 - data.questions.length)
+              }).map((_, index) => (
+                <div
+                  className="flex items-start w-full"
+                  key={`placeholder-${index}`}
+                >
+                  <ArrowRight className="h-4 w-4 mr-2 mt-0.5 shrink-0 text-accent-foreground/50" />
+                  <Skeleton className="h-6 w-full" />
+                </div>
+              ))}
+            </>
+          )}
+
           {data.status === 'loading' && (
             <>
               {[1, 2, 3].map((_, index) => (
@@ -49,23 +84,7 @@ export const RelatedQuestions: React.FC<RelatedQuestionsProps> = ({
           )}
 
           {data.status === 'success' && data.questions && (
-            <>
-              {data.questions.map((item, index) => (
-                <div className="flex items-start w-full" key={index}>
-                  <ArrowRight className="h-4 w-4 mr-2 mt-0.5 shrink-0 text-accent-foreground/50" />
-                  <Button
-                    variant="link"
-                    className="flex-1 justify-start px-0 py-0 h-fit font-semibold text-accent-foreground/50 whitespace-normal text-left"
-                    type="submit"
-                    name={'related_query'}
-                    value={item.question}
-                    onClick={() => onQuerySelect(item.question)}
-                  >
-                    {item.question}
-                  </Button>
-                </div>
-              ))}
-            </>
+            <>{renderQuestionButtons(data.questions)}</>
           )}
         </div>
       </Section>

--- a/lib/schema/related.tsx
+++ b/lib/schema/related.tsx
@@ -1,11 +1,10 @@
 import { z } from 'zod'
 
-export const relatedSchema = z.object({
-  questions: z.array(
-    z.object({
-      question: z.string()
-    })
-  )
+export const relatedQuestionSchema = z.object({
+  question: z.string()
 })
 
+export const relatedSchema = z.array(relatedQuestionSchema).length(3)
+
+export type RelatedQuestion = z.infer<typeof relatedQuestionSchema>
 export type Related = z.infer<typeof relatedSchema>

--- a/lib/types/ai.ts
+++ b/lib/types/ai.ts
@@ -26,7 +26,7 @@ export type UIMessage<
 > = AIMessage
 
 export interface RelatedQuestionsData {
-  status: 'loading' | 'success' | 'error'
+  status: 'loading' | 'streaming' | 'success' | 'error'
   questions?: Array<{ question: string }>
 }
 


### PR DESCRIPTION
## Summary
- switch related questions generator to use streamObject for array streaming
- emit incremental data-relatedQuestions payloads as each question arrives
- update schema, types, and UI to handle streaming status and placeholders