### PR TITLE
fix(chat): shorten post-composition Enter debounce

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -91,10 +91,14 @@ export function ChatPanel({
 
   const handleCompositionEnd = () => {
     setIsComposing(false)
+    // Brief debounce — the candidate-confirm Enter that fires
+    // immediately after compositionend may otherwise be treated as a
+    // submit. 50ms is enough to swallow that synchronous event but
+    // short enough not to drop a real "finish typing, press Enter".
     setEnterDisabled(true)
     setTimeout(() => {
       setEnterDisabled(false)
-    }, 300)
+    }, 50)
   }
 
   const handleNewChat = useCallback(() => {
@@ -270,10 +274,16 @@ export function ChatPanel({
             className="resize-none w-full min-h-12 bg-transparent border-0 p-3 md:p-4 text-sm placeholder:text-muted-foreground focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
             onChange={handleInputChange}
             onKeyDown={e => {
+              // e.nativeEvent.isComposing is the most reliable signal —
+              // it stays true on the keydown that confirms an IME
+              // candidate, even after the React-level isComposing state
+              // has been flipped. Belt-and-braces with isComposing and
+              // the short enterDisabled debounce.
               if (
                 e.key === 'Enter' &&
                 !e.shiftKey &&
                 !isComposing &&
+                !(e.nativeEvent as KeyboardEvent).isComposing &&
                 !enterDisabled
               ) {
                 if (input.trim().length === 0) {

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -84,7 +84,14 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
       return
     }
 
-    if (event.shiftKey || isComposing || enterDisabled) {
+    // event.nativeEvent.isComposing catches the IME candidate-confirm
+    // Enter even after the React-level isComposing state has flipped.
+    if (
+      event.shiftKey ||
+      isComposing ||
+      (event.nativeEvent as KeyboardEvent).isComposing ||
+      enterDisabled
+    ) {
       return
     }
 
@@ -105,7 +112,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
     enterResetTimeoutRef.current = setTimeout(() => {
       setEnterDisabled(false)
       enterResetTimeoutRef.current = null
-    }, 300)
+    }, 50)
   }
 
   return (


### PR DESCRIPTION
## Problem
With any IME active (Chinese, Japanese, Korean, etc.), pressing Enter immediately after finishing a word inserts a newline instead of submitting. Pressing Enter a **second** time sends. With Chinese IME this happens on essentially every message.

## Root cause
`components/chat-panel.tsx:92-98` disables the Enter-to-submit path for **300 ms** after every `compositionend`, originally introduced to swallow the candidate-confirm Enter:

```ts
const handleCompositionEnd = () => {
  setIsComposing(false)
  setEnterDisabled(true)
  setTimeout(() => setEnterDisabled(false), 300)
}
```

300 ms is longer than the natural ~100-200 ms gap between "finish typing the last character" and "press Enter to send", so a deliberate Enter falls inside the debounce window and is treated as a newline.

`components/user-text-section.tsx` has the same logic with the same 300 ms.

## Fix
Two complementary changes in both files:

1. **Timeout 300 ms → 50 ms.** The candidate-confirm Enter arrives in the same event loop tick as `compositionend` (< 10 ms gap), so 50 ms still reliably swallows it but is below human "type then press Enter" latency.

2. **Check `e.nativeEvent.isComposing` on the keydown itself.** Browsers set it `true` on the candidate-confirm Enter even after React's `onCompositionEnd` has flipped the React-level `isComposing` state. With this check the candidate Enter is rejected even when the 50 ms timeout has already elapsed — works as a safety net for IMEs that fire `compositionend` before the keydown.

## Files changed
- `components/chat-panel.tsx`
- `components/user-text-section.tsx`

## Testing
- `bun lint` / `bun typecheck` pass
- Manual on macOS Chrome with Pinyin IME:
  - Candidate-confirm Enter no longer submits
  - "Finish typing → press Enter once" submits as expected