### PR TITLE
Enable includeThoughts for Gemini 3.x cloud models

### DIFF
--- a/config/models/cloud.json
+++ b/config/models/cloud.json
@@ -7,13 +7,27 @@
           "id": "gemini-3.1-flash-lite-preview",
           "name": "Gemini 3.1 Flash Lite Preview",
           "provider": "Google",
-          "providerId": "google"
+          "providerId": "google",
+          "providerOptions": {
+            "google": {
+              "thinkingConfig": {
+                "includeThoughts": true
+              }
+            }
+          }
         },
         "quality": {
           "id": "gemini-3.1-pro-preview",
           "name": "Gemini 3.1 Pro Preview",
           "provider": "Google",
-          "providerId": "google"
+          "providerId": "google",
+          "providerOptions": {
+            "google": {
+              "thinkingConfig": {
+                "includeThoughts": true
+              }
+            }
+          }
         }
       },
       "adaptive": {
@@ -21,7 +35,14 @@
           "id": "gemini-3-flash-preview",
           "name": "Gemini 3 Flash Preview",
           "provider": "Google",
-          "providerId": "google"
+          "providerId": "google",
+          "providerOptions": {
+            "google": {
+              "thinkingConfig": {
+                "includeThoughts": true
+              }
+            }
+          }
         },
         "quality": {
           "id": "gpt-5.2",


### PR DESCRIPTION
## Summary
- Add `thinkingConfig.includeThoughts: true` to all Gemini 3.x cloud models (quick/speed, quick/quality, adaptive/speed)
- Without this setting, Gemini 3.x models do not surface their reasoning process in responses
- Reference: https://ai.google.dev/gemini-api/docs/gemini-3

## Test plan
- [ ] Verify Quick mode speed (Gemini 3.1 Flash Lite) returns thought summaries
- [ ] Verify Quick mode quality (Gemini 3.1 Pro) returns thought summaries
- [ ] Verify Adaptive mode speed (Gemini 3 Flash) returns thought summaries
- [ ] Confirm no regressions in Adaptive mode quality (GPT-5.2, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)