### PR TITLE
fix(chat): ignore Related-question clicks while a response is streaming

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 import { useChat } from '@ai-sdk/react'
@@ -86,6 +86,14 @@ export function Chat({
     message: ''
   })
 
+  // Locally-maintained streaming flag exposed through ChatContext so
+  // programmatic dispatch sites (e.g. Related-question buttons in
+  // spec-block) can throttle clicks. Held in a ref so closures
+  // captured by @json-render/react's ActionProvider (which freezes
+  // its `handlers` prop via useState(initialHandlers)) can still see
+  // the freshest value through `.current`. See lib/contexts/chat-context.tsx.
+  const isStreamingRef = useRef(false)
+
   const {
     messages,
     status,
@@ -130,9 +138,11 @@ export function Chat({
     }),
     messages: savedMessages,
     onFinish: () => {
+      isStreamingRef.current = false
       window.dispatchEvent(new CustomEvent('chat-history-updated'))
     },
     onError: error => {
+      isStreamingRef.current = false
       // Handle rate limiting errors from Vercel WAF
       // Check for status codes in error message or specific rate limit indicators
       const errorMessage = error.message?.toLowerCase() || ''
@@ -215,6 +225,17 @@ export function Chat({
     experimental_throttle: 100,
     generateId
   })
+
+  // Wrap sendMessage so every dispatch flips isStreamingRef on; onFinish
+  // and onError flip it off. Use this in place of the raw sendMessage at
+  // every call site so the throttle is uniform.
+  const safeSendMessage = useCallback<typeof sendMessage>(
+    (...args) => {
+      isStreamingRef.current = true
+      return sendMessage(...args)
+    },
+    [sendMessage]
+  )
 
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value)
@@ -439,7 +460,7 @@ export function Chat({
         })
       })
 
-      sendMessage({ role: 'user', parts })
+      safeSendMessage({ role: 'user', parts })
       setInput('')
       setUploadedFiles([])
 
@@ -474,7 +495,10 @@ export function Chat({
     : { isDragging, handleDragOver, handleDragLeave, handleDrop }
 
   return (
-    <ChatProvider sendMessage={sendMessage}>
+    <ChatProvider
+      sendMessage={safeSendMessage}
+      isStreamingRef={isStreamingRef}
+    >
       <div
         className={cn(
           'relative flex h-full min-w-0 flex-1 flex-col',
@@ -542,7 +566,7 @@ export function Chat({
           stop={stop}
           query={query}
           append={(message: any) => {
-            sendMessage(message)
+            safeSendMessage(message)
           }}
           showScrollToBottomButton={!isAtBottom}
           uploadedFiles={uploadedFiles}
@@ -568,7 +592,7 @@ export function Chat({
                       .filter(m => m.role === 'user')
                       .pop()
                     if (lastUserMessage) {
-                      sendMessage(lastUserMessage)
+                      safeSendMessage(lastUserMessage)
                     }
                   }
                 }

--- a/components/spec-block.tsx
+++ b/components/spec-block.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react'
 
 import { ActionProvider, JSONUIProvider, Renderer } from '@json-render/react'
+import { toast } from 'sonner'
 
 import { useChatContext } from '@/lib/contexts/chat-context'
 import { registry } from '@/lib/render/registry'
@@ -19,12 +20,22 @@ export function SpecBlock({ result }: SpecBlockProps) {
     () => ({
       submitQuery: (params: Record<string, unknown>) => {
         const query = (params as { query?: string }).query
-        if (typeof query === 'string' && query.trim()) {
-          chatContext.sendMessage({
-            role: 'user',
-            parts: [{ type: 'text', text: query }]
-          })
+        if (typeof query !== 'string' || !query.trim()) return
+
+        // Reject clicks while a response is in flight. Firing a second
+        // sendMessage mid-stream corrupts useChat's internal state and
+        // leaves the input box stuck disabled. Read via the ref so the
+        // frozen closure (ActionProvider stores handlers as
+        // useState(initialHandlers)) still sees the latest value.
+        if (chatContext.isStreamingRef.current) {
+          toast.info('Please wait for the current response to finish.')
+          return
         }
+
+        chatContext.sendMessage({
+          role: 'user',
+          parts: [{ type: 'text', text: query }]
+        })
       }
     }),
     [chatContext]

--- a/lib/contexts/chat-context.tsx
+++ b/lib/contexts/chat-context.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { MutableRefObject } from 'react'
 import { createContext, useContext } from 'react'
 
 type ChatContextValue = {
@@ -7,16 +8,25 @@ type ChatContextValue = {
     role: 'user'
     parts: Array<{ type: 'text'; text: string }>
   }) => void
+  // Ref (not state) so reads via `.current` always see the freshest
+  // value, even when the consumer is downstream of
+  // @json-render/react's ActionProvider — which captures its handlers
+  // prop into useState(initialHandlers) and never refreshes them,
+  // making any React-state value read through closure go stale on the
+  // very next render. Maintained by chat.tsx: set to true inside
+  // safeSendMessage, cleared inside useChat's onFinish / onError.
+  isStreamingRef: MutableRefObject<boolean>
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null)
 
 export function ChatProvider({
   sendMessage,
+  isStreamingRef,
   children
 }: ChatContextValue & { children: React.ReactNode }) {
   return (
-    <ChatContext.Provider value={{ sendMessage }}>
+    <ChatContext.Provider value={{ sendMessage, isStreamingRef }}>
       {children}
     </ChatContext.Provider>
   )


### PR DESCRIPTION
Closes #851.

## Problem
Clicking a Related follow-up button while the assistant is still streaming dispatches a second `sendMessage` into a `useChat` hook that's mid-stream. The result is a triple breakage that the user typically experiences as the input "freezing":

1. Two assistant messages end up with the same id → React "duplicate key" warnings (10+ per session, tracked separately in #852).
2. The chat input stays `disabled` for 5–10 seconds after the final token arrives.
3. The next render throws `TypeError: Cannot read properties of undefined (reading 'state')` from a tool part rendered with half-populated input.

## Root cause
`components/spec-block.tsx`'s `submitQuery` handler calls `chatContext.sendMessage(...)` with no guard on whether `useChat` is currently busy.

Two follow-on traps make a naive fix not work:

1. **`useChat.status` is unreliable** — it doesn't always transition back to `'ready'` once a stream contains tool calls or spec blocks. Guarding on `status === 'streaming'` rejects clicks that should be allowed.
2. **Stale closures** — `@json-render/react`'s `ActionProvider` stores its `handlers` prop in `useState(initialHandlers)` (see `node_modules/@json-render/react/dist/index.js:460`) and never refreshes it. Any closure that reads a React-state value through `useChatContext()` freezes at mount time. When the Related buttons mount, `isStreaming` is `true`, so a state-based check stays `true` forever.

## Fix
Local `MutableRefObject<boolean>` exposed through `ChatContext`:

- `chat.tsx` declares `isStreamingRef = useRef(false)`.
- Every `sendMessage` call goes through a `safeSendMessage` wrapper that sets `isStreamingRef.current = true` first. All four call sites (form submit, `append` prop, error-modal retry, ChatProvider passthrough) use the wrapper.
- `useChat`'s `onFinish` and `onError` set `isStreamingRef.current = false`.
- `ChatContext` exposes the ref (not a boolean) so the consumer's frozen closure still reads through `.current` — the object reference is stable, only its inner value changes, and React doesn't need to re-render to keep `.current` fresh.
- `spec-block.tsx` checks `chatContext.isStreamingRef.current` and `toast.info`s + no-ops while a response is in flight.

## Files changed
- `lib/contexts/chat-context.tsx` — replace `sendMessage`-only context with `{ sendMessage, isStreamingRef }`
- `components/chat.tsx` — `isStreamingRef` + `safeSendMessage`, wire through 4 dispatch sites + onFinish/onError
- `components/spec-block.tsx` — guard `submitQuery` on `isStreamingRef.current`

## Testing
- `bun lint` / `bun typecheck` pass
- Manual on macOS Chrome:
  - Ask a question → wait for Related buttons → click one → submits normally
  - Ask a question → click two Related buttons in quick succession before stream ends → only first is accepted, second shows toast "Please wait for the current response to finish."
  - Input is no longer stuck disabled, and the `TypeError ... 'state'` no longer appears

## Open design question
This touches the `ChatContext` API (adds `isStreamingRef`). I chose a ref rather than a boolean specifically because of the `ActionProvider`-freezes-handlers behavior described above. If a different shape would fit the project better — e.g. a `disabled` prop on the QuestionButton registered in `lib/render/registry.tsx`, or server-side rejection — happy to rework.