### PR TITLE
fix: Fix scroll listener registration to properly detect bottom position

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -41,8 +41,6 @@ interface ChatPanelProps {
   scrollContainerRef: React.RefObject<HTMLDivElement>
   uploadedFiles: UploadedFile[]
   setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
-  /** Function to set whether the scroll is at the bottom */
-  setIsAtBottom: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export function ChatPanel({
@@ -59,8 +57,7 @@ export function ChatPanel({
   showScrollToBottomButton,
   uploadedFiles,
   setUploadedFiles,
-  scrollContainerRef,
-  setIsAtBottom
+  scrollContainerRef
 }: ChatPanelProps) {
   const router = useRouter()
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -134,8 +131,6 @@ export function ChatPanel({
         top: scrollContainer.scrollHeight,
         behavior: 'smooth'
       })
-      // Immediately hide the button when clicked
-      setIsAtBottom(true)
     }
   }
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -231,7 +231,7 @@ export function Chat({
     handleScroll() // Set initial state
 
     return () => container.removeEventListener('scroll', handleScroll)
-  }, [])
+  }, [messages.length])
 
   // Check scroll position when messages change (during generation)
   useEffect(() => {
@@ -451,7 +451,6 @@ export function Chat({
         uploadedFiles={uploadedFiles}
         setUploadedFiles={setUploadedFiles}
         scrollContainerRef={scrollContainerRef}
-        setIsAtBottom={setIsAtBottom}
       />
       <DragOverlay visible={isDragging} />
       <AuthModal open={showAuthModal} onOpenChange={setShowAuthModal} />


### PR DESCRIPTION
## Summary

This PR fixes the root cause of the scroll-to-bottom button not disappearing when manually scrolling to the bottom of the chat. The issue was identified through careful analysis: the scroll event listener was only registered once during initial mount with an empty dependency array, and when the chat mounted with no messages, the listener never attached properly.

## Problem Analysis

The original issue (commit 8eeb260) attempted to fix the button not hiding by calling setIsAtBottom(true) directly on button click. However, this only masked the symptom - the scroll-to-bottom button still would not disappear when users manually scrolled to the bottom.

**Root Cause:**
1. The scroll listener in chat.tsx:216 had an empty dependency array []
2. On initial mount with no messages, scrollContainerRef.current was null
3. The effect would bail out early: if (!container) return
4. When messages later appeared, the effect never re-ran (due to [] dependencies)
5. Result: No scroll listener was ever attached, so manual scrolling never updated isAtBottom

## Changes

### Files Modified

- **components/chat.tsx**
  - Changed useEffect dependency from [] to [messages.length] (line 234)
  - Listener now re-registers when messages appear
  - Removed setIsAtBottom prop from ChatPanel (line 454)

- **components/chat-panel.tsx**
  - Removed setIsAtBottom prop from interface (line 44-45)
  - Removed manual setIsAtBottom(true) call from handleScrollToBottom (line 138)
  - Removed prop from destructuring (line 63)

## Technical Details

By changing the dependency array to [messages.length], the scroll listener effect now:
1. Re-runs whenever messages are added/removed
2. Properly attaches the listener once the scroll container exists
3. Correctly detects when users scroll to the bottom (manual or via button)
4. Updates isAtBottom state automatically through the scroll event

This eliminates the need for the workaround in commit 8eeb260 and solves both:
- Button click scrolling (already worked with the workaround)
- Manual scrolling detection (now works properly)

## Testing

**Quality Checks:** All passing
- Linting: Passed
- Type checking: Passed  
- Formatting: Passed

**Manual Testing Recommended:**
1. Start a new chat with no messages
2. Send several messages to generate content
3. Scroll up to trigger the scroll-to-bottom button appearance
4. Click the button - it should disappear as you reach the bottom
5. Scroll up again, then manually scroll to the bottom - button should disappear
6. Verify button behavior during message generation

## Impact

- Makes commit 8eeb260 unnecessary - this fix addresses the underlying issue
- No breaking changes
- No new dependencies
- Improved user experience with correct scroll detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)