### PR TITLE
fix: prevent iOS Safari viewport shift when keyboard dismisses

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -73,7 +73,7 @@ export default async function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={cn(
-          'min-h-screen flex flex-col font-sans antialiased overflow-hidden',
+          'fixed inset-0 flex flex-col font-sans antialiased overflow-hidden',
           fontSans.variable
         )}
       >

--- a/components/artifact/chat-artifact-container.tsx
+++ b/components/artifact/chat-artifact-container.tsx
@@ -131,7 +131,7 @@ export function ChatArtifactContainer({
   }, [containerElement, isResizing])
 
   return (
-    <div className="flex-1 min-h-0 min-w-0 h-screen flex">
+    <div className="flex-1 min-h-0 min-w-0 h-full flex">
       <div className="absolute p-4 z-50 transition-opacity duration-1000">
         {hasUser && (!open || isMobileSidebar) && (
           <SidebarTrigger className="animate-fade-in" />


### PR DESCRIPTION
## Summary
- Use `fixed inset-0` on body instead of `min-h-screen` to prevent iOS Safari from scrolling the window during virtual keyboard show/hide
- Change `h-screen` to `h-full` in artifact container to inherit height from fixed parent

## Problem
On iOS Safari, focusing an input field triggers the keyboard, which causes the browser to scroll the window. When the keyboard is dismissed, the scroll position fails to restore, pushing content behind the iOS status bar. This doesn't reproduce on desktop browsers.

## Test plan
- [ ] Open on iOS Safari, focus input, dismiss keyboard — verify no status bar overlap
- [ ] Verify desktop layout is unaffected