### PR TITLE
fix(registry): route openai-compatible provider through chat completions endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@ai-sdk/gateway": "^3.0.114",
         "@ai-sdk/google": "^3.0.73",
         "@ai-sdk/openai": "^3.0.63",
+        "@ai-sdk/openai-compatible": "^2.0.47",
         "@ai-sdk/react": "^3.0.182",
         "@aws-sdk/client-s3": "^3.850.0",
         "@json-render/core": "^0.16.0",
@@ -104,6 +105,8 @@
     "@ai-sdk/google": ["@ai-sdk/google@3.0.73", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-o2MuIeyvZrFIeIbnbA8Thrr63irdyUBh0uWBZ2lY6yFeXuE/tcwyXF74bDKS4KvTu84uFpQfpbS/LXHGKKXz+g=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.63", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4yY/m8a57MNNVoJCsXuNblKf6BO4yuAuLKRX4tzSNffBEBSp1FlcWdPE0Z4FkqUeS0AJhYSSqp0GIiA/cIcDNA=="],
+
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.47", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Enm5UlL0zUCrW3792opk5h7hRWxZOZzDe6eQYVFqX9LUOGGCe1h8MZWAGim765nwzgnjlpeYOsuzZmLtRsTPlg=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 

--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -1,18 +1,30 @@
 import { anthropic } from '@ai-sdk/anthropic'
 import { createGateway } from '@ai-sdk/gateway'
 import { google } from '@ai-sdk/google'
-import { createOpenAI, openai } from '@ai-sdk/openai'
+import { openai } from '@ai-sdk/openai'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { createProviderRegistry, LanguageModel } from 'ai'
 import { createOllama } from 'ai-sdk-ollama'
+
+// Strip a trailing /v1 from the configured base URL, then re-append it,
+// so both shapes work for OpenAI-compatible hosts:
+//   OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com
+//   OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com/v1
+function normalizeOpenAICompatibleBaseURL(raw: string): string {
+  return raw.replace(/\/+$/, '').replace(/\/v1$/, '') + '/v1'
+}
 
 // Build providers object conditionally
 const providers: Record<string, any> = {
   openai,
   anthropic,
   google,
-  'openai-compatible': createOpenAI({
+  'openai-compatible': createOpenAICompatible({
+    name: process.env.OPENAI_COMPATIBLE_PROVIDER_NAME || 'openai-compatible',
     apiKey: process.env.OPENAI_COMPATIBLE_API_KEY,
-    baseURL: process.env.OPENAI_COMPATIBLE_API_BASE_URL
+    baseURL: normalizeOpenAICompatibleBaseURL(
+      process.env.OPENAI_COMPATIBLE_API_BASE_URL || ''
+    )
   }),
   gateway: createGateway({
     apiKey: process.env.AI_GATEWAY_API_KEY

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ai-sdk/gateway": "^3.0.114",
     "@ai-sdk/google": "^3.0.73",
     "@ai-sdk/openai": "^3.0.63",
+    "@ai-sdk/openai-compatible": "^2.0.47",
     "@ai-sdk/react": "^3.0.182",
     "@aws-sdk/client-s3": "^3.850.0",
     "@json-render/core": "^0.16.0",


### PR DESCRIPTION
## Problem
With `OPENAI_COMPATIBLE_API_KEY` + `OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com` (or any other OpenAI-compatible host — Moonshot, Zhipu, Together, etc.), every chat request returns 404:

```
url: 'https://api.deepseek.com/responses'
statusCode: 404
```

## Root cause
`lib/utils/registry.ts:14` builds the `openai-compatible` provider with `createOpenAI(...)`. In current `@ai-sdk/openai` versions that defaults to OpenAI's new Responses API (`/responses`). DeepSeek and the other major OpenAI-compatible hosts only implement the legacy `/v1/chat/completions` shape, so every dispatch 404s before reaching the model.

## Fix
Switch to `@ai-sdk/openai-compatible`'s `createOpenAICompatible`, which speaks `/v1/chat/completions` exclusively and accepts any host. Normalize the base URL so both `https://api.deepseek.com` and `https://api.deepseek.com/v1` resolve to the same endpoint.

## Files changed
- `lib/utils/registry.ts` — replace `createOpenAI(...)` with `createOpenAICompatible(...)`, add `normalizeOpenAICompatibleBaseURL`
- `package.json` / `bun.lock` — add `@ai-sdk/openai-compatible`

## Testing
- `bun lint` / `bun typecheck` pass
- Manual: DeepSeek chat replies correctly in dev (previously 404'd on every request)