### PR TITLE
fix: handle null value for exclude_domains validation

### DIFF
--- a/lib/schema/search.tsx
+++ b/lib/schema/search.tsx
@@ -31,15 +31,15 @@ export const searchSchema = z.object({
     ),
   include_domains: z
     .array(z.string())
-    .optional()
-    .default([])
+    .nullish()
+    .transform(val => val ?? [])
     .describe(
       'A list of domains to specifically include in the search results. Default is None, which includes all domains.'
     ),
   exclude_domains: z
     .array(z.string())
-    .optional()
-    .default([])
+    .nullish()
+    .transform(val => val ?? [])
     .describe(
       "A list of domains to specifically exclude from the search results. Default is None, which doesn't exclude any domains."
     )
@@ -60,11 +60,15 @@ export const strictSearchSchema = z.object({
     .describe('The depth of the search'),
   include_domains: z
     .array(z.string())
+    .nullish()
+    .transform(val => val ?? [])
     .describe(
       'A list of domains to specifically include in the search results. Default is None, which includes all domains.'
     ),
   exclude_domains: z
     .array(z.string())
+    .nullish()
+    .transform(val => val ?? [])
     .describe(
       "A list of domains to specifically exclude from the search results. Default is None, which doesn't exclude any domains."
     )


### PR DESCRIPTION
## Summary
- Fix validation error when `exclude_domains` or `include_domains` is `null` instead of `undefined`
- Use `nullish()` with `transform()` to convert `null` values to empty arrays

## Problem
When using the search tool in follow-up queries, a validation error occurs:
```
Invalid input for tool search: Type validation failed: Value: {"query": "...", "exclude_domains": null}. 
Error message: [{ "expected": "array", "code": "invalid_type", "path": ["exclude_domains"], "message": "Invalid input: expected array, received null" }]
```

## Solution
Changed from `.optional().default([])` to `.nullish().transform(val => val ?? [])` which handles both `undefined` and `null` values.

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Prettier format check passes
- [x] All 136 tests pass
- [x] Production build succeeds

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)