### PR TITLE
fix(chat): treat Opt/Cmd/Ctrl+Enter as newline, not submit

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -270,11 +270,16 @@ export function ChatPanel({
             className="resize-none w-full min-h-12 bg-transparent border-0 p-3 md:p-4 text-sm placeholder:text-muted-foreground focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
             onChange={handleInputChange}
             onKeyDown={e => {
+              if (e.key !== 'Enter' || isComposing || enterDisabled) {
+                return
+              }
+
+              // Plain Enter (no modifiers) → submit
               if (
-                e.key === 'Enter' &&
                 !e.shiftKey &&
-                !isComposing &&
-                !enterDisabled
+                !e.altKey &&
+                !e.metaKey &&
+                !e.ctrlKey
               ) {
                 if (input.trim().length === 0) {
                   e.preventDefault()
@@ -283,9 +288,26 @@ export function ChatPanel({
                 e.preventDefault()
                 const textarea = e.target as HTMLTextAreaElement
                 textarea.form?.requestSubmit()
-                // Reset focus state after Enter key submission
                 setIsInputFocused(false)
                 textarea.blur()
+                return
+              }
+
+              // Shift+Enter falls through to textarea default (inserts \n).
+              // Alt/Option+Enter on macOS does NOT insert \n by default,
+              // so insert it manually to match user expectation.
+              if (e.altKey && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+                e.preventDefault()
+                const textarea = e.target as HTMLTextAreaElement
+                const start = textarea.selectionStart ?? input.length
+                const end = textarea.selectionEnd ?? input.length
+                const next = input.slice(0, start) + '\n' + input.slice(end)
+                handleInputChange({
+                  target: { value: next }
+                } as React.ChangeEvent<HTMLTextAreaElement>)
+                requestAnimationFrame(() => {
+                  textarea.selectionStart = textarea.selectionEnd = start + 1
+                })
               }
             }}
           />

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -84,7 +84,29 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
       return
     }
 
-    if (event.shiftKey || isComposing || enterDisabled) {
+    // Any modifier (Shift / Alt / Meta / Ctrl) + Enter → let it insert a
+    // newline instead of submitting the edit.
+    if (
+      event.shiftKey ||
+      event.altKey ||
+      event.metaKey ||
+      event.ctrlKey ||
+      isComposing ||
+      enterDisabled
+    ) {
+      // Alt+Enter on macOS does not insert \n by default; do it manually.
+      if (event.altKey && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
+        event.preventDefault()
+        const textarea = event.target as HTMLTextAreaElement
+        const start = textarea.selectionStart ?? editedContent.length
+        const end = textarea.selectionEnd ?? editedContent.length
+        const next =
+          editedContent.slice(0, start) + '\n' + editedContent.slice(end)
+        setEditedContent(next)
+        requestAnimationFrame(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + 1
+        })
+      }
       return
     }
 


### PR DESCRIPTION
## Problem
Opt+Enter and Cmd+Enter in the chat input submit the message instead of inserting a newline. This is the opposite of the convention used by ChatGPT, Claude, and most other chat UIs.

Repro:
1. Type a question in the chat input
2. Press Opt+Enter (or Cmd+Enter)
3. Message sends; no newline is inserted

## Root cause
`components/chat-panel.tsx:273-278` only excludes `shiftKey` from the submit branch:

```ts
if (
  e.key === 'Enter' &&
  !e.shiftKey &&     // ← altKey / metaKey / ctrlKey are not checked
  !isComposing &&
  !enterDisabled
) {
  ...
  textarea.form?.requestSubmit()
}
```

`components/user-text-section.tsx` (the inline editor for previously-sent user messages) has the same gap.

## Fix
- Add `!e.altKey && !e.metaKey && !e.ctrlKey` to the submit guard in both files
- Opt/Alt+Enter additionally inserts `\n` manually, since macOS does not natively insert a newline for Option+Enter in a textarea
- Cmd+Enter / Ctrl+Enter fall through to the browser default (no-op in a textarea)

Resulting behavior:

| Key | Action |
|---|---|
| Enter | submit |
| Shift+Enter | newline (textarea default) |
| Opt/Alt+Enter | newline (inserted manually) |
| Cmd+Enter, Ctrl+Enter | no-op |

## Files changed
- `components/chat-panel.tsx`
- `components/user-text-section.tsx`

## Testing
- `bun lint` / `bun typecheck` pass
- Manual on macOS Chrome: each key combination behaves as listed above