### PR TITLE
chore: switch quick model to Gemini 3.1 Flash Lite GA

### DIFF
--- a/config/models/cloud.json
+++ b/config/models/cloud.json
@@ -2,8 +2,8 @@
   "version": 2,
   "models": {
     "quick": {
-      "id": "gemini-3.1-flash-lite-preview",
-      "name": "Gemini 3.1 Flash Lite Preview",
+      "id": "gemini-3.1-flash-lite",
+      "name": "Gemini 3.1 Flash Lite",
       "provider": "Google",
       "providerId": "google",
       "providerOptions": {


### PR DESCRIPTION
## Summary
- Update the `quick` model from `gemini-3.1-flash-lite-preview` to the GA model ID `gemini-3.1-flash-lite`.
- Google announced Gemini 3.1 Flash-Lite general availability, and the `-preview` alias will be retired.

## Test plan
- [ ] `bun run build` succeeds
- [ ] Verify quick-mode chats resolve to the new model in the deployed cloud config