### PR TITLE
feat: add keyboard shortcuts dialog (⌘/)

### DIFF
--- a/components/keyboard-shortcut-dialog.tsx
+++ b/components/keyboard-shortcut-dialog.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import {
+  formatShortcutKeys,
+  SHORTCUT_EVENTS,
+  type ShortcutDefinition,
+  SHORTCUTS} from '@/lib/keyboard-shortcuts'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from './ui/dialog'
+
+const shortcutList: ShortcutDefinition[] = Object.values(SHORTCUTS).filter(
+  s => s.id !== 'showShortcuts'
+)
+
+function ShortcutKey({ children }: { children: string }) {
+  return (
+    <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1 font-mono text-[11px] text-muted-foreground">
+      {children}
+    </kbd>
+  )
+}
+
+export function KeyboardShortcutDialog() {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const handler = () => setOpen(prev => !prev)
+    window.addEventListener(SHORTCUT_EVENTS.showShortcuts, handler)
+    return () =>
+      window.removeEventListener(SHORTCUT_EVENTS.showShortcuts, handler)
+  }, [])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+          <DialogDescription className="sr-only">
+            List of available keyboard shortcuts
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1">
+          {shortcutList.map(shortcut => (
+            <div
+              key={shortcut.id}
+              className="flex items-center justify-between rounded-md px-2 py-1.5"
+            >
+              <span className="text-sm text-foreground">
+                {shortcut.description}
+              </span>
+              <div className="flex items-center gap-1">
+                {formatShortcutKeys(shortcut).map((key, i) => (
+                  <ShortcutKey key={i}>{key}</ShortcutKey>
+                ))}
+              </div>
+            </div>
+          ))}
+          <div className="border-t pt-1">
+            <div className="flex items-center justify-between rounded-md px-2 py-1.5">
+              <span className="text-sm text-foreground">
+                {SHORTCUTS.showShortcuts.description}
+              </span>
+              <div className="flex items-center gap-1">
+                {formatShortcutKeys(SHORTCUTS.showShortcuts).map((key, i) => (
+                  <ShortcutKey key={i}>{key}</ShortcutKey>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/keyboard-shortcut-dialog.tsx
+++ b/components/keyboard-shortcut-dialog.tsx
@@ -6,7 +6,8 @@ import {
   formatShortcutKeys,
   SHORTCUT_EVENTS,
   type ShortcutDefinition,
-  SHORTCUTS} from '@/lib/keyboard-shortcuts'
+  SHORTCUTS
+} from '@/lib/keyboard-shortcuts'
 
 import {
   Dialog,

--- a/components/keyboard-shortcut-handler.tsx
+++ b/components/keyboard-shortcut-handler.tsx
@@ -11,6 +11,7 @@ import { getCookie, setCookie } from '@/lib/utils/cookies'
 import { useKeyboardShortcut } from '@/hooks/use-keyboard-shortcut'
 
 import { useSidebar } from './ui/sidebar'
+import { KeyboardShortcutDialog } from './keyboard-shortcut-dialog'
 
 const THEME_CYCLE: Record<string, string> = {
   dark: 'light',
@@ -52,5 +53,9 @@ export function KeyboardShortcutHandler() {
     toast.info(`Search mode: ${SEARCH_MODE_LABELS[next]}`)
   })
 
-  return null
+  useKeyboardShortcut(SHORTCUTS.showShortcuts, () => {
+    window.dispatchEvent(new CustomEvent(SHORTCUT_EVENTS.showShortcuts))
+  })
+
+  return <KeyboardShortcutDialog />
 }

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -41,13 +41,32 @@ export const SHORTCUTS = {
     meta: true,
     shift: true,
     description: 'Toggle search mode'
+  },
+  showShortcuts: {
+    id: 'showShortcuts',
+    key: '/',
+    meta: true,
+    shift: false,
+    description: 'Show keyboard shortcuts'
   }
 } as const satisfies Record<string, ShortcutDefinition>
 
 export const SHORTCUT_EVENTS = {
   newChat: 'shortcut:new-chat',
-  copyMessage: 'shortcut:copy-message'
+  copyMessage: 'shortcut:copy-message',
+  showShortcuts: 'shortcut:show-shortcuts'
 } as const
+
+export function formatShortcutKeys(shortcut: ShortcutDefinition): string[] {
+  const isMac =
+    typeof navigator !== 'undefined' &&
+    navigator.userAgent.toLowerCase().includes('mac')
+  const keys: string[] = []
+  keys.push(isMac ? '⌘' : 'Ctrl')
+  if (shortcut.shift) keys.push('Shift')
+  keys.push(shortcut.key.toUpperCase())
+  return keys
+}
 
 export function matchesShortcut(
   event: KeyboardEvent,

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -3,6 +3,8 @@ export type ShortcutDefinition = {
   key: string
   meta: boolean
   shift: boolean
+  /** If true, ignore shiftKey state when matching (for keys like / that require Shift on some layouts) */
+  ignoreShift?: boolean
   description: string
 }
 
@@ -47,6 +49,7 @@ export const SHORTCUTS = {
     key: '/',
     meta: true,
     shift: false,
+    ignoreShift: true,
     description: 'Show keyboard shortcuts'
   }
 } as const satisfies Record<string, ShortcutDefinition>
@@ -74,9 +77,12 @@ export function matchesShortcut(
 ): boolean {
   if (event.repeat) return false
   if (event.altKey) return false
+  const shiftMatch = shortcut.ignoreShift
+    ? true
+    : event.shiftKey === shortcut.shift
   return (
     event.key.toLowerCase() === shortcut.key &&
     (event.metaKey || event.ctrlKey) === shortcut.meta &&
-    event.shiftKey === shortcut.shift
+    shiftMatch
   )
 }


### PR DESCRIPTION
## Summary
- Add a modal dialog displaying all available keyboard shortcuts, triggered by `⌘/` (`Ctrl+/` on Windows/Linux)
- Add `showShortcuts` shortcut definition and `formatShortcutKeys()` helper for cross-platform key display
- Create `KeyboardShortcutDialog` component using existing Dialog UI primitives

## Test plan
- [ ] Press `⌘/` (or `Ctrl+/`) to open the shortcuts dialog
- [ ] Verify all 5 shortcuts are listed with correct key combinations
- [ ] Verify the dialog closes via the X button, clicking outside, or pressing Escape
- [ ] Press `⌘/` again while the dialog is open to toggle it closed
- [ ] Verify key labels show `⌘` on Mac and `Ctrl` on Windows/Linux