### PR TITLE
fix: restore cursor pointer for buttons in Tailwind v4

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -420,4 +420,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Tailwind v4: Restore pointer cursor for buttons */
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes the cursor pointer issue for buttons when using Tailwind CSS v4.

## Changes

- Added CSS rule in `@layer base` to restore `cursor: pointer` for interactive button elements
- Targets `button:not(:disabled)` and `[role="button"]:not(:disabled)` elements

## Issue

In Tailwind CSS v4, buttons no longer have `cursor: pointer` by default. This was an intentional design change to align with browser defaults. However, this breaks the expected UX behavior where buttons show a pointer cursor on hover.

## Solution

Added the following CSS to `app/globals.css`:

```css
@layer base {
  /* Tailwind v4: Restore pointer cursor for buttons */
  button:not(:disabled),
  [role="button"]:not(:disabled) {
    cursor: pointer;
  }
}
```

This follows the official recommendation from shadcn/ui and Tailwind CSS v4 migration guide.

## Testing

Verified that buttons now show pointer cursor on hover in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)