### PR TITLE
fix: keep reasoning in pruneMessages for OpenAI compatibility

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -138,11 +138,13 @@ export async function createChatStreamResponse(
         // Convert to model messages and apply context window management
         let modelMessages = await convertToModelMessages(messagesToModel)
 
-        // Prune messages to remove unnecessary reasoning, tool calls, and empty messages
+        // Prune messages to remove unnecessary tool calls and empty messages
         // This reduces token usage while keeping recent context
+        // Note: reasoning is kept ('none') for OpenAI reasoning model compatibility
+        // (removing reasoning without its paired tool-call causes API errors)
         modelMessages = pruneMessages({
           messages: modelMessages,
-          reasoning: 'before-last-message', // Keep reasoning in last message for LLM context
+          reasoning: 'none', // Keep all reasoning for OpenAI compatibility
           toolCalls: 'before-last-2-messages', // Keep recent tool calls (last 2 messages)
           emptyMessages: 'remove' // Remove messages that become empty after pruning
         })


### PR DESCRIPTION
## Summary
- Change `reasoning` option from `'before-last-message'` to `'none'` in `pruneMessages` call
- This fixes OpenAI API errors with reasoning models (GPT-5, o1, o3)

## Problem
OpenAI reasoning models require reasoning parts and their paired tool-calls to be kept together. When `pruneMessages` removes only reasoning parts (keeping tool-calls), it causes validation errors:

```
Item 'rs_...' of type 'reasoning' was provided without its required following item.
```

## Solution
Keep all reasoning parts by setting `reasoning: 'none'`. Tool-calls are still pruned for token savings.

## References
- Related AI SDK issue: https://github.com/vercel/ai/issues/11036

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Prettier format check passes
- [x] All 136 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)