### PR TITLE
feat: switch AI provider from OpenAI to Google Gemini 3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.33",
         "@ai-sdk/gateway": "^3.0.29",
-        "@ai-sdk/google": "^3.0.18",
+        "@ai-sdk/google": "^3.0.22",
         "@ai-sdk/openai": "^3.0.23",
         "@ai-sdk/react": "^3.0.66",
         "@aws-sdk/client-s3": "^3.850.0",
@@ -102,7 +102,7 @@
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.29", "", { "dependencies": { "@ai-sdk/provider": "3.0.6", "@ai-sdk/provider-utils": "4.0.11", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zf6yXT+7DcVGWG7ntxVCYC48X/opsWlO5ePvgH8W9DaEVUtkemqKUEzBqowQ778PkZo8sqMnRfD0+fi9HamRRQ=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@3.0.18", "", { "dependencies": { "@ai-sdk/provider": "3.0.6", "@ai-sdk/provider-utils": "4.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-g36Arlv38wjnqAhNlxMkfTvmWpMbD+FTFoXLppZ8dZhMQbr/UI5dEtFAByU1/lWeDyOmj/uTWzAuRTyJRw7OLA=="],
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.22", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.14" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-g1N5P/jfTiH4qwdv4WT3hkKzzAbITFz457NomtBfjP8Q3SCzdbU9oPK5ACBMG8RN5mc2QPL6DLtM3Hf5T8KPmw=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.6", "@ai-sdk/provider-utils": "4.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vFfFadJH+hbrgI4lhC9H/r8qPzuFJFUwZNS8oMI8KujO/woovbE1EWOOGMRGtNVL8PrhhxBfgJzvOKdux3c1gw=="],
 
@@ -2283,6 +2283,10 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.14", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7bzKd9lgiDeXM7O4U4nQ8iTxguAOkg8LZGD9AfDVZYjO5cKYRwBPwVjboFcVrxncRHu0tYxZtXZtiLKpG4pEng=="],
 
     "@antfu/install-pkg/tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
 

--- a/config/models/default.json
+++ b/config/models/default.json
@@ -4,62 +4,38 @@
     "byMode": {
       "quick": {
         "speed": {
-          "id": "gpt-5-mini",
-          "name": "GPT-5 mini",
-          "provider": "OpenAI",
-          "providerId": "openai",
-          "providerOptions": {
-            "openai": {
-              "reasoningEffort": "low",
-              "reasoningSummary": "auto"
-            }
-          }
+          "id": "gemini-3.0-flash",
+          "name": "Gemini 3.0 Flash",
+          "provider": "Google",
+          "providerId": "google"
         },
         "quality": {
-          "id": "gpt-5",
-          "name": "GPT-5",
-          "provider": "OpenAI",
-          "providerId": "openai",
-          "providerOptions": {
-            "openai": {
-              "reasoningEffort": "low",
-              "reasoningSummary": "auto"
-            }
-          }
+          "id": "gemini-3.0-pro",
+          "name": "Gemini 3.0 Pro",
+          "provider": "Google",
+          "providerId": "google"
         }
       },
       "adaptive": {
         "speed": {
-          "id": "gpt-5-mini",
-          "name": "GPT-5 mini",
-          "provider": "OpenAI",
-          "providerId": "openai",
-          "providerOptions": {
-            "openai": {
-              "reasoningEffort": "low",
-              "reasoningSummary": "auto"
-            }
-          }
+          "id": "gemini-3.0-flash",
+          "name": "Gemini 3.0 Flash",
+          "provider": "Google",
+          "providerId": "google"
         },
         "quality": {
-          "id": "gpt-5",
-          "name": "GPT-5",
-          "provider": "OpenAI",
-          "providerId": "openai",
-          "providerOptions": {
-            "openai": {
-              "reasoningEffort": "medium",
-              "reasoningSummary": "auto"
-            }
-          }
+          "id": "gemini-3.0-pro",
+          "name": "Gemini 3.0 Pro",
+          "provider": "Google",
+          "providerId": "google"
         }
       }
     },
     "relatedQuestions": {
-      "id": "gpt-4o-mini",
-      "name": "GPT-4o mini",
-      "provider": "OpenAI",
-      "providerId": "openai"
+      "id": "gemini-3.0-flash",
+      "name": "Gemini 3.0 Flash",
+      "provider": "Google",
+      "providerId": "google"
     }
   }
 }

--- a/lib/utils/model-selection.ts
+++ b/lib/utils/model-selection.ts
@@ -7,16 +7,10 @@ import { SearchMode } from '@/lib/types/search'
 import { isProviderEnabled } from '@/lib/utils/registry'
 
 const DEFAULT_MODEL: Model = {
-  id: 'gpt-5-mini',
-  name: 'GPT-5 mini',
-  provider: 'OpenAI',
-  providerId: 'openai',
-  providerOptions: {
-    openai: {
-      reasoningEffort: 'low',
-      reasoningSummary: 'auto'
-    }
-  }
+  id: 'gemini-3.0-flash',
+  name: 'Gemini 3.0 Flash',
+  provider: 'Google',
+  providerId: 'google'
 }
 
 const VALID_MODEL_TYPES: ModelType[] = ['speed', 'quality']

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.33",
     "@ai-sdk/gateway": "^3.0.29",
-    "@ai-sdk/google": "^3.0.18",
+    "@ai-sdk/google": "^3.0.22",
     "@ai-sdk/openai": "^3.0.23",
     "@ai-sdk/react": "^3.0.66",
     "@aws-sdk/client-s3": "^3.850.0",


### PR DESCRIPTION
- Update default model config to use gemini-3.0-flash (speed) and gemini-3.0-pro (quality)
- Update DEFAULT_MODEL fallback in model-selection.ts to Gemini 3.0 Flash
- Upgrade @ai-sdk/google from v3.0.18 to v3.0.22 for latest Gemini 3 support