### PR TITLE
Authenticate upload requests before storage config checks

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -14,6 +14,11 @@ const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'application/pdf']
 
 export async function POST(req: NextRequest) {
   try {
+    const userId = await getCurrentUserId()
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
     if (!isObjectStorageConfigured()) {
       return NextResponse.json(
         {
@@ -25,10 +30,6 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    const userId = await getCurrentUserId()
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
     const contentType = req.headers.get('content-type') || ''
     if (!contentType.includes('multipart/form-data')) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- Move authentication to run before object-storage configuration validation in the upload API.
- Ensure unauthenticated requests consistently receive `401 Unauthorized`.
- Avoid exposing storage configuration details to unauthenticated callers.

This addresses the unresolved review feedback from merged PR #790:
- https://github.com/miurla/morphic/pull/790#discussion_r3005795808

## Validation
- `bun lint`
- `bun typecheck`