### PR TITLE
feat(models): list openai-compatible provider models in the selector

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -34,6 +34,17 @@ OPENAI_API_KEY=[YOUR_OPENAI_API_KEY]
 # Requires Ollama to be installed and running: https://ollama.com/
 # OLLAMA_BASE_URL=http://localhost:11434
 
+# Option 6: OpenAI-compatible endpoint (DeepSeek, Moonshot, Zhipu, etc.)
+# Any provider that exposes /v1/chat/completions in the OpenAI shape.
+# OPENAI_COMPATIBLE_API_KEY=[YOUR_API_KEY]
+# OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com
+# Optional display name in the model selector (defaults to "OpenAI Compatible")
+# OPENAI_COMPATIBLE_PROVIDER_NAME=DeepSeek
+# Optional comma-separated model whitelist. When set, the app skips the
+# /v1/models HTTP call and uses this list directly. Required for providers
+# without a /v1/models endpoint.
+# OPENAI_COMPATIBLE_MODELS=deepseek-chat,deepseek-reasoner
+
 # -----------------------------------------------------------------------------
 # Database Configuration (Required for local development)
 # -----------------------------------------------------------------------------

--- a/lib/models/__tests__/fetch-models.test.ts
+++ b/lib/models/__tests__/fetch-models.test.ts
@@ -233,4 +233,123 @@ describe('fetch-models', () => {
       }
     ])
   })
+
+  describe('fetchOpenAICompatibleModels', () => {
+    afterEach(() => {
+      delete process.env.OPENAI_COMPATIBLE_API_BASE_URL
+      delete process.env.OPENAI_COMPATIBLE_API_KEY
+      delete process.env.OPENAI_COMPATIBLE_PROVIDER_NAME
+      delete process.env.OPENAI_COMPATIBLE_MODELS
+    })
+
+    it('fetches /v1/models and filters embeddings + audio', async () => {
+      mockIsProviderEnabled.mockImplementation(
+        providerId => providerId === 'openai-compatible'
+      )
+      process.env.OPENAI_COMPATIBLE_API_BASE_URL = 'https://api.deepseek.com'
+      process.env.OPENAI_COMPATIBLE_API_KEY = 'test-key'
+      process.env.OPENAI_COMPATIBLE_PROVIDER_NAME = 'DeepSeek'
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          data: [
+            { id: 'deepseek-chat' },
+            { id: 'deepseek-reasoner' },
+            { id: 'text-embedding-3-small' },
+            { id: 'whisper-1' }
+          ]
+        })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const models = await fetchModels.fetchOpenAICompatibleModels()
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.deepseek.com/v1/models',
+        expect.objectContaining({ method: 'GET' })
+      )
+      expect(models.map(m => m.id)).toEqual([
+        'deepseek-chat',
+        'deepseek-reasoner'
+      ])
+      expect(models[0]).toMatchObject({
+        provider: 'DeepSeek',
+        providerId: 'openai-compatible'
+      })
+    })
+
+    it('strips trailing /v1 from base URL before appending /v1/models', async () => {
+      mockIsProviderEnabled.mockImplementation(
+        providerId => providerId === 'openai-compatible'
+      )
+      process.env.OPENAI_COMPATIBLE_API_BASE_URL =
+        'https://api.example.com/v1/'
+      process.env.OPENAI_COMPATIBLE_API_KEY = 'test-key'
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ data: [{ id: 'foo-1' }] })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      await fetchModels.fetchOpenAICompatibleModels()
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/v1/models',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('falls back to "OpenAI Compatible" provider name when env not set', async () => {
+      mockIsProviderEnabled.mockImplementation(
+        providerId => providerId === 'openai-compatible'
+      )
+      process.env.OPENAI_COMPATIBLE_API_BASE_URL = 'https://api.deepseek.com'
+      process.env.OPENAI_COMPATIBLE_API_KEY = 'test-key'
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ data: [{ id: 'deepseek-chat' }] })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const models = await fetchModels.fetchOpenAICompatibleModels()
+      expect(models[0]?.provider).toBe('OpenAI Compatible')
+    })
+
+    it('returns empty list when provider not enabled', async () => {
+      mockIsProviderEnabled.mockImplementation(() => false)
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      const models = await fetchModels.fetchOpenAICompatibleModels()
+      expect(models).toEqual([])
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('uses OPENAI_COMPATIBLE_MODELS static list when set, skipping fetch', async () => {
+      mockIsProviderEnabled.mockImplementation(
+        providerId => providerId === 'openai-compatible'
+      )
+      process.env.OPENAI_COMPATIBLE_MODELS =
+        'deepseek-chat, deepseek-reasoner , '
+      process.env.OPENAI_COMPATIBLE_PROVIDER_NAME = 'DeepSeek'
+
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      const models = await fetchModels.fetchOpenAICompatibleModels()
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(models.map(m => m.id)).toEqual([
+        'deepseek-chat',
+        'deepseek-reasoner'
+      ])
+      expect(models[0]?.provider).toBe('DeepSeek')
+    })
+  })
 })

--- a/lib/models/fetch-models.ts
+++ b/lib/models/fetch-models.ts
@@ -35,6 +35,15 @@ const ANTHROPIC_ALLOWED_PREFIXES = [
 ]
 const GOOGLE_ALLOWED_PREFIXES = ['gemini-2.5', 'gemini-3']
 const GOOGLE_EXCLUDED_KEYWORDS = ['image', 'live', 'native-audio', 'embedding']
+const OPENAI_COMPATIBLE_EXCLUDED_KEYWORDS = [
+  'embed',
+  'tts',
+  'whisper',
+  'audio',
+  'transcribe',
+  'image',
+  'realtime'
+]
 
 let modelsCache:
   | {
@@ -115,6 +124,12 @@ function passesGoogleFilters(id: string): boolean {
   }
 
   return !GOOGLE_EXCLUDED_KEYWORDS.some(keyword =>
+    id.toLowerCase().includes(keyword)
+  )
+}
+
+function passesOpenAICompatibleFilters(id: string): boolean {
+  return !OPENAI_COMPATIBLE_EXCLUDED_KEYWORDS.some(keyword =>
     id.toLowerCase().includes(keyword)
   )
 }
@@ -303,6 +318,71 @@ export async function fetchGoogleModels(): Promise<Model[]> {
   }
 }
 
+export async function fetchOpenAICompatibleModels(): Promise<Model[]> {
+  if (!isProviderEnabled('openai-compatible')) {
+    return []
+  }
+
+  const providerName =
+    process.env.OPENAI_COMPATIBLE_PROVIDER_NAME || 'OpenAI Compatible'
+
+  // Static-list path: when OPENAI_COMPATIBLE_MODELS is set, skip the
+  // network call and trust the comma-separated list. Useful when the
+  // provider has no /v1/models endpoint, or when that endpoint is
+  // slow / unreachable.
+  const staticList = process.env.OPENAI_COMPATIBLE_MODELS
+  if (staticList) {
+    return sortModels(
+      dedupeModels(
+        staticList
+          .split(',')
+          .map(id => id.trim())
+          .filter(Boolean)
+          .map(id => ({
+            id,
+            name: id,
+            provider: providerName,
+            providerId: 'openai-compatible'
+          }))
+      )
+    )
+  }
+
+  try {
+    const rawBaseURL = process.env.OPENAI_COMPATIBLE_API_BASE_URL || ''
+    if (!rawBaseURL) {
+      return []
+    }
+    const baseURL = rawBaseURL.replace(/\/+$/, '').replace(/\/v1$/, '')
+
+    const json = await fetchJson(`${baseURL}/v1/models`, {
+      Authorization: `Bearer ${process.env.OPENAI_COMPATIBLE_API_KEY}`
+    })
+
+    const data = Array.isArray(json?.data) ? json.data : []
+    return sortModels(
+      dedupeModels(
+        data
+          .map(item => String(item?.id ?? ''))
+          .filter(Boolean)
+          .filter(passesOpenAICompatibleFilters)
+          .map(id => ({
+            id,
+            name: id,
+            provider: providerName,
+            providerId: 'openai-compatible'
+          }))
+      )
+    )
+  } catch (error) {
+    console.warn(
+      '[ModelFetch] Failed to fetch OpenAI-compatible models:',
+      error
+    )
+    return []
+  }
+}
+
 export async function fetchOllamaModels(): Promise<Model[]> {
   if (!isProviderEnabled('ollama')) {
     return []
@@ -389,16 +469,25 @@ export async function fetchAvailableModels(options?: {
     return modelsCache.value
   }
 
-  const [openai, anthropic, google, ollama, gateway] = await Promise.all([
-    fetchOpenAIModels(),
-    fetchAnthropicModels(),
-    fetchGoogleModels(),
-    fetchOllamaModels(),
-    fetchGatewayModels()
-  ])
+  const [openai, anthropic, google, openaiCompatible, ollama, gateway] =
+    await Promise.all([
+      fetchOpenAIModels(),
+      fetchAnthropicModels(),
+      fetchGoogleModels(),
+      fetchOpenAICompatibleModels(),
+      fetchOllamaModels(),
+      fetchGatewayModels()
+    ])
 
   const grouped = groupByProvider(
-    dedupeModels([...openai, ...anthropic, ...google, ...ollama, ...gateway])
+    dedupeModels([
+      ...openai,
+      ...anthropic,
+      ...google,
+      ...openaiCompatible,
+      ...ollama,
+      ...gateway
+    ])
   )
 
   // Keep stable ordering for each provider list.


### PR DESCRIPTION
## Problem
When `OPENAI_COMPATIBLE_API_KEY` + `OPENAI_COMPATIBLE_API_BASE_URL` are configured (e.g. for DeepSeek), the provider is registered but the model selector dropdown is empty — users can't pick a model.

## Root cause
`lib/models/fetch-models.ts` has dedicated fetchers for `openai` / `anthropic` / `google` / `ollama` / `gateway`, but none for `openai-compatible`. `fetchAvailableModels()` therefore never enumerates models from that provider, even though the registry knows about it.

## Fix
Add `fetchOpenAICompatibleModels()`, wired into `fetchAvailableModels()`'s `Promise.all`:

- If `OPENAI_COMPATIBLE_MODELS` env is set (comma-separated whitelist), use it directly — needed for hosts without a `/v1/models` endpoint and useful in dev when that endpoint is slow / unreachable
- Otherwise, `GET ${baseURL}/v1/models` (stripping a trailing `/v1` so both URL shapes work) and filter out embeddings, audio, and image models
- Display name comes from `OPENAI_COMPATIBLE_PROVIDER_NAME` env, falling back to `"OpenAI Compatible"`

## Files changed
- `lib/models/fetch-models.ts` — new fetcher, hooked into `fetchAvailableModels()`
- `lib/models/__tests__/fetch-models.test.ts` — 5 new cases: dynamic fetch + filter, `/v1` URL normalization, fallback display name, disabled-provider short-circuit, static whitelist path
- `.env.local.example` — Option 6 section documenting `OPENAI_COMPATIBLE_PROVIDER_NAME` and `OPENAI_COMPATIBLE_MODELS`

## Testing
- `bun lint` / `bun typecheck` / `bun run test` pass (24 files / 205 tests, 5 new)
- Manual: selector now lists models under "DeepSeek" with the env vars set

## Note
Pairs with #846. Without that PR the selected model is listed but still 404s at chat time.