### PR TITLE
Fix account deletion review follow-ups

### DIFF
--- a/lib/storage/__tests__/r2-client.test.ts
+++ b/lib/storage/__tests__/r2-client.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const s3Mocks = vi.hoisted(() => {
+  const send = vi.fn()
+  const S3Client = vi.fn(() => ({ send }))
+
+  class ListObjectsV2Command {
+    input: unknown
+
+    constructor(input: unknown) {
+      this.input = input
+    }
+  }
+
+  class DeleteObjectsCommand {
+    input: unknown
+
+    constructor(input: unknown) {
+      this.input = input
+    }
+  }
+
+  return {
+    DeleteObjectsCommand,
+    ListObjectsV2Command,
+    S3Client,
+    send
+  }
+})
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  DeleteObjectsCommand: s3Mocks.DeleteObjectsCommand,
+  ListObjectsV2Command: s3Mocks.ListObjectsV2Command,
+  S3Client: s3Mocks.S3Client
+}))
+
+const originalEnv = {
+  R2_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID,
+  R2_ACCOUNT_ID: process.env.R2_ACCOUNT_ID,
+  R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
+  R2_PUBLIC_URL: process.env.R2_PUBLIC_URL,
+  R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
+  S3_ENDPOINT: process.env.S3_ENDPOINT
+}
+
+async function importR2Client() {
+  vi.resetModules()
+  return import('../r2-client')
+}
+
+describe('R2 client', () => {
+  beforeEach(() => {
+    s3Mocks.send.mockReset()
+    s3Mocks.S3Client.mockClear()
+
+    process.env.R2_ACCESS_KEY_ID = 'test-access-key'
+    process.env.R2_SECRET_ACCESS_KEY = 'test-secret-key'
+    process.env.R2_BUCKET_NAME = 'test-bucket'
+    process.env.R2_PUBLIC_URL = 'https://uploads.example.com'
+    process.env.S3_ENDPOINT = 'https://r2.example.com'
+    delete process.env.R2_ACCOUNT_ID
+  })
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  })
+
+  it('counts deleted objects when object storage deletion succeeds', async () => {
+    s3Mocks.send
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: 'user-id/file-1.png' },
+          { Key: 'user-id/file-2.png' }
+        ],
+        IsTruncated: false
+      })
+      .mockResolvedValueOnce({})
+
+    const { deleteObjectsByPrefix } = await importR2Client()
+
+    await expect(deleteObjectsByPrefix('user-id/')).resolves.toEqual({
+      deletedCount: 2,
+      skipped: false
+    })
+
+    expect(s3Mocks.send).toHaveBeenCalledTimes(2)
+    expect(s3Mocks.send.mock.calls[1][0]).toBeInstanceOf(
+      s3Mocks.DeleteObjectsCommand
+    )
+    expect((s3Mocks.send.mock.calls[1][0] as any).input.Delete.Objects).toEqual(
+      [{ Key: 'user-id/file-1.png' }, { Key: 'user-id/file-2.png' }]
+    )
+  })
+
+  it('fails when object storage reports per-object delete errors', async () => {
+    s3Mocks.send
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: 'user-id/file-1.png' },
+          { Key: 'user-id/file-2.png' }
+        ],
+        IsTruncated: false
+      })
+      .mockResolvedValueOnce({
+        Errors: [{ Code: 'AccessDenied', Key: 'user-id/file-2.png' }]
+      })
+
+    const { deleteObjectsByPrefix } = await importR2Client()
+
+    await expect(deleteObjectsByPrefix('user-id/')).rejects.toThrow(
+      'Failed to delete 1 object(s) from storage: user-id/file-2.png'
+    )
+  })
+})

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -79,7 +79,7 @@ export async function deleteObjectsByPrefix(prefix: string) {
       ) ?? []
 
     if (keys.length > 0) {
-      await r2Client.send(
+      const deleteResponse = await r2Client.send(
         new DeleteObjectsCommand({
           Bucket: R2_BUCKET_NAME,
           Delete: {
@@ -88,6 +88,19 @@ export async function deleteObjectsByPrefix(prefix: string) {
           }
         })
       )
+
+      const deleteErrors = deleteResponse.Errors ?? []
+      if (deleteErrors.length > 0) {
+        const sampleErrors = deleteErrors
+          .slice(0, 3)
+          .map(error => error.Key ?? error.Code ?? 'unknown')
+          .join(', ')
+
+        throw new Error(
+          `Failed to delete ${deleteErrors.length} object(s) from storage: ${sampleErrors}`
+        )
+      }
+
       deletedCount += keys.length
     }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
+import { hasSupabasePublicConfig } from '@/lib/supabase/keys'
 import { updateSession } from '@/lib/supabase/middleware'
 
 export async function proxy(request: NextRequest) {
@@ -17,11 +18,7 @@ export async function proxy(request: NextRequest) {
   // Create a response
   let response: NextResponse
 
-  // Handle Supabase session if configured
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (supabaseUrl && supabaseAnonKey) {
+  if (hasSupabasePublicConfig()) {
     response = await updateSession(request)
   } else {
     // If Supabase is not configured, just pass the request through


### PR DESCRIPTION
## Summary
- Use the shared Supabase publishable-key config check in proxy session handling instead of the legacy anon-key gate
- Detect per-object errors returned by S3-compatible DeleteObjects responses before continuing account deletion
- Add R2 deletion tests for successful deletes and partial delete failures

## Verification
- bun lint
- bun typecheck
- bun run test
- bun run build
- prettier --check proxy.ts lib/storage/r2-client.ts lib/storage/__tests__/r2-client.test.ts