### PR TITLE
refactor: redesign citation popover layout

### DIFF
--- a/components/citation-link.tsx
+++ b/components/citation-link.tsx
@@ -78,44 +78,44 @@ export const CitationLink = memo(function CitationLink({
           </a>
         </PopoverTrigger>
         <PopoverContent
-          className="w-72 p-3 z-50"
-          side="top"
-          align="center"
-          sideOffset={8}
+          className="w-80 p-0 z-50 shadow-xs"
+          side="bottom"
+          align="start"
+          sideOffset={4}
           onPointerDownOutside={e => e.preventDefault()}
         >
           {citationData ? (
-            <div className="space-y-2">
-              <div className="flex items-start space-x-2">
-                <Avatar className="h-4 w-4 mt-0.5 shrink-0">
-                  <AvatarImage
-                    src={`https://www.google.com/s2/favicons?domain=${getHostname(
-                      citationData.url
-                    )}`}
-                    alt={getHostname(citationData.url)}
-                  />
-                  <AvatarFallback className="text-xs">
-                    {getHostname(citationData.url)[0]?.toUpperCase() || '?'}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="flex-1 min-w-0 space-y-1">
-                  <Link
-                    href={citationData.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm font-medium hover:underline block"
-                  >
-                    <span className="line-clamp-2">{citationData.title}</span>
-                  </Link>
-                  <p className="text-xs text-muted-foreground line-clamp-2">
-                    {citationData.content}
-                  </p>
-                  <p className="text-xs text-muted-foreground/80 truncate">
+            <Link
+              href={citationData.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block p-3 hover:bg-accent/50 transition-colors"
+            >
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Avatar className="h-4 w-4 shrink-0">
+                    <AvatarImage
+                      src={`https://www.google.com/s2/favicons?domain=${getHostname(
+                        citationData.url
+                      )}`}
+                      alt={getHostname(citationData.url)}
+                    />
+                    <AvatarFallback className="text-xs">
+                      {getHostname(citationData.url)[0]?.toUpperCase() || '?'}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-xs text-muted-foreground truncate">
                     {getHostname(citationData.url)}
-                  </p>
+                  </span>
                 </div>
+                <p className="text-sm font-medium line-clamp-1">
+                  {citationData.title}
+                </p>
+                <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
+                  {citationData.content}
+                </p>
               </div>
-            </div>
+            </Link>
           ) : null}
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
## Summary

This PR redesigns the citation popover component with an improved layout and visual hierarchy for better user experience.

## Changes

### Layout Improvements
- **Popover Position**: Changed from top to bottom for better UX
- **Width**: Increased from `w-72` to `w-80` for improved readability
- **Alignment**: Changed to `align="start"` for better positioning
- **Spacing**: Reduced `sideOffset` to 4px for tighter spacing

### Content Hierarchy Redesign
**New 3-line layout:**
1. **First line**: Favicon + Domain name (`text-xs text-muted-foreground`)
2. **Second line**: Title (`text-sm font-medium`, single-line clamp)
3. **Third line**: Content preview (`text-xs text-muted-foreground`, two-line clamp with relaxed leading)

**Previous layout** had title on the first line with favicon, which caused hierarchy confusion.

### Visual Enhancements
- **Shadow**: Reduced from `shadow-md` to `shadow-xs` for subtler appearance
- **Clickable Area**: Entire popover is now clickable as a link
- **Hover Effect**: Added `hover:bg-accent/50` transition for better feedback
- **Removed**: Redundant domain name display at bottom

### Technical Details
- Removed `p-3` from PopoverContent and moved to Link element
- Simplified structure with cleaner separation of concerns
- Maintains existing hover behavior (onMouseEnter/onMouseLeave)

## Files Changed

- `components/citation-link.tsx`: Complete popover layout redesign

## Testing

✅ Lint check passed
✅ TypeScript type check passed
✅ Code formatting verified

## Visual Changes

The new design provides:
- Better visual hierarchy with domain → title → content flow
- More compact and readable layout
- Improved hover interactions
- Subtler shadow for cleaner appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)