### PR TITLE
refactor: replace createUIMessageStream + writer.merge with toUIMessageStreamResponse

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -1,12 +1,8 @@
 import {
   consumeStream,
   convertToModelMessages,
-  createUIMessageStream,
-  createUIMessageStreamResponse,
   pruneMessages,
-  smoothStream,
-  UIMessage,
-  UIMessageStreamWriter
+  smoothStream
 } from 'ai'
 import { randomUUID } from 'crypto'
 import { Langfuse } from 'langfuse'
@@ -106,141 +102,134 @@ export async function createChatStreamResponse(
     trigger,
     initialChat,
     abortSignal,
-    parentTraceId, // Add parent trace ID to context
+    parentTraceId,
     isNewChat
   }
 
   // Declare titlePromise in outer scope for onFinish access
   let titlePromise: Promise<string> | undefined
 
-  // Create the stream
-  const stream = createUIMessageStream<UIMessage>({
-    execute: async ({ writer }: { writer: UIMessageStreamWriter }) => {
-      try {
-        // Prepare messages for the model
-        const prepareStart = performance.now()
-        perfLog(
-          `prepareMessages - Invoked: trigger=${trigger}, isNewChat=${isNewChat}`
+  try {
+    // Prepare messages for the model
+    const prepareStart = performance.now()
+    perfLog(
+      `prepareMessages - Invoked: trigger=${trigger}, isNewChat=${isNewChat}`
+    )
+    const messagesToModel = await prepareMessages(context, message)
+    perfTime('prepareMessages completed (stream)', prepareStart)
+
+    // Get the researcher agent with parent trace ID and search mode.
+    const researchAgent = researcher({
+      model: context.modelId,
+      modelConfig: model,
+      parentTraceId,
+      searchMode
+    })
+
+    // For OpenAI models, strip reasoning parts from UIMessages before conversion
+    // OpenAI's Responses API requires reasoning items and their following items to be kept together
+    // See: https://github.com/vercel/ai/issues/11036
+    const isOpenAI = context.modelId.startsWith('openai:')
+    const messagesWithoutSpec = stripSpecFromMessages(messagesToModel)
+    const messagesToConvert = isOpenAI
+      ? stripReasoningParts(messagesWithoutSpec)
+      : messagesWithoutSpec
+
+    // Convert to model messages and apply context window management
+    let modelMessages = await convertToModelMessages(messagesToConvert)
+
+    // Prune messages to reduce token usage while keeping recent context
+    modelMessages = pruneMessages({
+      messages: modelMessages,
+      reasoning: 'before-last-message',
+      toolCalls: 'before-last-2-messages',
+      emptyMessages: 'remove'
+    })
+
+    if (shouldTruncateMessages(modelMessages, model)) {
+      const maxTokens = getMaxAllowedTokens(model)
+      const originalCount = modelMessages.length
+      modelMessages = truncateMessages(modelMessages, maxTokens, model.id)
+
+      if (process.env.NODE_ENV === 'development') {
+        console.log(
+          `Context window limit reached. Truncating from ${originalCount} to ${modelMessages.length} messages`
         )
-        const messagesToModel = await prepareMessages(context, message)
-        perfTime('prepareMessages completed (stream)', prepareStart)
+      }
+    }
 
-        // Get the researcher agent with parent trace ID and search mode.
-        const researchAgent = researcher({
-          model: context.modelId,
-          modelConfig: model,
-          parentTraceId,
-          searchMode
-        })
+    // Start title generation in parallel if it's a new chat
+    if (!initialChat && message) {
+      const userContent = getTextFromParts(message.parts)
+      titlePromise = generateChatTitle({
+        userMessageContent: userContent,
+        modelId: context.modelId,
+        abortSignal,
+        parentTraceId
+      }).catch(error => {
+        console.error('Error generating title:', error)
+        return DEFAULT_CHAT_TITLE
+      })
+    }
 
-        // For OpenAI models, strip reasoning parts from UIMessages before conversion
-        // OpenAI's Responses API requires reasoning items and their following items to be kept together
-        // See: https://github.com/vercel/ai/issues/11036
-        const isOpenAI = context.modelId.startsWith('openai:')
-        const messagesWithoutSpec = stripSpecFromMessages(messagesToModel)
-        const messagesToConvert = isOpenAI
-          ? stripReasoningParts(messagesWithoutSpec)
-          : messagesWithoutSpec
+    const llmStart = performance.now()
+    perfLog(
+      `researchAgent.stream - Start: model=${context.modelId}, searchMode=${searchMode}`
+    )
+    const result = await researchAgent.stream({
+      messages: modelMessages,
+      abortSignal,
+      experimental_transform: smoothStream({ chunking: 'word' })
+    })
+    result.consumeStream()
+    perfTime('researchAgent.stream completed', llmStart)
 
-        // Convert to model messages and apply context window management
-        let modelMessages = await convertToModelMessages(messagesToConvert)
-
-        // Prune messages to reduce token usage while keeping recent context
-        modelMessages = pruneMessages({
-          messages: modelMessages,
-          reasoning: 'before-last-message',
-          toolCalls: 'before-last-2-messages',
-          emptyMessages: 'remove'
-        })
-
-        if (shouldTruncateMessages(modelMessages, model)) {
-          const maxTokens = getMaxAllowedTokens(model)
-          const originalCount = modelMessages.length
-          modelMessages = truncateMessages(modelMessages, maxTokens, model.id)
-
-          if (process.env.NODE_ENV === 'development') {
-            console.log(
-              `Context window limit reached. Truncating from ${originalCount} to ${modelMessages.length} messages`
-            )
+    return result.toUIMessageStreamResponse({
+      messageMetadata: ({ part }) => {
+        if (part.type === 'start') {
+          return {
+            traceId: parentTraceId,
+            searchMode,
+            modelId: context.modelId
           }
         }
+      },
+      onFinish: async ({ responseMessage, isAborted }) => {
+        try {
+          if (isAborted || !responseMessage) return
 
-        // Start title generation in parallel if it's a new chat
-        if (!initialChat && message) {
-          const userContent = getTextFromParts(message.parts)
-          titlePromise = generateChatTitle({
-            userMessageContent: userContent,
-            modelId: context.modelId,
-            abortSignal,
-            parentTraceId
-          }).catch(error => {
-            console.error('Error generating title:', error)
-            return DEFAULT_CHAT_TITLE
-          })
+          // Persist stream results to database
+          await persistStreamResults(
+            responseMessage,
+            chatId,
+            userId,
+            titlePromise,
+            parentTraceId,
+            searchMode,
+            context.modelId,
+            context.pendingInitialSave,
+            context.pendingInitialUserMessage
+          )
+        } finally {
+          if (langfuse) {
+            await langfuse.flushAsync()
+          }
         }
-
-        const llmStart = performance.now()
-        perfLog(
-          `researchAgent.stream - Start: model=${context.modelId}, searchMode=${searchMode}`
-        )
-        const result = await researchAgent.stream({
-          messages: modelMessages,
-          abortSignal,
-          experimental_transform: smoothStream({ chunking: 'word' })
-        })
-        result.consumeStream()
-        // Stream with the research agent, including metadata
-        writer.merge(
-          result.toUIMessageStream({
-            messageMetadata: ({ part }) => {
-              // Send metadata when streaming starts
-              if (part.type === 'start') {
-                return {
-                  traceId: parentTraceId,
-                  searchMode,
-                  modelId: context.modelId
-                }
-              }
-            }
-          })
-        )
-
-        await result.response
-        perfTime('researchAgent.stream completed', llmStart)
-      } catch (error) {
-        console.error('Stream execution error:', error)
-        throw error // This error will be handled by the onError callback
-      } finally {
-        // Flush Langfuse traces if enabled
-        if (langfuse) {
-          await langfuse.flushAsync()
-        }
-      }
-    },
-    onError: (error: any) => {
-      // console.error('Stream error:', error)
-      return error instanceof Error ? error.message : String(error)
-    },
-    onFinish: async ({ responseMessage, isAborted }) => {
-      if (isAborted || !responseMessage) return
-
-      // Persist stream results to database
-      await persistStreamResults(
-        responseMessage,
-        chatId,
-        userId,
-        titlePromise,
-        parentTraceId,
-        searchMode,
-        context.modelId,
-        context.pendingInitialSave,
-        context.pendingInitialUserMessage
-      )
+      },
+      onError: (error: unknown) => {
+        return error instanceof Error ? error.message : String(error)
+      },
+      consumeSseStream: consumeStream
+    })
+  } catch (error) {
+    if (langfuse) {
+      await langfuse.flushAsync()
     }
-  })
-
-  return createUIMessageStreamResponse({
-    stream,
-    consumeSseStream: consumeStream
-  })
+    console.error('Stream execution error:', error)
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    return new Response(errorMessage, {
+      status: 500,
+      statusText: 'Internal Server Error'
+    })
+  }
 }

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -182,7 +182,6 @@ export async function createChatStreamResponse(
       experimental_transform: smoothStream({ chunking: 'word' })
     })
     result.consumeStream()
-    perfTime('researchAgent.stream completed', llmStart)
 
     return result.toUIMessageStreamResponse({
       messageMetadata: ({ part }) => {
@@ -196,6 +195,7 @@ export async function createChatStreamResponse(
       },
       onFinish: async ({ responseMessage, isAborted }) => {
         try {
+          perfTime('researchAgent.stream completed', llmStart)
           if (isAborted || !responseMessage) return
 
           // Persist stream results to database

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -1,12 +1,9 @@
+import type { UIMessage } from 'ai'
 import {
   consumeStream,
   convertToModelMessages,
-  createUIMessageStream,
-  createUIMessageStreamResponse,
   pruneMessages,
-  smoothStream,
-  UIMessage,
-  UIMessageStreamWriter
+  smoothStream
 } from 'ai'
 import { randomUUID } from 'crypto'
 import { Langfuse } from 'langfuse'
@@ -64,70 +61,69 @@ export async function createEphemeralChatStreamResponse(
     })
   }
 
-  const stream = createUIMessageStream<UIMessage>({
-    execute: async ({ writer }: { writer: UIMessageStreamWriter }) => {
-      try {
-        const isOpenAI = `${model.providerId}:${model.id}`.startsWith('openai:')
-        const messagesWithoutSpec = stripSpecFromMessages(messages)
-        const messagesToConvert = isOpenAI
-          ? stripReasoningParts(messagesWithoutSpec)
-          : messagesWithoutSpec
+  try {
+    const isOpenAI = `${model.providerId}:${model.id}`.startsWith('openai:')
+    const messagesWithoutSpec = stripSpecFromMessages(messages)
+    const messagesToConvert = isOpenAI
+      ? stripReasoningParts(messagesWithoutSpec)
+      : messagesWithoutSpec
 
-        let modelMessages = await convertToModelMessages(messagesToConvert)
+    let modelMessages = await convertToModelMessages(messagesToConvert)
 
-        modelMessages = pruneMessages({
-          messages: modelMessages,
-          reasoning: 'before-last-message',
-          toolCalls: 'before-last-2-messages',
-          emptyMessages: 'remove'
-        })
+    modelMessages = pruneMessages({
+      messages: modelMessages,
+      reasoning: 'before-last-message',
+      toolCalls: 'before-last-2-messages',
+      emptyMessages: 'remove'
+    })
 
-        if (shouldTruncateMessages(modelMessages, model)) {
-          const maxTokens = getMaxAllowedTokens(model)
-          modelMessages = truncateMessages(modelMessages, maxTokens, model.id)
+    if (shouldTruncateMessages(modelMessages, model)) {
+      const maxTokens = getMaxAllowedTokens(model)
+      modelMessages = truncateMessages(modelMessages, maxTokens, model.id)
+    }
+
+    const researchAgent = researcher({
+      model: `${model.providerId}:${model.id}`,
+      modelConfig: model,
+      parentTraceId,
+      searchMode
+    })
+
+    const result = await researchAgent.stream({
+      messages: modelMessages,
+      abortSignal,
+      experimental_transform: smoothStream({ chunking: 'word' })
+    })
+    result.consumeStream()
+
+    return result.toUIMessageStreamResponse({
+      messageMetadata: ({ part }) => {
+        if (part.type === 'start') {
+          return {
+            traceId: parentTraceId,
+            searchMode,
+            modelId: `${model.providerId}:${model.id}`
+          }
         }
-
-        const researchAgent = researcher({
-          model: `${model.providerId}:${model.id}`,
-          modelConfig: model,
-          parentTraceId,
-          searchMode
-        })
-
-        const result = await researchAgent.stream({
-          messages: modelMessages,
-          abortSignal,
-          experimental_transform: smoothStream({ chunking: 'word' })
-        })
-        result.consumeStream()
-        writer.merge(
-          result.toUIMessageStream({
-            messageMetadata: ({ part }) => {
-              if (part.type === 'start') {
-                return {
-                  traceId: parentTraceId,
-                  searchMode,
-                  modelId: `${model.providerId}:${model.id}`
-                }
-              }
-            }
-          })
-        )
-
-        await result.response
-      } finally {
+      },
+      onFinish: async () => {
         if (langfuse) {
           await langfuse.flushAsync()
         }
-      }
-    },
-    onError: (error: any) => {
-      return error instanceof Error ? error.message : String(error)
+      },
+      onError: (error: unknown) => {
+        return error instanceof Error ? error.message : String(error)
+      },
+      consumeSseStream: consumeStream
+    })
+  } catch (error) {
+    if (langfuse) {
+      await langfuse.flushAsync()
     }
-  })
-
-  return createUIMessageStreamResponse({
-    stream,
-    consumeSseStream: consumeStream
-  })
+    const message = error instanceof Error ? error.message : String(error)
+    return new Response(message, {
+      status: 500,
+      statusText: 'Internal Server Error'
+    })
+  }
 }


### PR DESCRIPTION
## Summary
- Replace `createUIMessageStream` + `writer.merge(result.toUIMessageStream())` with `result.toUIMessageStreamResponse()` in both chat and ephemeral stream handlers
- Remove `UIMessageStreamWriter`, `createUIMessageStream`, and `createUIMessageStreamResponse` imports
- Move `onFinish`, `messageMetadata`, and `onError` directly into `toUIMessageStreamResponse()` options

Closes #804

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun format:check` passes
- [x] `bun run test` passes (167 tests)
- [ ] Manual: verify streaming, metadata (traceId, searchMode, modelId), and chat persistence work correctly