### PR TITLE
Fix guest rate limit not showing auth dialog

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -138,7 +138,8 @@ export function Chat({
       const isAuthError =
         error.message?.includes('401') ||
         errorMessage.includes('unauthorized') ||
-        errorMessage.includes('authentication required')
+        errorMessage.includes('authentication required') ||
+        errorMessage.includes('sign in to continue')
 
       if (isRateLimit) {
         // Try to parse JSON error response for quality mode rate limit


### PR DESCRIPTION
## Summary
- Fix guest rate limit error not triggering the auth dialog
- The guest limit response contains "Please sign in to continue." but onError did not match this message, falling through to a generic toast
- Add "sign in to continue" to the isAuthError detection in chat.tsx

## Root cause
- guest-limit.ts returns status 401 with body {"error":"Please sign in to continue."}
- AI SDK HttpChatTransport throws new Error(responseBodyText) — status code is NOT included in error.message
- onError checked for 429, rate limit, 401, unauthorized — none matched the JSON body text

## Test plan
- [x] TypeScript type check passes
- [x] All 141 tests pass
- [ ] Manual: Set GUEST_CHAT_DAILY_LIMIT=1, exceed limit as guest, verify auth dialog appears

Generated with [Claude Code](https://claude.com/claude-code)