### PR TITLE
fix: remove plus icon overlay from image grid

### DIFF
--- a/components/search-results-image.tsx
+++ b/components/search-results-image.tsx
@@ -11,8 +11,6 @@ import {
   useState
 } from 'react'
 
-import { PlusCircle } from 'lucide-react'
-
 import { SearchResultImage } from '@/lib/types'
 
 import {
@@ -295,9 +293,6 @@ export const SearchResultsImageSection: React.FC<
           )
         }
 
-        const showPreviewOverlay =
-          displayMode === 'preview' && actualIndex === 3 && filteredCount > 4
-
         return (
           <Dialog key={image.id}>
             <DialogTrigger asChild>
@@ -315,11 +310,6 @@ export const SearchResultsImageSection: React.FC<
                     />
                   </div>
                 </div>
-                {!isLoading && showPreviewOverlay && (
-                  <div className="absolute inset-0 bg-black/30 rounded-md flex items-center justify-center text-white/80 text-sm">
-                    <PlusCircle size={24} />
-                  </div>
-                )}
               </div>
             </DialogTrigger>
             <DialogContent className="sm:max-w-3xl max-h-[80vh] overflow-auto">


### PR DESCRIPTION
## Summary

Removed the PlusCircle icon overlay that appeared on the 4th image in the image grid preview mode. This simplifies the UI by removing the visual indicator that suggested additional images were available.

## Technical Details

### Changes Made
- **Removed overlay component**: Deleted the absolute positioned div with PlusCircle icon (lines 318-322)
- **Cleaned up imports**: Removed unused `PlusCircle` import from lucide-react
- **Removed dead code**: Deleted the `showPreviewOverlay` variable that was only used for the removed overlay

### Files Changed
- `components/search-results-image.tsx`
  - Removed overlay rendering logic
  - Removed PlusCircle import
  - Removed showPreviewOverlay variable calculation

## Visual Changes

**Before**: The 4th image in preview mode displayed a semi-transparent black overlay with a `+` icon when there were more than 4 images available.

**After**: All images display cleanly without any overlay, maintaining the same functionality for opening the image carousel dialog.

## Testing

- ✅ Lint checks passed
- ✅ TypeScript type checking passed
- ✅ Code formatting validated

### Manual Testing Recommended
- Verify image grid displays correctly in preview mode
- Confirm clicking on any image still opens the carousel dialog
- Test with both 4 images and more than 4 images to ensure no visual regressions

## Breaking Changes

None - this is a purely visual change that removes UI decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)