### PR TITLE
fix: improve auth error handling in ErrorModal

### DIFF
--- a/components/error-modal.tsx
+++ b/components/error-modal.tsx
@@ -23,14 +23,21 @@ interface ErrorModalProps {
     details?: string
   }
   onRetry?: () => void
+  onAuthClose?: () => void
 }
 
 export function ErrorModal({
   open,
   onOpenChange,
   error,
-  onRetry
+  onRetry,
+  onAuthClose
 }: ErrorModalProps) {
+  const handleAuthClose = () => {
+    onOpenChange(false)
+    onAuthClose?.()
+  }
+
   const getErrorIcon = () => {
     switch (error.type) {
       case 'rate-limit':
@@ -48,7 +55,7 @@ export function ErrorModal({
       case 'rate-limit':
         return 'Rate Limit Exceeded'
       case 'auth':
-        return 'Authentication Required'
+        return 'Continue with Morphic'
       case 'forbidden':
         return 'Access Denied'
       default:
@@ -64,7 +71,7 @@ export function ErrorModal({
           'You have made too many requests. Please wait a moment before trying again.'
         )
       case 'auth':
-        return 'You need to sign in to continue using this feature.'
+        return 'To use Morphic, sign in to your account or create a new one.'
       case 'forbidden':
         return 'You do not have permission to access this resource.'
       default:
@@ -82,7 +89,16 @@ export function ErrorModal({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={open => {
+        if (!open && error.type === 'auth') {
+          handleAuthClose()
+        } else {
+          onOpenChange(open)
+        }
+      }}
+    >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-muted">


### PR DESCRIPTION
## Summary

Follow-up to #757. Improves auth error handling in ErrorModal.

- Detect 'authentication required' message in `onError` handler to properly show auth modal
- Add `onAuthClose` callback to clear messages and navigate to root on modal close
- Update auth error title/description to match previous AuthModal UX

## Changes

### ErrorModal
- Added `onAuthClose` optional prop
- Updated auth error messages:
  - Title: "Continue with Morphic"
  - Description: "To use Morphic, sign in to your account or create a new one."

### Chat
- Added `useRouter` for navigation
- Added `authentication required` detection in `onError`
- Pass `onAuthClose` to ErrorModal that clears messages and navigates to `/`

## Test plan

- [ ] With `ENABLE_AUTH=true`: Unauthenticated user sends message → Modal shows with correct title/description
- [ ] Clicking Sign Up/Sign In navigates to auth pages
- [ ] Closing modal (click outside, Escape, or X) clears messages and navigates to root

🤖 Generated with [Claude Code](https://claude.com/claude-code)