### PR TITLE
fix: Prevent unwanted scroll on mobile Safari

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -417,8 +417,14 @@
   * {
     @apply border-border;
   }
+
+  html,
   body {
     @apply bg-background text-foreground;
+    height: 100%;
+    overflow: hidden;
+    position: fixed;
+    width: 100%;
   }
 
   /* Tailwind v4: Restore pointer cursor for buttons */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,7 +45,8 @@ export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   minimumScale: 1,
-  maximumScale: 1
+  maximumScale: 1,
+  viewportFit: 'cover'
 }
 
 export default async function RootLayout({
@@ -69,7 +70,7 @@ export default async function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={cn(
-          'min-h-screen flex flex-col font-sans antialiased',
+          'h-full flex flex-col font-sans antialiased',
           fontSans.variable
         )}
       >


### PR DESCRIPTION
## Summary

Fixed an issue where the page content was scrollable on mobile Safari even when all content fit within the viewport, causing the header to scroll unnecessarily.

## Technical Details

The problem was caused by iOS Safari's dynamic address bar behavior, which changes the viewport height as the user scrolls. This caused the page to have more height than the visible viewport, triggering unwanted scroll.

**Changes made:**

1. **CSS Layout Changes** ([app/globals.css](app/globals.css#L421-L428))
   - Applied `position: fixed`, `height: 100%`, `overflow: hidden`, and `width: 100%` to both `html` and `body` elements
   - This prevents iOS Safari's address bar height changes from affecting the page layout

2. **Body Class Update** ([app/layout.tsx#L72](app/layout.tsx#L72))
   - Changed from `min-h-screen` to `h-full` for consistent fixed height

3. **Viewport Configuration** ([app/layout.tsx#L49](app/layout.tsx#L49))
   - Added `viewportFit: 'cover'` for better iOS Safari support

## Files Changed

- `app/globals.css` - Added fixed positioning and overflow control for html/body
- `app/layout.tsx` - Updated body class and viewport configuration

## Testing Notes

Please test on:
- iOS Safari (iPhone/iPad)
- Chrome on iOS
- Android browsers (to ensure no regression)

**Expected behavior:**
- No unwanted scrolling when all content fits in viewport
- Header remains fixed at the top
- No scroll bounce on iOS

## Quality Checks

✅ ESLint: Passed
✅ TypeScript: Passed  
✅ Prettier: Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)