### PR TITLE
feat: add collapsible user messages with 3-line clamp

### DIFF
--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import TextareaAutosize from 'react-textarea-autosize'
 
-import { Check, Copy, Pencil } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, Copy, Pencil } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
@@ -26,7 +26,15 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
   const [isComposing, setIsComposing] = useState(false)
   const [enterDisabled, setEnterDisabled] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [isClamped, setIsClamped] = useState(false)
   const enterResetTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const contentRef = useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      setIsClamped(node.scrollHeight > node.clientHeight)
+    }
+  }, [])
 
   useEffect(() => {
     return () => {
@@ -130,7 +138,32 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
           </div>
         ) : (
           <div className="relative">
-            <div className="whitespace-pre-wrap">{content}</div>
+            <div
+              ref={contentRef}
+              className={cn(
+                'whitespace-pre-wrap',
+                !isExpanded && 'line-clamp-3'
+              )}
+            >
+              {content}
+            </div>
+            {(isClamped || isExpanded) && (
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground mt-1"
+                onClick={() => setIsExpanded(prev => !prev)}
+              >
+                {isExpanded ? (
+                  <span className="inline-flex items-center gap-0.5">
+                    Show less <ChevronUp className="size-3" />
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-0.5">
+                    Show more <ChevronDown className="size-3" />
+                  </span>
+                )}
+              </button>
+            )}
             <div
               className={cn(
                 'absolute -top-1 -right-1 flex items-center gap-0.5 p-0.5 transition-opacity bg-background rounded-full shadow-sm border',


### PR DESCRIPTION
## Summary
- Truncate long user messages to 3 lines using CSS `line-clamp-3`
- Add Show more / Show less toggle with chevron icons
- Use callback ref for DOM overflow detection (avoids unnecessary useEffect)
- Toggle only appears when message content exceeds 3 lines

## Test plan
- [ ] Send a long message (5+ lines) — message is truncated to 3 lines with "Show more" toggle
- [ ] Click "Show more" — full message is displayed with "Show less" toggle
- [ ] Click "Show less" — message collapses back to 3 lines
- [ ] Send a short message (1-2 lines) — no toggle is shown
- [ ] Copy and edit buttons still work correctly on collapsed/expanded messages