### PR TITLE
feat: integrate Ollama model discovery with tools filtering

### DIFF
--- a/app/api/config/models/route.ts
+++ b/app/api/config/models/route.ts
@@ -5,17 +5,20 @@ import { getModels } from '@/lib/config/models'
 export async function GET() {
   try {
     const models = await getModels()
-    
-    return NextResponse.json({ models }, {
-      headers: {
-        'Cache-Control': 'public, max-age=60, s-maxage=60', // Cache for 1 minute
-        'Content-Type': 'application/json'
+
+    return NextResponse.json(
+      { models },
+      {
+        headers: {
+          'Cache-Control': 'public, max-age=60, s-maxage=60', // Cache for 1 minute
+          'Content-Type': 'application/json'
+        }
       }
-    })
+    )
   } catch (error) {
     console.error('Failed to fetch models from /api/config/models:', error)
     return NextResponse.json(
-      { error: 'Failed to fetch models' }, 
+      { error: 'Failed to fetch models' },
       { status: 500 }
     )
   }

--- a/app/api/config/models/route.ts
+++ b/app/api/config/models/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+
+import { getModels } from '@/lib/config/models'
+
+export async function GET() {
+  try {
+    const models = await getModels()
+    
+    return NextResponse.json({ models }, {
+      headers: {
+        'Cache-Control': 'public, max-age=60, s-maxage=60', // Cache for 1 minute
+        'Content-Type': 'application/json'
+      }
+    })
+  } catch (error) {
+    console.error('Failed to fetch models from /api/config/models:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch models' }, 
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/ollama/models/route.ts
+++ b/app/api/ollama/models/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
   try {
     const client = new OllamaClient(ollamaUrl)
     const ollamaModels = await client.getModels()
-    
+
     const models = []
     for (const ollamaModel of ollamaModels) {
       try {
@@ -26,7 +26,7 @@ export async function GET() {
         continue
       }
     }
-    
+
     return NextResponse.json({ models })
   } catch {
     return NextResponse.json({ models: [] })

--- a/app/api/ollama/models/route.ts
+++ b/app/api/ollama/models/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+
+import { OllamaClient } from '@/lib/ollama/client'
+import { transformOllamaModel } from '@/lib/ollama/transformer'
+
+export async function GET() {
+  const ollamaUrl = process.env.OLLAMA_BASE_URL
+  if (!ollamaUrl) {
+    return NextResponse.json({ models: [] })
+  }
+
+  try {
+    const client = new OllamaClient(ollamaUrl)
+    const ollamaModels = await client.getModels()
+    
+    const models = []
+    for (const ollamaModel of ollamaModels) {
+      try {
+        const capabilities = await client.getModelCapabilities(ollamaModel.name)
+        const transformedModel = transformOllamaModel(ollamaModel, capabilities)
+        if (transformedModel) {
+          models.push(transformedModel)
+        }
+      } catch {
+        // Skip models that fail capability detection
+        continue
+      }
+    }
+    
+    return NextResponse.json({ models })
+  } catch {
+    return NextResponse.json({ models: [] })
+  }
+}

--- a/lib/config/models.ts
+++ b/lib/config/models.ts
@@ -73,11 +73,13 @@ export async function getModels(): Promise<Model[]> {
 
     // Fetch Ollama models
     const ollamaModels = await fetchOllamaModels(baseUrlObj)
-    
+
     // Combine static and Ollama models
     const allModels = [...staticModels, ...ollamaModels]
-    
-    console.log(`Loaded ${staticModels.length} static models and ${ollamaModels.length} Ollama models`)
+
+    console.log(
+      `Loaded ${staticModels.length} static models and ${ollamaModels.length} Ollama models`
+    )
     return allModels
   } catch (error) {
     console.warn('Failed to load models:', error)
@@ -100,7 +102,10 @@ async function fetchOllamaModels(baseUrl: URL): Promise<Model[]> {
     }
 
     const ollamaApiUrl = new URL('/api/ollama/models', baseUrl)
-    console.log('Attempting to fetch Ollama models from:', ollamaApiUrl.toString())
+    console.log(
+      'Attempting to fetch Ollama models from:',
+      ollamaApiUrl.toString()
+    )
 
     const response = await fetch(ollamaApiUrl, {
       cache: 'no-store',
@@ -110,7 +115,9 @@ async function fetchOllamaModels(baseUrl: URL): Promise<Model[]> {
     })
 
     if (!response.ok) {
-      console.warn(`HTTP error when fetching Ollama models: ${response.status} ${response.statusText}`)
+      console.warn(
+        `HTTP error when fetching Ollama models: ${response.status} ${response.statusText}`
+      )
       return []
     }
 
@@ -126,4 +133,3 @@ async function fetchOllamaModels(baseUrl: URL): Promise<Model[]> {
     return []
   }
 }
-

--- a/lib/config/models.ts
+++ b/lib/config/models.ts
@@ -25,6 +25,8 @@ export async function getModels(): Promise<Model[]> {
     const modelUrl = new URL('/config/models.json', baseUrlObj)
     console.log('Attempting to fetch models from:', modelUrl.toString())
 
+    let staticModels: Model[] = []
+
     try {
       const response = await fetch(modelUrl, {
         cache: 'no-store',
@@ -51,7 +53,7 @@ export async function getModels(): Promise<Model[]> {
       const config = JSON.parse(text)
       if (Array.isArray(config.models) && config.models.every(validateModel)) {
         console.log('Successfully loaded models from URL')
-        return config.models
+        staticModels = config.models
       }
     } catch (error: any) {
       // Fallback to default models if fetch fails
@@ -65,9 +67,18 @@ export async function getModels(): Promise<Model[]> {
         defaultModels.models.every(validateModel)
       ) {
         console.log('Successfully loaded default models')
-        return defaultModels.models
+        staticModels = defaultModels.models
       }
     }
+
+    // Fetch Ollama models
+    const ollamaModels = await fetchOllamaModels(baseUrlObj)
+    
+    // Combine static and Ollama models
+    const allModels = [...staticModels, ...ollamaModels]
+    
+    console.log(`Loaded ${staticModels.length} static models and ${ollamaModels.length} Ollama models`)
+    return allModels
   } catch (error) {
     console.warn('Failed to load models:', error)
   }
@@ -76,3 +87,43 @@ export async function getModels(): Promise<Model[]> {
   console.warn('All attempts to load models failed, returning empty array')
   return []
 }
+
+/**
+ * Fetch Ollama models from the API endpoint
+ */
+async function fetchOllamaModels(baseUrl: URL): Promise<Model[]> {
+  try {
+    const ollamaUrl = process.env.OLLAMA_BASE_URL
+    if (!ollamaUrl) {
+      console.log('OLLAMA_BASE_URL not configured, skipping Ollama models')
+      return []
+    }
+
+    const ollamaApiUrl = new URL('/api/ollama/models', baseUrl)
+    console.log('Attempting to fetch Ollama models from:', ollamaApiUrl.toString())
+
+    const response = await fetch(ollamaApiUrl, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+
+    if (!response.ok) {
+      console.warn(`HTTP error when fetching Ollama models: ${response.status} ${response.statusText}`)
+      return []
+    }
+
+    const data = await response.json()
+    if (Array.isArray(data.models)) {
+      console.log(`Successfully loaded ${data.models.length} Ollama models`)
+      return data.models
+    }
+
+    return []
+  } catch (error) {
+    console.warn('Failed to fetch Ollama models:', error)
+    return []
+  }
+}
+

--- a/lib/ollama/client.ts
+++ b/lib/ollama/client.ts
@@ -1,0 +1,81 @@
+import { OllamaModel, OllamaModelCapabilities, OllamaModelsResponse, OllamaShowResponse } from './types'
+
+export class OllamaClient {
+  private baseUrl: string
+  
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl
+  }
+  
+  /**
+   * Get all available models from Ollama instance
+   * Uses GET /api/models endpoint for fast model listing
+   */
+  async getModels(): Promise<OllamaModel[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/tags`, {
+        cache: 'no-store',
+        headers: {
+          'Accept': 'application/json'
+        }
+      })
+      
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`)
+      }
+      
+      const data: OllamaModelsResponse = await response.json()
+      return data.models || []
+    } catch (error) {
+      console.error('Failed to fetch Ollama models:', error)
+      throw error
+    }
+  }
+  
+  /**
+   * Get detailed model capabilities from Ollama instance
+   * Uses POST /api/show endpoint for detailed model information
+   */
+  async getModelCapabilities(modelName: string): Promise<OllamaModelCapabilities> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/show`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({ name: modelName })
+      })
+      
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`)
+      }
+      
+      const data: OllamaShowResponse = await response.json()
+      return {
+        name: data.name,
+        capabilities: data.capabilities || [],
+        contextWindow: data.context_window || 128_000,
+        parameters: data.parameters || {}
+      }
+    } catch (error) {
+      console.error(`Failed to get capabilities for ${modelName}:`, error)
+      throw error
+    }
+  }
+  
+  /**
+   * Check if Ollama instance is available
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/tags`, {
+        method: 'HEAD',
+        cache: 'no-store'
+      })
+      return response.ok
+    } catch (error) {
+      return false
+    }
+  }
+}

--- a/lib/ollama/client.ts
+++ b/lib/ollama/client.ts
@@ -1,12 +1,17 @@
-import { OllamaModel, OllamaModelCapabilities, OllamaModelsResponse, OllamaShowResponse } from './types'
+import {
+  OllamaModel,
+  OllamaModelCapabilities,
+  OllamaModelsResponse,
+  OllamaShowResponse
+} from './types'
 
 export class OllamaClient {
   private baseUrl: string
-  
+
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl
   }
-  
+
   /**
    * Get all available models from Ollama instance
    * Uses GET /api/models endpoint for fast model listing
@@ -16,14 +21,16 @@ export class OllamaClient {
       const response = await fetch(`${this.baseUrl}/api/tags`, {
         cache: 'no-store',
         headers: {
-          'Accept': 'application/json'
+          Accept: 'application/json'
         }
       })
-      
+
       if (!response.ok) {
-        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`)
+        throw new Error(
+          `Ollama API error: ${response.status} ${response.statusText}`
+        )
       }
-      
+
       const data: OllamaModelsResponse = await response.json()
       return data.models || []
     } catch (error) {
@@ -31,26 +38,30 @@ export class OllamaClient {
       throw error
     }
   }
-  
+
   /**
    * Get detailed model capabilities from Ollama instance
    * Uses POST /api/show endpoint for detailed model information
    */
-  async getModelCapabilities(modelName: string): Promise<OllamaModelCapabilities> {
+  async getModelCapabilities(
+    modelName: string
+  ): Promise<OllamaModelCapabilities> {
     try {
       const response = await fetch(`${this.baseUrl}/api/show`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Accept': 'application/json'
+          Accept: 'application/json'
         },
         body: JSON.stringify({ name: modelName })
       })
-      
+
       if (!response.ok) {
-        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`)
+        throw new Error(
+          `Ollama API error: ${response.status} ${response.statusText}`
+        )
       }
-      
+
       const data: OllamaShowResponse = await response.json()
       return {
         name: data.name,
@@ -63,7 +74,7 @@ export class OllamaClient {
       throw error
     }
   }
-  
+
   /**
    * Check if Ollama instance is available
    */

--- a/lib/ollama/transformer.ts
+++ b/lib/ollama/transformer.ts
@@ -11,7 +11,7 @@ export function transformOllamaModel(
   capabilities?: OllamaModelCapabilities
 ): Model | null {
   const hasTools = capabilities?.capabilities.includes('tools') || false
-  
+
   if (!hasTools) {
     return null
   }

--- a/lib/ollama/transformer.ts
+++ b/lib/ollama/transformer.ts
@@ -1,0 +1,43 @@
+import { Model } from '@/lib/types/models'
+
+import { OllamaModel, OllamaModelCapabilities } from './types'
+
+/**
+ * Transform Ollama model to Morphic Model format
+ * Only includes models with tools capability (required for Morphic)
+ */
+export function transformOllamaModel(
+  ollamaModel: OllamaModel,
+  capabilities?: OllamaModelCapabilities
+): Model | null {
+  const hasTools = capabilities?.capabilities.includes('tools') || false
+  
+  if (!hasTools) {
+    return null
+  }
+
+  return {
+    id: ollamaModel.name,
+    name: formatModelName(ollamaModel.name),
+    provider: 'Ollama',
+    providerId: 'ollama',
+    enabled: true,
+    toolCallType: 'native',
+    toolCallModel: ollamaModel.name,
+    capabilities: capabilities?.capabilities || [],
+    contextWindow: capabilities?.contextWindow || 128_000
+  }
+}
+
+/**
+ * Format model name for display
+ * Convert "llama3.2:latest" to "Llama 3.2 Latest"
+ */
+function formatModelName(name: string): string {
+  return name
+    .replace(/[:]/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}

--- a/lib/ollama/types.ts
+++ b/lib/ollama/types.ts
@@ -1,0 +1,33 @@
+export interface OllamaModel {
+  name: string
+  model: string
+  modified_at: string
+  size: number
+  digest: string
+  details?: {
+    format: string
+    family: string
+    families?: string[]
+    parameter_size: string
+    quantization_level: string
+  }
+}
+
+export interface OllamaModelCapabilities {
+  name: string
+  capabilities: string[]
+  contextWindow: number
+  parameters: Record<string, any>
+  timestamp?: number
+}
+
+export interface OllamaModelsResponse {
+  models: OllamaModel[]
+}
+
+export interface OllamaShowResponse {
+  name: string
+  capabilities: string[]
+  context_window: number
+  parameters: Record<string, any>
+}

--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -6,4 +6,7 @@ export interface Model {
   enabled: boolean
   toolCallType: 'native' | 'manual'
   toolCallModel?: string
+  // Ollama-specific fields (only added when needed)
+  capabilities?: string[]
+  contextWindow?: number
 }

--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -7,9 +7,9 @@ import { groq } from '@ai-sdk/groq'
 import { createOpenAI, openai } from '@ai-sdk/openai'
 import { xai } from '@ai-sdk/xai'
 import {
-  createProviderRegistry,
-  extractReasoningMiddleware,
-  wrapLanguageModel
+    createProviderRegistry,
+    extractReasoningMiddleware,
+    wrapLanguageModel
 } from 'ai'
 import { createOllama } from 'ollama-ai-provider'
 
@@ -147,7 +147,8 @@ export function isToolCallSupported(model?: string) {
   const modelName = modelNameParts.join(':')
 
   if (provider === 'ollama') {
-    return false
+    // Ollama models are dynamically checked for tools capability
+    return true
   }
 
   if (provider === 'google') {

--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -7,9 +7,9 @@ import { groq } from '@ai-sdk/groq'
 import { createOpenAI, openai } from '@ai-sdk/openai'
 import { xai } from '@ai-sdk/xai'
 import {
-    createProviderRegistry,
-    extractReasoningMiddleware,
-    wrapLanguageModel
+  createProviderRegistry,
+  extractReasoningMiddleware,
+  wrapLanguageModel
 } from 'ai'
 import { createOllama } from 'ollama-ai-provider'
 


### PR DESCRIPTION
Add dynamic Ollama model discovery that fetches models from running Ollama instance and filters them based on "tools" capability for websearch-capabilities.. 
This includes new API endpoints and extends model interface

**In detail:** 
- Add OllamaClient for API integration with /api/tags and /api/show endpoints
- Implement dynamic model discovery with tools capability detection
- Add /api/ollama/models and /api/config/models endpoints
- Extend Model interface with capabilities and contextWindow fields
- Update registry to support Ollama tool calling
- Filter models to only include those with tools capability
- Merge static and Ollama models in unified endpoint"

**Screenshot of using morphic with a Ollama Server with several models:** 
 
![morphic_ollama_model_discovery](https://github.com/user-attachments/assets/0cd39603-c2a8-4c04-93b3-0d76a6c0dfd0)

(Models without "tools" capabilities are automatically stripped from the discovery as they can't be used for websearch)

**What may be missing:** 
The static examples (DeepSeek R1 and <OLLAMA MODEL_NAME>) for Ollama could be removed after merging this code, as they are obsolete. I kept that to show the successful combination of the static models and the dynamic discovery. 

