### PR TITLE
fix(chat): dedupe messages by id when building sections

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -220,14 +220,21 @@ export function Chat({
     setInput(e.target.value)
   }
 
-  // Convert messages array to sections array
+  // Convert messages array to sections array.
+  // Deduplicate by message.id — @ai-sdk/react useChat can occasionally
+  // surface the same assistant message twice during stream finalization,
+  // which would otherwise produce React 'duplicate key' warnings in
+  // chat-messages.tsx (one warning per re-render).
   const sections = useMemo<ChatSection[]>(() => {
     const result: ChatSection[] = []
+    const seenIds = new Set<string>()
     let currentSection: ChatSection | null = null
 
     for (const message of messages) {
+      if (seenIds.has(message.id)) continue
+      seenIds.add(message.id)
+
       if (message.role === 'user') {
-        // Start a new section when a user message is found
         if (currentSection) {
           result.push(currentSection)
         }
@@ -237,13 +244,10 @@ export function Chat({
           assistantMessages: []
         }
       } else if (currentSection && message.role === 'assistant') {
-        // Add assistant message to the current section
         currentSection.assistantMessages.push(message)
       }
-      // Ignore other role types like 'system' for now
     }
 
-    // Add the last section if exists
     if (currentSection) {
       result.push(currentSection)
     }


### PR DESCRIPTION
Refs #852.

## Problem
React emits the following warning multiple times during a normal chat exchange:

```
Encountered two children with the same key, '<assistantMessage.id>'.
...
    at <unknown> (components/chat-messages.tsx:208:17)
    at Array.map (<anonymous>)
```

The same warning is logged once per render (typically 5–10 times) because both copies of the message keep re-rendering.

## Root cause
`useChat` from `@ai-sdk/react@3.0.158` (on top of `ai@6.0.156`) occasionally emits the same assistant message twice in its `messages` array during stream finalization. The exact failure mode lives in the AI SDK; this PR addresses the downstream symptom only.

In `components/chat.tsx` the `sections` `useMemo` iterates `messages` in order and pushes each one into a `ChatSection`. When two messages share an id, both flow through, both render with the same React `key={assistantMessage.id}`, and the warning fires.

## Fix
Guard the section builder with a `seenIds = new Set<string>()` and skip previously-seen ids. ~3 lines of code, zero behavior change for the non-duplicated case.

```ts
const seenIds = new Set<string>()
for (const message of messages) {
  if (seenIds.has(message.id)) continue
  seenIds.add(message.id)
  // ... existing user/assistant branching
}
```

This is intentionally a **defensive downstream patch**. The proper fix lives in the AI SDK and is worth tracking separately (#852 contains more detail and reproduction notes). Merging this in morphic still has value because:

- It eliminates the warning today without waiting on an upstream release cycle
- It hardens morphic against any future race that produces duplicate ids (e.g. the concurrent-dispatch path in #851, before that's fully fixed)
- It's pure dedupe — non-duplicated streams render identically to today

If you'd rather keep morphic's render layer thin and pursue an upstream-only fix, feel free to close this and I'll file against `vercel/ai`.

## Files changed
- `components/chat.tsx` — dedupe by `message.id` in the sections builder

## Testing
- `bun lint` / `bun typecheck` pass
- Manual: with two same-id messages injected via React DevTools, only the first renders and no duplicate-key warning appears; normal chats render identically to before