### PR TITLE
refactor: clarify fetch tool PDF support and type usage

### DIFF
--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -46,6 +46,8 @@ Fetch tool usage:
 - **ONLY use fetch tool when a URL is directly provided by the user in their query**
 - Do NOT use fetch to get more details from search results
 - This keeps responses fast and efficient
+- **For PDF URLs (ending in .pdf)**: ALWAYS use \`type: "api"\` - regular type will fail on PDFs
+- **For regular web pages**: Use default \`type: "regular"\` for fast HTML fetching
 
 Citation Format (MANDATORY):
 [number](#toolCallId) - Always use this EXACT format
@@ -196,6 +198,9 @@ Fetch tool usage:
 - Use when you need deeper content analysis beyond search snippets
 - Fetch the top 2-3 most relevant/recent URLs for comprehensive coverage
 - Especially important for news, current events, and time-sensitive information
+- **For PDF URLs (ending in .pdf)**: ALWAYS use \`type: "api"\` - regular type will fail on PDFs
+- **For complex JavaScript-rendered pages**: Use \`type: "api"\` for better extraction
+- **For regular web pages**: Use default \`type: "regular"\` for fast HTML fetching
 
 When using the ask_question tool:
 - Create clear, concise questions

--- a/lib/schema/fetch.tsx
+++ b/lib/schema/fetch.tsx
@@ -7,7 +7,7 @@ export const fetchSchema = z.object({
     .enum(['regular', 'api'])
     .default('regular')
     .describe(
-      'Fetch method: "regular" (default) = fast direct HTML fetch, "api" = advanced extraction for PDFs or complex pages (requires API keys)'
+      'Fetch method: "regular" (default) = fast direct HTML fetch for simple web pages (does NOT support PDFs), "api" = advanced extraction for PDFs and complex JavaScript-rendered pages (requires Jina or Tavily API keys)'
     )
 })
 

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -82,7 +82,7 @@ async function fetchRegularData(url: string): Promise<SearchResultsType> {
     if (error instanceof Error && error.name === 'AbortError') {
       throw new Error('Request timeout after 10 seconds')
     }
-    console.error('Regular fetch error:', error)
+    console.error('Fetch error:', error)
     throw error instanceof Error ? error : new Error('Unknown fetch error')
   }
 }
@@ -115,7 +115,7 @@ async function fetchJinaReaderData(url: string): Promise<SearchResultsType> {
       images: []
     }
   } catch (error) {
-    console.error('Jina Reader API error:', error)
+    console.error('API Error:', error)
     throw error instanceof Error ? error : new Error('Jina Reader API failed')
   }
 }
@@ -150,7 +150,7 @@ async function fetchTavilyExtractData(url: string): Promise<SearchResultsType> {
       images: []
     }
   } catch (error) {
-    console.error('Tavily Extract API error:', error)
+    console.error('API Error:', error)
     throw error instanceof Error
       ? error
       : new Error('Tavily Extract API failed')
@@ -159,7 +159,7 @@ async function fetchTavilyExtractData(url: string): Promise<SearchResultsType> {
 
 export const fetchTool = tool({
   description:
-    'Fetch content from any URL. By default uses "regular" type which performs fast, direct HTML fetching without external APIs - ideal for most websites. Only use "api" type when you need: 1) PDF content extraction, 2) Complex JavaScript-rendered pages, 3) Better markdown formatting, 4) Table extraction. The "api" type requires Jina or Tavily API keys.',
+    'Fetch content from any URL. By default uses "regular" type which performs fast, direct HTML fetching without external APIs - ideal for most websites. IMPORTANT: "regular" type does NOT support PDFs and will fail on PDF URLs. Use "api" type when you need: 1) PDF content extraction (required for .pdf URLs), 2) Complex JavaScript-rendered pages, 3) Better markdown formatting, 4) Table extraction. The "api" type requires Jina or Tavily API keys and uses Jina Reader if available, otherwise falls back to Tavily Extract.',
   inputSchema: fetchSchema,
   async *execute({ url, type = 'regular' }) {
     // Yield initial fetching state


### PR DESCRIPTION
## Summary

This PR improves the documentation and guidance for the fetch tool to clearly distinguish between `regular` and `api` types, with special emphasis on PDF support requirements.

## Changes

### 1. Schema Documentation (lib/schema/fetch.tsx)
- Updated type description to explicitly state `regular` type does NOT support PDFs
- Clarified that `api` type requires Jina or Tavily API keys for PDF and complex page extraction

### 2. Tool Description (lib/tools/fetch.ts)
- Added prominent warning: "regular" type will FAIL on PDF URLs
- Emphasized `.pdf` URLs require `type: "api"`
- Documented fallback behavior: Jina Reader → Tavily Extract
- Standardized error logging:
  - `API Error:` for Jina and Tavily API failures
  - `Fetch error:` for regular fetch failures

### 3. Agent Prompts (lib/agents/prompts/search-mode-prompts.ts)

**Quick Mode:**
- Added guidance to always use `type: "api"` for PDF URLs (.pdf extension)
- Specified default `type: "regular"` for regular web pages

**Adaptive Mode:**
- Added guidance for PDF URLs requiring `type: "api"`
- Added recommendation for complex JavaScript-rendered pages
- Specified when to use default `type: "regular"`

## Technical Details

**Fetch Type Comparison:**

| Feature | `regular` | `api` |
|---------|-----------|-------|
| PDF Support | ❌ No | ✅ Yes |
| Complex JS Pages | ❌ Limited | ✅ Yes |
| API Key Required | ❌ No | ✅ Yes (Jina or Tavily) |
| Speed | ⚡ Fast | 🐢 Slower |
| Use Case | Simple HTML pages | PDFs, complex pages |

**Implementation:**
- Regular type: Direct HTML fetch with 10s timeout
- API type: Jina Reader (preferred) or Tavily Extract (fallback)

## Files Changed

- `lib/schema/fetch.tsx` - Schema description
- `lib/tools/fetch.ts` - Tool description and error logging
- `lib/agents/prompts/search-mode-prompts.ts` - Agent guidance for Quick and Adaptive modes

## Testing

✅ All quality checks passed:
- `bun lint` - No linting errors
- `bun typecheck` - No TypeScript errors  
- `bun format:check` - Code properly formatted

## Impact

This change improves the AI agent's ability to:
1. Correctly identify when to use `api` type for PDF URLs
2. Avoid failures when attempting to fetch PDF content with `regular` type
3. Make informed decisions about fetch type based on URL characteristics
4. Understand the fallback behavior for API-based extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)