### PR TITLE
fix: change inspector panel Minimize button to Close

### DIFF
--- a/components/inspector/inspector-panel.tsx
+++ b/components/inspector/inspector-panel.tsx
@@ -4,8 +4,8 @@ import {
   LightbulbIcon,
   ListTodo,
   MessageSquare,
-  Minimize2,
-  Search
+  Search,
+  X
 } from 'lucide-react'
 
 import { Separator } from '@/components/ui/separator'
@@ -71,9 +71,9 @@ export function InspectorPanel() {
               size="icon"
               onClick={close}
               aria-label="Close panel"
-              tooltipContent="Minimize"
+              tooltipContent="Close"
             >
-              <Minimize2 className="h-4 w-4" />
+              <X className="h-4 w-4" />
             </TooltipButton>
           </div>
           <Separator className="my-1 bg-border/50" />

--- a/components/inspector/inspector-panel.tsx
+++ b/components/inspector/inspector-panel.tsx
@@ -73,7 +73,7 @@ export function InspectorPanel() {
               aria-label="Close panel"
               tooltipContent="Close"
             >
-              <X className="h-4 w-4" />
+              <X className="size-4" />
             </TooltipButton>
           </div>
           <Separator className="my-1 bg-border/50" />

--- a/components/inspector/inspector-panel.tsx
+++ b/components/inspector/inspector-panel.tsx
@@ -1,12 +1,6 @@
 'use client'
 
-import {
-  LightbulbIcon,
-  ListTodo,
-  MessageSquare,
-  Search,
-  X
-} from 'lucide-react'
+import { LightbulbIcon, ListTodo, MessageSquare, Search, X } from 'lucide-react'
 
 import { Separator } from '@/components/ui/separator'
 import { TooltipProvider } from '@/components/ui/tooltip'


### PR DESCRIPTION
## Summary
- Replace "Minimize" tooltip with "Close" on the inspector panel button to match its actual behavior
- Replace `Minimize2` icon with `X` icon for clearer intent

## Test plan
- [ ] Open a search result page and verify the inspector panel close button shows "Close" tooltip on hover
- [ ] Verify the X icon renders correctly
- [ ] Verify clicking the button still closes the panel as expected