### PR TITLE
fix: align upload client MIME types with server allow-list

### DIFF
--- a/components/file-upload-button.tsx
+++ b/components/file-upload-button.tsx
@@ -9,12 +9,8 @@ import { cn } from '@/lib/utils'
 
 import { Button } from './ui/button'
 
-const allowedImageTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
-const allowedOtherTypes = [
-  'application/pdf',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-]
+const allowedImageTypes = ['image/png', 'image/jpeg']
+const allowedOtherTypes = ['application/pdf']
 
 const isAllowedFileType = (file: File) =>
   allowedImageTypes.includes(file.type) || allowedOtherTypes.includes(file.type)
@@ -70,7 +66,7 @@ export function FileUploadButton({
       <input
         ref={inputRef}
         type="file"
-        accept="image/*,.pdf,.doc,.docx"
+        accept="image/png,image/jpeg,application/pdf"
         hidden
         multiple
         onChange={e => {


### PR DESCRIPTION
## Summary
- The file upload button accepted `image/gif`, `image/webp`, `.doc`, and `.docx`, but [`app/api/upload/route.ts`](app/api/upload/route.ts#L13) only allows `image/jpeg`, `image/png`, and `application/pdf`.
- Users could pick a Word doc from the file picker, pass client validation, and then hit a 400 `Unsupported file type` on the server — surfaced as a generic "Failed to upload" toast.
- Narrow the client allow-list (`allowedImageTypes`, `allowedOtherTypes`, `<input accept>`) to PNG/JPEG/PDF so unsupported files are rejected up front with the "Some files were not accepted" toast.

Fixes #822.

## Test plan
- [ ] Open the chat panel as an authenticated user and click the paperclip button — file picker only offers PNG/JPEG/PDF.
- [ ] Drag-and-drop a `.docx` onto the input — "Some files were not accepted" toast appears, no network request to `/api/upload`.
- [ ] Upload a PNG and a PDF — both succeed end-to-end.