### PR TITLE
fix(supabase): warn at most once when Supabase config is missing

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -2,15 +2,20 @@ import { createBrowserClient } from '@supabase/ssr'
 
 import { getSupabasePublishableKey } from './keys'
 
+let warnedOnce = false
+
 export function createClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = getSupabasePublishableKey()
 
   if (!url || !key) {
-    console.warn(
-      'Supabase client configuration missing. Authentication features will be unavailable. ' +
-        'To enable authentication, set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY at build time.'
-    )
+    if (!warnedOnce) {
+      warnedOnce = true
+      console.warn(
+        'Supabase client configuration missing. Authentication features will be unavailable. ' +
+          'To enable authentication, set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY at build time.'
+      )
+    }
     throw new Error('Supabase not configured')
   }
 


### PR DESCRIPTION
## Problem
In `ENABLE_AUTH=false` anonymous mode the devtools console fills up with 20+ identical warnings:

```
Supabase client configuration missing. Authentication features will be unavailable.
To enable authentication, set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY at build time.
```

## Root cause
`lib/supabase/client.ts:10` calls `console.warn(...)` on every `createClient()` invocation when the env is missing. About 8 distinct call sites (`hooks/use-current-user-name.ts`, `components/user-menu.tsx`, `components/login-form.tsx`, etc.) call it through normal React lifecycle, and each re-mount produces another warning, so a single anonymous-mode page load can show 20+ copies of the same message. All callers already wrap the call in `try/catch` and degrade gracefully, so the warning is informational only — but the noise drowns out genuine console errors.

## Fix
Gate the `console.warn` behind a module-level `warnedOnce` flag so the message still appears exactly once per session (preserves the original discoverability signal for developers who actually want Supabase auth) but stops flooding the console.

## Files changed
- `lib/supabase/client.ts`

## Testing
- `bun lint` / `bun typecheck` pass
- Manual: with `ENABLE_AUTH=false` and no `NEXT_PUBLIC_SUPABASE_*` env, the warning now shows once instead of ~20 times after a full page interaction