### PR TITLE
fix: remove client-side auth check for Docker anonymous mode

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -16,10 +16,8 @@ import {
 } from '@/lib/types/dynamic-tools'
 import { cn } from '@/lib/utils'
 
-import { useAuthCheck } from '@/hooks/use-auth-check'
 import { useFileDropzone } from '@/hooks/use-file-dropzone'
 
-import { AuthModal } from './auth-modal'
 import { ChatMessages } from './chat-messages'
 import { ChatPanel } from './chat-panel'
 import { DragOverlay } from './drag-overlay'
@@ -64,7 +62,6 @@ export function Chat({
   const [isAtBottom, setIsAtBottom] = useState(true)
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([])
   const [input, setInput] = useState('')
-  const [showAuthModal, setShowAuthModal] = useState(false)
   const [errorModal, setErrorModal] = useState<{
     open: boolean
     type: 'rate-limit' | 'auth' | 'forbidden' | 'general'
@@ -75,7 +72,6 @@ export function Chat({
     type: 'general',
     message: ''
   })
-  const { isAuthenticated } = useAuthCheck()
 
   const {
     messages,
@@ -351,12 +347,6 @@ export function Chat({
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    // Check authentication before sending message
-    if (!isAuthenticated) {
-      setShowAuthModal(true)
-      return
-    }
-
     const uploaded = uploadedFiles.filter(f => f.status === 'uploaded')
 
     if (input.trim() || uploaded.length > 0) {
@@ -471,7 +461,6 @@ export function Chat({
         onNewChat={handleNewChat}
       />
       <DragOverlay visible={isDragging} />
-      <AuthModal open={showAuthModal} onOpenChange={setShowAuthModal} />
       <ErrorModal
         open={errorModal.open}
         onOpenChange={open => setErrorModal(prev => ({ ...prev, open }))}

--- a/components/error-modal.tsx
+++ b/components/error-modal.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Link from 'next/link'
+
 import { AlertCircle, Clock, RefreshCw } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -99,27 +101,40 @@ export function ErrorModal({
           )}
         </DialogHeader>
         <DialogFooter className="flex-col gap-2">
-          {onRetry && error.type !== 'rate-limit' && (
-            <Button
-              onClick={() => {
-                onRetry()
-                onOpenChange(false)
-              }}
-              className="w-full"
-            >
-              <RefreshCw className="mr-2 size-4" />
-              Try Again
-            </Button>
+          {error.type === 'auth' ? (
+            <>
+              <Button asChild className="w-full">
+                <Link href="/auth/sign-up">Sign Up</Link>
+              </Button>
+              <Button asChild variant="outline" className="w-full">
+                <Link href="/auth/login">Sign In</Link>
+              </Button>
+            </>
+          ) : (
+            <>
+              {onRetry && error.type !== 'rate-limit' && (
+                <Button
+                  onClick={() => {
+                    onRetry()
+                    onOpenChange(false)
+                  }}
+                  className="w-full"
+                >
+                  <RefreshCw className="mr-2 size-4" />
+                  Try Again
+                </Button>
+              )}
+              <Button
+                variant={
+                  onRetry && error.type !== 'rate-limit' ? 'outline' : 'default'
+                }
+                onClick={() => onOpenChange(false)}
+                className="w-full"
+              >
+                {error.type === 'rate-limit' ? 'Understood' : 'Close'}
+              </Button>
+            </>
           )}
-          <Button
-            variant={
-              onRetry && error.type !== 'rate-limit' ? 'outline' : 'default'
-            }
-            onClick={() => onOpenChange(false)}
-            className="w-full"
-          >
-            {error.type === 'rate-limit' ? 'Understood' : 'Close'}
-          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

- Remove client-side authentication check that was blocking message submission when `ENABLE_AUTH=false`
- Add Sign Up/Sign In buttons to ErrorModal for server-side auth errors (401)

## Problem

When running Docker with `ENABLE_AUTH=false`, users were incorrectly prompted to log in when trying to send a message. The server-side `getCurrentUserId()` already properly handles anonymous mode, but the client-side `useAuthCheck` hook was checking Supabase session only, unaware of the `ENABLE_AUTH` setting.

## Solution

Remove the client-side pre-check and rely on server-side authentication. When the server returns 401, the ErrorModal now shows Sign Up/Sign In buttons instead of just a Close button.

| Scenario | Before | After |
|----------|--------|-------|
| `ENABLE_AUTH=false` (Docker) | AuthModal shown (bug) | Request sent, works ✅ |
| `ENABLE_AUTH=true` + unauthenticated | AuthModal shown | Request → 401 → ErrorModal with Sign In/Sign Up |

## Test plan

- [ ] Docker with `ENABLE_AUTH=false`: Can send messages without login prompt
- [ ] Vercel with `ENABLE_AUTH=true`: Unauthenticated users see ErrorModal with Sign In/Sign Up buttons

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)