### PR TITLE
fix: strip reasoning parts for OpenAI models to fix multi-turn errors

### DIFF
--- a/lib/streaming/helpers/strip-reasoning-parts.ts
+++ b/lib/streaming/helpers/strip-reasoning-parts.ts
@@ -1,0 +1,30 @@
+import { UIMessage } from 'ai'
+
+/**
+ * Strips reasoning parts from UIMessages for OpenAI models.
+ *
+ * OpenAI's Responses API requires reasoning items and their following items
+ * (tool-calls or text) to be kept together. The AI SDK's convertToModelMessages
+ * doesn't properly handle these requirements, causing errors like:
+ * "Item 'rs_...' of type 'reasoning' was provided without its required following item"
+ *
+ * By stripping reasoning parts before conversion, we avoid this compatibility issue.
+ *
+ * @see https://github.com/vercel/ai/issues/11036
+ */
+export function stripReasoningParts(messages: UIMessage[]): UIMessage[] {
+  return messages.map(msg => {
+    if (msg.role !== 'assistant' || !msg.parts) {
+      return msg
+    }
+
+    const filteredParts = msg.parts.filter(part => part.type !== 'reasoning')
+
+    // If all parts were reasoning, keep the original message
+    if (filteredParts.length === 0) {
+      return msg
+    }
+
+    return { ...msg, parts: filteredParts }
+  })
+}


### PR DESCRIPTION
## Summary

OpenAI's Responses API requires reasoning items and their following items (tool-calls or text) to be kept together. When sending multi-turn conversations back to OpenAI, the AI SDK's `convertToModelMessages` doesn't properly handle these requirements, causing errors like:

```
Item 'rs_...' of type 'reasoning' was provided without its required following item
```

## Changes

- Adds `stripReasoningParts` helper function to remove reasoning from UIMessages before conversion
- Applies the fix only for OpenAI models (`providerId: openai`)
- Restores `pruneMessages` with `reasoning: 'before-last-message'` for all models

## Related Issues

- https://github.com/vercel/ai/issues/11036

## Test Plan

- [x] Tested with OpenAI GPT-5 models in multi-turn conversations
- [x] Verified that follow-up questions no longer cause reasoning errors
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)