### PR TITLE
feat: tighten chat input layout on mobile

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -180,7 +180,9 @@ export function ChatPanel({
     <div
       className={cn(
         'w-full bg-background group/form-container shrink-0',
-        messages.length > 0 ? 'sticky bottom-0 px-2 pb-2 md:pb-4' : 'px-4 md:px-6'
+        messages.length > 0
+          ? 'sticky bottom-0 px-2 pb-2 md:pb-4'
+          : 'px-4 md:px-6'
       )}
     >
       {messages.length === 0 && (

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -180,7 +180,7 @@ export function ChatPanel({
     <div
       className={cn(
         'w-full bg-background group/form-container shrink-0',
-        messages.length > 0 ? 'sticky bottom-0 px-2 pb-2 md:pb-4' : 'px-6'
+        messages.length > 0 ? 'sticky bottom-0 px-2 pb-2 md:pb-4' : 'px-4 md:px-6'
       )}
     >
       {messages.length === 0 && (
@@ -411,7 +411,7 @@ export function ChatPanel({
               inputRef.current?.focus()
             }}
             inputRef={inputRef}
-            className="mt-2"
+            className="mt-2 hidden md:block"
           />
         )}
       </form>


### PR DESCRIPTION
## Summary
- Hide the prompt suggestion buttons (Research / Compare / Latest / Summarize / Explain) below the `md` breakpoint to declutter the mobile empty state.
- Reduce the empty-state horizontal padding around the chat input from `px-6` to `px-4` on mobile so the input uses more of the viewport.

## Test plan
- [x] Verified at 375x812 (mobile): prompt buttons hidden, chat input has px-4 side padding.
- [x] Verified at 1280x800 (desktop): prompt buttons visible, padding unchanged at px-6.