### PR TITLE
refactor: remove focus input shortcut (⌘K) to reserve for command palette

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -117,21 +117,14 @@ export function ChatPanel({
   }, [handleNewChat])
 
   useEffect(() => {
-    const handleFocusInput = (e: Event) => {
-      if (e.defaultPrevented) return
-      e.preventDefault()
-      inputRef.current?.focus()
-    }
     const handleNewChatShortcut = (e: Event) => {
       if (e.defaultPrevented) return
       e.preventDefault()
       handleNewChatRef.current()
     }
 
-    window.addEventListener(SHORTCUT_EVENTS.focusInput, handleFocusInput)
     window.addEventListener(SHORTCUT_EVENTS.newChat, handleNewChatShortcut)
     return () => {
-      window.removeEventListener(SHORTCUT_EVENTS.focusInput, handleFocusInput)
       window.removeEventListener(SHORTCUT_EVENTS.newChat, handleNewChatShortcut)
     }
   }, [])

--- a/components/keyboard-shortcut-handler.tsx
+++ b/components/keyboard-shortcut-handler.tsx
@@ -29,12 +29,6 @@ export function KeyboardShortcutHandler() {
 
   useKeyboardShortcut(SHORTCUTS.toggleSidebar, toggleSidebar)
 
-  useKeyboardShortcut(SHORTCUTS.focusInput, () => {
-    window.dispatchEvent(
-      new CustomEvent(SHORTCUT_EVENTS.focusInput, { cancelable: true })
-    )
-  })
-
   useKeyboardShortcut(SHORTCUTS.newChat, () => {
     window.dispatchEvent(
       new CustomEvent(SHORTCUT_EVENTS.newChat, { cancelable: true })

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -14,13 +14,6 @@ export const SHORTCUTS = {
     shift: false,
     description: 'Toggle sidebar'
   },
-  focusInput: {
-    id: 'focusInput',
-    key: 'k',
-    meta: true,
-    shift: false,
-    description: 'Focus search input'
-  },
   newChat: {
     id: 'newChat',
     key: 'o',
@@ -52,7 +45,6 @@ export const SHORTCUTS = {
 } as const satisfies Record<string, ShortcutDefinition>
 
 export const SHORTCUT_EVENTS = {
-  focusInput: 'shortcut:focus-input',
   newChat: 'shortcut:new-chat',
   copyMessage: 'shortcut:copy-message'
 } as const


### PR DESCRIPTION
## Summary

- Remove `⌘/Ctrl+K` focus input shortcut to reserve the key binding for a future command palette
- Clean up related event listener and CustomEvent relay code

## Test plan

- [ ] Verify remaining shortcuts still work (⌘B, ⌘⇧O, ⌘⇧D, ⌘⇧C, ⌘⇧M)
- [ ] Verify ⌘K no longer triggers any action
- [ ] Run `bun typecheck && bun lint && bun format:check && bun run build` (all pass)