### PR TITLE
fix: offset chat section scroll target for mobile header

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -171,7 +171,7 @@ export function ChatMessages({
           <div
             key={section.id}
             id={`section-${section.id}`}
-            className="chat-section pb-4 md:pb-14"
+            className="chat-section scroll-mt-14 pb-4 md:pb-14"
             style={
               sectionIndex === sections.length - 1
                 ? { minHeight: `calc(100dvh - ${offsetHeight}px)` }


### PR DESCRIPTION
## Summary
- On tablet and smaller viewports the header has an opaque background (`bg-background/80 backdrop-blur-sm` below `lg`), so clicking a message navigation dot (#814) scrolled the target user message behind the header.
- Add `scroll-mt-14` to `.chat-section` so `scrollIntoView({ block: 'start' })` accounts for the header height.
- No effect on `lg`+ viewports where the header is transparent.

## Test plan
- [ ] On a tablet viewport (e.g. 768px), send multiple messages and click a navigation dot — the target user message should land below the header, not behind it.
- [ ] Verify PC (lg+) behavior is unchanged.
- [ ] Verify mobile viewport behavior is correct.