### PR TITLE
fix: Hide scroll-to-bottom button immediately on click

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -41,6 +41,8 @@ interface ChatPanelProps {
   scrollContainerRef: React.RefObject<HTMLDivElement>
   uploadedFiles: UploadedFile[]
   setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
+  /** Function to set whether the scroll is at the bottom */
+  setIsAtBottom: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export function ChatPanel({
@@ -57,7 +59,8 @@ export function ChatPanel({
   showScrollToBottomButton,
   uploadedFiles,
   setUploadedFiles,
-  scrollContainerRef
+  scrollContainerRef,
+  setIsAtBottom
 }: ChatPanelProps) {
   const router = useRouter()
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -131,6 +134,8 @@ export function ChatPanel({
         top: scrollContainer.scrollHeight,
         behavior: 'smooth'
       })
+      // Immediately hide the button when clicked
+      setIsAtBottom(true)
     }
   }
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -451,6 +451,7 @@ export function Chat({
         uploadedFiles={uploadedFiles}
         setUploadedFiles={setUploadedFiles}
         scrollContainerRef={scrollContainerRef}
+        setIsAtBottom={setIsAtBottom}
       />
       <DragOverlay visible={isDragging} />
       <AuthModal open={showAuthModal} onOpenChange={setShowAuthModal} />


### PR DESCRIPTION
## Summary

This PR fixes an issue where the scroll-to-bottom button remained visible after being clicked during message generation. The button now hides instantly when clicked, providing better user feedback.

## Problem

In commit 558b610, a fix was added to show the scroll-to-bottom button during message generation. However, a new issue was introduced:

- When the button was clicked during message generation, it would not disappear
- The button worked correctly only when the chat was loaded (not during generation)

### Root Cause

The `useEffect` hook in `chat.tsx` that monitors `messages` changes was checking scroll position during the smooth scroll animation. When new message content was added while scrolling, the effect would recalculate and incorrectly determine that the container was not at the bottom yet, preventing the button from disappearing.

## Solution

Instead of waiting for the scroll animation to complete, the button state is now updated immediately when clicked:

1. Added `setIsAtBottom` prop to `ChatPanel` component
2. Modified `handleScrollToBottom` to call `setIsAtBottom(true)` immediately on click
3. Button now hides instantly, regardless of scroll animation state or ongoing message generation

## Technical Details

### Files Changed

- `components/chat.tsx`: Pass `setIsAtBottom` to ChatPanel
- `components/chat-panel.tsx`: 
  - Added `setIsAtBottom` to props interface
  - Modified `handleScrollToBottom` to update state immediately

### Code Changes

```typescript
// chat-panel.tsx
const handleScrollToBottom = () => {
  const scrollContainer = scrollContainerRef.current
  if (scrollContainer) {
    scrollContainer.scrollTo({
      top: scrollContainer.scrollHeight,
      behavior: 'smooth'
    })
    // Immediately hide the button when clicked
    setIsAtBottom(true)
  }
}
```

## Testing

- ✅ Linting passed
- ✅ Type checking passed
- ✅ Code formatting passed
- Manual testing recommended: Click scroll-to-bottom button during message generation and verify it disappears immediately

## Related

- Fixes issue introduced in commit 558b610
- Related to PR #727 (scroll button visibility during generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)