### PR TITLE
feat: enlarge image carousel dialog with dark floating style

### DIFF
--- a/components/search-results-image.tsx
+++ b/components/search-results-image.tsx
@@ -317,10 +317,10 @@ export const SearchResultsImageSection: React.FC<
                   )}
               </div>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-3xl max-h-[80vh] overflow-auto">
+            <DialogContent className="max-w-[90vw] sm:max-w-[90vw] max-h-[90vh] overflow-auto border border-white/10 bg-black/60 shadow-2xl backdrop-blur-md">
               <DialogHeader>
-                <DialogTitle>Search Images</DialogTitle>
-                <DialogDescription className="text-sm">
+                <DialogTitle className="text-white">Images</DialogTitle>
+                <DialogDescription className="text-sm text-white/70">
                   {query}
                 </DialogDescription>
               </DialogHeader>
@@ -331,7 +331,7 @@ export const SearchResultsImageSection: React.FC<
                     startIndex: selectedIndex,
                     loop: filteredCount > 1
                   }}
-                  className="w-full bg-muted max-h-[60vh]"
+                  className="w-full max-h-[70vh]"
                 >
                   <CarouselContent>
                     {filteredImages.map((img, idx) => (
@@ -340,7 +340,7 @@ export const SearchResultsImageSection: React.FC<
                           <img
                             src={img.url}
                             alt={`Image ${idx + 1}`}
-                            className="max-w-full max-h-[60vh] object-contain"
+                            className="max-w-full max-h-[70vh] object-contain"
                             onError={() => removeImage(img.id)}
                           />
                           <ImageCreditOverlay
@@ -362,7 +362,7 @@ export const SearchResultsImageSection: React.FC<
                     </div>
                   )}
                 </Carousel>
-                <div className="py-2 text-center text-sm text-muted-foreground">
+                <div className="py-2 text-center text-sm text-white/70">
                   {current} of {filteredCount}
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Enlarges the image carousel lightbox (triggered from search result images) and swaps the white card surface for a dark, floating style so images get more room and feel more like a viewer.

## Changes

- **Size**: `DialogContent` → `max-w-[90vw] max-h-[90vh]`; carousel + image → `max-h-[70vh]`.
- **Surface**: Remove `bg-background` / `bg-muted`, use `bg-black/60 border-white/10 backdrop-blur-md shadow-2xl` so the image floats on the dark overlay while the dialog boundary stays visible.
- **Text**: Title, description, and `N of M` counter switched to white/muted-white for contrast.
- **Title**: Rename `Search Images` → `Images` to match other section labels (`Sources`, `Videos`, etc.).

Layout structure and shadcn `Carousel` wiring are unchanged.

## Test plan

- [x] `bun typecheck` / `lint` / `format:check`
- [x] Manual: search for a query that returns images, click any thumbnail → dialog opens larger, floats on dark backdrop, dialog boundary is visible, no vertical scroll.