### PR TITLE
track account deletion analytics

### DIFF
--- a/lib/actions/__tests__/account.test.ts
+++ b/lib/actions/__tests__/account.test.ts
@@ -2,6 +2,7 @@ import { revalidateTag } from 'next/cache'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { trackAccountDeleted } from '@/lib/analytics'
 import { getCurrentUser } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import { deleteUserObjects } from '@/lib/storage/r2-client'
@@ -9,6 +10,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 
 import { deleteAccount } from '../account'
 
+vi.mock('@/lib/analytics')
 vi.mock('@/lib/auth/get-current-user')
 vi.mock('@/lib/db/actions')
 vi.mock('@/lib/storage/r2-client')
@@ -33,6 +35,7 @@ describe('Account Actions', () => {
       deletedCount: 0,
       skipped: true
     })
+    vi.mocked(trackAccountDeleted).mockResolvedValue()
     deleteUser.mockResolvedValue({ data: { user: null }, error: null })
     vi.mocked(createAdminClient).mockReturnValue({
       auth: { admin: { deleteUser } }
@@ -92,6 +95,7 @@ describe('Account Actions', () => {
     expect(deleteUserObjects).toHaveBeenCalledWith(user.id)
     expect(deleteUser).toHaveBeenCalledWith(user.id)
     expect(revalidateTag).toHaveBeenCalledWith('chat', 'max')
+    expect(trackAccountDeleted).toHaveBeenCalledTimes(1)
   })
 
   it('stops before storage and auth deletion when app data deletion fails', async () => {
@@ -108,6 +112,7 @@ describe('Account Actions', () => {
     })
     expect(deleteUserObjects).not.toHaveBeenCalled()
     expect(deleteUser).not.toHaveBeenCalled()
+    expect(trackAccountDeleted).not.toHaveBeenCalled()
   })
 
   it('stops before storage and auth deletion when feedback anonymization fails', async () => {
@@ -124,6 +129,7 @@ describe('Account Actions', () => {
     })
     expect(deleteUserObjects).not.toHaveBeenCalled()
     expect(deleteUser).not.toHaveBeenCalled()
+    expect(trackAccountDeleted).not.toHaveBeenCalled()
   })
 
   it('stops before auth deletion when uploaded file deletion fails', async () => {
@@ -137,5 +143,21 @@ describe('Account Actions', () => {
     })
     expect(dbActions.deleteUserChats).toHaveBeenCalledWith(user.id)
     expect(deleteUser).not.toHaveBeenCalled()
+    expect(trackAccountDeleted).not.toHaveBeenCalled()
+  })
+
+  it('does not track account deletion when auth deletion fails', async () => {
+    deleteUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error('Auth deletion failed')
+    })
+
+    const result = await deleteAccount()
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Auth deletion failed'
+    })
+    expect(trackAccountDeleted).not.toHaveBeenCalled()
   })
 })

--- a/lib/actions/account.ts
+++ b/lib/actions/account.ts
@@ -2,6 +2,7 @@
 
 import { revalidateTag } from 'next/cache'
 
+import { trackAccountDeleted } from '@/lib/analytics'
 import { getCurrentUser } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import { deleteUserObjects } from '@/lib/storage/r2-client'
@@ -70,6 +71,7 @@ export async function deleteAccount(): Promise<{
     }
 
     revalidateTag('chat', 'max')
+    await trackAccountDeleted()
 
     return { success: true }
   } catch (error) {

--- a/lib/analytics/__tests__/track-account-event.test.ts
+++ b/lib/analytics/__tests__/track-account-event.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockTrack = vi.hoisted(() => vi.fn())
+
+vi.mock('@vercel/analytics/server', () => ({
+  track: (...args: unknown[]) => mockTrack(...args)
+}))
+
+import { trackAccountDeleted } from '@/lib/analytics/track-account-event'
+
+const originalCloudDeployment = process.env.MORPHIC_CLOUD_DEPLOYMENT
+
+describe('trackAccountDeleted', () => {
+  beforeEach(() => {
+    mockTrack.mockReset()
+    mockTrack.mockResolvedValue(undefined)
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'true'
+  })
+
+  afterEach(() => {
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = originalCloudDeployment
+  })
+
+  it('tracks an anonymous account deletion event in cloud deployment', async () => {
+    await trackAccountDeleted()
+
+    expect(mockTrack).toHaveBeenCalledTimes(1)
+    expect(mockTrack).toHaveBeenCalledWith('account_deleted')
+  })
+
+  it('does not track outside cloud deployment', async () => {
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'false'
+
+    await trackAccountDeleted()
+
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when analytics tracking fails', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mockTrack.mockRejectedValue(new Error('Analytics unavailable'))
+
+    await expect(trackAccountDeleted()).resolves.toBeUndefined()
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to track account deletion event:',
+      expect.any(Error)
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -8,6 +8,7 @@
  * @module analytics
  */
 
+export { trackAccountDeleted } from './track-account-event'
 export {
   type AdaptiveLimitEventData,
   trackAdaptiveLimitEvent

--- a/lib/analytics/track-account-event.ts
+++ b/lib/analytics/track-account-event.ts
@@ -1,0 +1,19 @@
+import { track } from '@vercel/analytics/server'
+
+/**
+ * Track successful account deletion.
+ *
+ * Keep this event anonymous: the account has just been deleted, and the only
+ * metric we need is the aggregate deletion count.
+ */
+export async function trackAccountDeleted(): Promise<void> {
+  if (process.env.MORPHIC_CLOUD_DEPLOYMENT !== 'true') {
+    return
+  }
+
+  try {
+    await track('account_deleted')
+  } catch (error) {
+    console.error('Failed to track account deletion event:', error)
+  }
+}


### PR DESCRIPTION
## Summary

- Add an anonymous `account_deleted` Vercel Analytics server event for successful account deletion.
- Emit the event only after Supabase Auth user deletion succeeds.
- Add tests for successful tracking, skipped tracking outside cloud deployment, tracking failure tolerance, and no tracking on failed account deletion.

## Impact

This lets the project monitor aggregate account deletion volume without sending user identifiers or changing the deletion flow behavior.

## Validation

- `bun lint`
- `bun typecheck`
- `bun run build`
- `bun run test`
- `bunx prettier --check lib/actions/account.ts lib/actions/__tests__/account.test.ts lib/analytics/index.ts lib/analytics/track-account-event.ts lib/analytics/__tests__/track-account-event.test.ts`

Note: `bun format:check` across the whole repo currently fails on untracked `.claude/settings.local.json`, which is outside this PR and was left untouched.