### PR TITLE
feat: add per-user daily limit for adaptive search mode

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import { cookies } from 'next/headers'
 import { loadChat } from '@/lib/actions/chat'
 import { calculateConversationTurn, trackChatEvent } from '@/lib/analytics'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
+import { checkAndEnforceAdaptiveLimit } from '@/lib/rate-limit/adaptive-limit'
 import { checkAndEnforceOverallChatLimit } from '@/lib/rate-limit/chat-limits'
 import { checkAndEnforceGuestLimit } from '@/lib/rate-limit/guest-limit'
 import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'
@@ -111,9 +112,35 @@ export async function POST(req: Request) {
       )
     }
 
+    // Adaptive mode is gated to authenticated users on cloud deployments.
+    // Guests are nudged to sign in instead of being downgraded silently.
+    if (
+      isGuest &&
+      searchMode === 'adaptive' &&
+      process.env.MORPHIC_CLOUD_DEPLOYMENT === 'true'
+    ) {
+      return new Response(
+        JSON.stringify({
+          error:
+            'Sign in to use Adaptive mode. Quick mode remains available without an account.',
+          mode: 'adaptive',
+          authRequired: true
+        }),
+        {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+    }
+
     if (!isGuest) {
       const overallLimitResponse = await checkAndEnforceOverallChatLimit(userId)
       if (overallLimitResponse) return overallLimitResponse
+
+      if (searchMode === 'adaptive') {
+        const adaptiveLimitResponse = await checkAndEnforceAdaptiveLimit(userId)
+        if (adaptiveLimitResponse) return adaptiveLimitResponse
+      }
     }
 
     const streamStart = performance.now()

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -150,14 +150,15 @@ export function Chat({
         errorMessage.includes('sign in to continue')
 
       if (isRateLimit) {
-        // Try to parse JSON error response for quality mode rate limit
+        // Try to parse JSON error response. The body may include `mode`
+        // (e.g. "adaptive") so we can show context-specific guidance.
         let parsedError: {
           error?: string
           resetAt?: number
           remaining?: number
+          mode?: string
         } = {}
         try {
-          // Extract JSON from error message if it exists
           const jsonMatch = error.message?.match(/\{.*\}/)
           if (jsonMatch) {
             parsedError = JSON.parse(jsonMatch[0])
@@ -166,22 +167,36 @@ export function Chat({
           // Ignore parse errors
         }
 
-        // Use parsed error message or fallback
         const userMessage =
           parsedError.error ||
-          'You have reached your daily limit for quality mode chat requests.'
+          'You have reached your daily chat limit. Please try again tomorrow.'
+
+        const details =
+          parsedError.mode === 'adaptive'
+            ? 'The limit resets at midnight UTC. You can continue using Quick mode without restrictions.'
+            : 'The limit resets at midnight UTC.'
 
         setErrorModal({
           open: true,
           type: 'rate-limit',
           message: userMessage,
-          details: undefined
+          details
         })
       } else if (isAuthError) {
+        // Try to parse JSON for context-specific auth prompts
+        // (e.g. adaptive mode requires sign in).
+        let parsedAuthError: { error?: string; authRequired?: boolean } = {}
+        try {
+          const jsonMatch = error.message?.match(/\{.*\}/)
+          if (jsonMatch) parsedAuthError = JSON.parse(jsonMatch[0])
+        } catch {
+          // Ignore parse errors
+        }
+
         setErrorModal({
           open: true,
           type: 'auth',
-          message: error.message
+          message: parsedAuthError.error || error.message
         })
       } else if (
         error.message?.includes('403') ||

--- a/components/error-modal.tsx
+++ b/components/error-modal.tsx
@@ -71,7 +71,10 @@ export function ErrorModal({
           'You have made too many requests. Please wait a moment before trying again.'
         )
       case 'auth':
-        return 'To use Morphic, sign in to your account or create a new one.'
+        return (
+          error.message ||
+          'To use Morphic, sign in to your account or create a new one.'
+        )
       case 'forbidden':
         return 'You do not have permission to access this resource.'
       default:
@@ -83,7 +86,7 @@ export function ErrorModal({
 
   const getErrorDetails = () => {
     if (error.type === 'rate-limit') {
-      return 'The limit will reset at midnight UTC. You can continue using speed mode without restrictions.'
+      return error.details || 'The limit resets at midnight UTC.'
     }
     return error.details
   }

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -8,6 +8,10 @@
  * @module analytics
  */
 
+export {
+  type AdaptiveLimitEventData,
+  trackAdaptiveLimitEvent
+} from './track-adaptive-limit-event'
 export { trackChatEvent } from './track-chat-event'
 export type { AnalyticsProvider, ChatEventData } from './types'
 export { calculateConversationTurn } from './utils'

--- a/lib/analytics/track-adaptive-limit-event.ts
+++ b/lib/analytics/track-adaptive-limit-event.ts
@@ -1,0 +1,42 @@
+import { track } from '@vercel/analytics/server'
+
+export interface AdaptiveLimitEventData {
+  /** Outcome of the adaptive-mode rate-limit check */
+  outcome: 'allowed' | 'blocked'
+  /** Authenticated Supabase user ID */
+  userId: string
+  /** Current daily usage count after the check (incl. this attempt) */
+  used: number
+  /** Effective daily limit at the time of the check */
+  limit: number
+}
+
+/**
+ * Track adaptive (Adaptive search mode) per-user daily limit events.
+ *
+ * Fires on every adaptive request:
+ * - `outcome: "allowed"` while under the cap (with running counter), so we
+ *   can plot daily usage distribution and percentiles.
+ * - `outcome: "blocked"` when the request is denied, so we can monitor the
+ *   429 hit-rate over time and decide whether to relax / tighten the cap.
+ *
+ * No-op outside cloud deployment; never throws.
+ */
+export async function trackAdaptiveLimitEvent(
+  data: AdaptiveLimitEventData
+): Promise<void> {
+  if (process.env.MORPHIC_CLOUD_DEPLOYMENT !== 'true') {
+    return
+  }
+
+  try {
+    await track('adaptive_limit_check', {
+      outcome: data.outcome,
+      userId: data.userId,
+      used: data.used,
+      limit: data.limit
+    })
+  } catch (error) {
+    console.error('Failed to track adaptive limit event:', error)
+  }
+}

--- a/lib/rate-limit/__tests__/adaptive-limit.test.ts
+++ b/lib/rate-limit/__tests__/adaptive-limit.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { checkAndEnforceAdaptiveLimit } from '@/lib/rate-limit/adaptive-limit'
+
+const mockRedisIncr = vi.fn()
+const mockRedisExpire = vi.fn()
+const mockTrack = vi.fn()
+
+vi.mock('@upstash/redis', () => ({
+  Redis: vi.fn().mockImplementation(() => ({
+    incr: mockRedisIncr,
+    expire: mockRedisExpire
+  }))
+}))
+
+vi.mock('@vercel/analytics/server', () => ({
+  track: (...args: unknown[]) => mockTrack(...args)
+}))
+
+describe('checkAndEnforceAdaptiveLimit', () => {
+  beforeEach(() => {
+    mockRedisIncr.mockReset()
+    mockRedisExpire.mockReset()
+    mockTrack.mockReset()
+    mockTrack.mockResolvedValue(undefined)
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'true'
+    process.env.UPSTASH_REDIS_REST_URL = 'https://example.com'
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token'
+    delete process.env.ADAPTIVE_CHAT_DAILY_LIMIT
+  })
+
+  it('allows requests under the default limit', async () => {
+    mockRedisIncr.mockResolvedValue(5)
+    mockRedisExpire.mockResolvedValue(1)
+
+    const response = await checkAndEnforceAdaptiveLimit('user-1')
+    expect(response).toBeNull()
+  })
+
+  it('returns 429 when the default 30/day limit is exceeded', async () => {
+    mockRedisIncr.mockResolvedValue(31)
+    mockRedisExpire.mockResolvedValue(1)
+
+    const response = await checkAndEnforceAdaptiveLimit('user-2')
+    expect(response).not.toBeNull()
+    expect(response?.status).toBe(429)
+
+    const body = await response!.json()
+    expect(body.limit).toBe(30)
+    expect(body.mode).toBe('adaptive')
+    expect(body.remaining).toBe(0)
+    expect(typeof body.error).toBe('string')
+  })
+
+  it('honors ADAPTIVE_CHAT_DAILY_LIMIT override', async () => {
+    process.env.ADAPTIVE_CHAT_DAILY_LIMIT = '5'
+    mockRedisIncr.mockResolvedValue(6)
+    mockRedisExpire.mockResolvedValue(1)
+
+    const response = await checkAndEnforceAdaptiveLimit('user-3')
+    expect(response?.status).toBe(429)
+    const body = await response!.json()
+    expect(body.limit).toBe(5)
+  })
+
+  it('sets TTL only on first increment of the day', async () => {
+    mockRedisIncr.mockResolvedValue(1)
+    mockRedisExpire.mockResolvedValue(1)
+
+    await checkAndEnforceAdaptiveLimit('user-4')
+    expect(mockRedisExpire).toHaveBeenCalledTimes(1)
+
+    mockRedisExpire.mockClear()
+    mockRedisIncr.mockResolvedValue(2)
+
+    await checkAndEnforceAdaptiveLimit('user-4')
+    expect(mockRedisExpire).not.toHaveBeenCalled()
+  })
+
+  it('allows the request when redis fails (fail-open)', async () => {
+    mockRedisIncr.mockRejectedValue(new Error('boom'))
+
+    const response = await checkAndEnforceAdaptiveLimit('user-5')
+    expect(response).toBeNull()
+  })
+
+  it('skips enforcement when not in cloud deployment', async () => {
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'false'
+    mockRedisIncr.mockResolvedValue(9999)
+
+    const response = await checkAndEnforceAdaptiveLimit('user-6')
+    expect(response).toBeNull()
+    expect(mockRedisIncr).not.toHaveBeenCalled()
+  })
+
+  it('emits an "allowed" analytics event when under the limit', async () => {
+    mockRedisIncr.mockResolvedValue(7)
+    mockRedisExpire.mockResolvedValue(1)
+
+    await checkAndEnforceAdaptiveLimit('user-7')
+
+    // Allow the void-fired track promise to resolve.
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(mockTrack).toHaveBeenCalledTimes(1)
+    expect(mockTrack).toHaveBeenCalledWith('adaptive_limit_check', {
+      outcome: 'allowed',
+      userId: 'user-7',
+      used: 7,
+      limit: 30
+    })
+  })
+
+  it('emits a "blocked" analytics event when over the limit', async () => {
+    mockRedisIncr.mockResolvedValue(31)
+    mockRedisExpire.mockResolvedValue(1)
+
+    await checkAndEnforceAdaptiveLimit('user-8')
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(mockTrack).toHaveBeenCalledTimes(1)
+    expect(mockTrack).toHaveBeenCalledWith('adaptive_limit_check', {
+      outcome: 'blocked',
+      userId: 'user-8',
+      used: 31,
+      limit: 30
+    })
+  })
+
+  it('does not emit analytics when redis is unavailable (no enforcement)', async () => {
+    mockRedisIncr.mockRejectedValue(new Error('boom'))
+
+    await checkAndEnforceAdaptiveLimit('user-9')
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+})

--- a/lib/rate-limit/adaptive-limit.ts
+++ b/lib/rate-limit/adaptive-limit.ts
@@ -1,0 +1,159 @@
+import { Redis } from '@upstash/redis'
+
+import { trackAdaptiveLimitEvent } from '@/lib/analytics'
+import { perfLog } from '@/lib/utils/perf-logging'
+
+const DEFAULT_ADAPTIVE_DAILY_LIMIT = 30
+
+function getAdaptiveDailyLimit(): number {
+  const raw = process.env.ADAPTIVE_CHAT_DAILY_LIMIT
+  const parsed = raw ? Number(raw) : DEFAULT_ADAPTIVE_DAILY_LIMIT
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_ADAPTIVE_DAILY_LIMIT
+  }
+  return Math.floor(parsed)
+}
+
+function getSecondsUntilMidnight(): number {
+  const now = new Date()
+  const midnight = new Date(now)
+  midnight.setUTCHours(24, 0, 0, 0)
+  return Math.floor((midnight.getTime() - now.getTime()) / 1000)
+}
+
+function getNextMidnightTimestamp(): number {
+  const now = new Date()
+  const midnight = new Date(now)
+  midnight.setUTCHours(24, 0, 0, 0)
+  return midnight.getTime()
+}
+
+interface AdaptiveLimitCheckResult {
+  allowed: boolean
+  /** Current count after this attempt is included */
+  used: number
+  remaining: number
+  resetAt: number
+  limit: number
+  /** True when the check ran against Redis (i.e. enforced) */
+  enforced: boolean
+}
+
+async function checkAdaptiveLimit(
+  userId: string
+): Promise<AdaptiveLimitCheckResult> {
+  const limit = getAdaptiveDailyLimit()
+
+  if (process.env.MORPHIC_CLOUD_DEPLOYMENT !== 'true') {
+    return {
+      allowed: true,
+      used: 0,
+      remaining: Infinity,
+      resetAt: 0,
+      limit,
+      enforced: false
+    }
+  }
+
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    return {
+      allowed: true,
+      used: 0,
+      remaining: Infinity,
+      resetAt: 0,
+      limit,
+      enforced: false
+    }
+  }
+
+  try {
+    const redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN
+    })
+
+    const dateKey = new Date().toISOString().split('T')[0]
+    const key = `rl:adaptive:${userId}:${dateKey}`
+
+    const count = await Promise.race([
+      redis.incr(key),
+      new Promise<number>((_, reject) =>
+        setTimeout(() => reject(new Error('Redis timeout')), 3000)
+      )
+    ])
+
+    if (count === 1) {
+      await redis.expire(key, getSecondsUntilMidnight())
+    }
+
+    return {
+      allowed: count <= limit,
+      used: count,
+      remaining: Math.max(0, limit - count),
+      resetAt: getNextMidnightTimestamp(),
+      limit,
+      enforced: true
+    }
+  } catch (error) {
+    console.error('Adaptive rate limit check failed:', error)
+    return {
+      allowed: true,
+      used: 0,
+      remaining: Infinity,
+      resetAt: 0,
+      limit,
+      enforced: false
+    }
+  }
+}
+
+/**
+ * Enforce per-user daily limit on adaptive search mode.
+ * Returns a 429 Response if the limit is reached, null otherwise.
+ */
+export async function checkAndEnforceAdaptiveLimit(
+  userId: string
+): Promise<Response | null> {
+  const result = await checkAdaptiveLimit(userId)
+
+  // Only emit analytics for real (Redis-backed) checks. Local dev / cloud
+  // without Upstash returns enforced=false and we skip tracking to avoid
+  // polluting the dashboard with no-op events.
+  if (result.enforced) {
+    void trackAdaptiveLimitEvent({
+      outcome: result.allowed ? 'allowed' : 'blocked',
+      userId,
+      used: result.used,
+      limit: result.limit
+    })
+  }
+
+  if (!result.allowed) {
+    return new Response(
+      JSON.stringify({
+        error:
+          'Daily limit for Adaptive mode reached. Please try again tomorrow, or continue in Quick mode.',
+        remaining: 0,
+        resetAt: result.resetAt,
+        limit: result.limit,
+        mode: 'adaptive'
+      }),
+      {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-RateLimit-Limit': String(result.limit),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(result.resetAt)
+        }
+      }
+    )
+  }
+
+  perfLog(`Adaptive usage: ${result.used}/${result.limit}`)
+
+  return null
+}


### PR DESCRIPTION
## Summary

- Adds a per-user daily request limit for Adaptive search mode (default 30, override via `ADAPTIVE_CHAT_DAILY_LIMIT`).
- Guests attempting Adaptive mode receive a 401 with the existing auth modal pointing them to sign in; Quick mode remains unrestricted for guests.
- Tracks `adaptive_limit_check` events to Vercel Analytics so usage and 429 rates can be observed.

Cloud-only (gated by `MORPHIC_CLOUD_DEPLOYMENT=true`); local dev is unaffected.

## Test plan

- [x] `bun run test lib/rate-limit/` (under/over default, env override, TTL, fail-open, cloud-disabled, allowed/blocked analytics, no analytics on redis failure)
- [x] `bun lint` / `bun typecheck` / `bun format:check`
- [ ] Verify in Cloud staging that Adaptive request beyond the cap returns 429 with the rate-limit modal, and a guest selecting Adaptive sees the sign-in modal.