### PR TITLE
improve openai-compatible provider docs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -38,7 +38,8 @@ OPENAI_API_KEY=[YOUR_OPENAI_API_KEY]
 # Any provider that exposes /v1/chat/completions in the OpenAI shape.
 # OPENAI_COMPATIBLE_API_KEY=[YOUR_API_KEY]
 # OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com
-# Optional display name in the model selector (defaults to "OpenAI Compatible")
+# Optional display name in the model selector. This is a UI label only; the
+# internal provider id remains "openai-compatible". Defaults to "OpenAI Compatible".
 # OPENAI_COMPATIBLE_PROVIDER_NAME=DeepSeek
 # Optional comma-separated model whitelist. When set, the app skips the
 # /v1/models HTTP call and uses this list directly. Required for providers

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An AI-powered search engine with a generative UI.
 
 - AI-powered search with GenerativeUI
 - Search modes: Quick and Adaptive
-- Model selector with dynamic provider detection (OpenAI, Anthropic, Google, Ollama, Vercel AI Gateway)
+- Model selector with dynamic provider detection (OpenAI, Anthropic, Google, Ollama, Vercel AI Gateway, OpenAI-compatible providers)
 - Multiple search providers (Tavily, SearXNG, Brave, Exa)
 - Chat history stored in PostgreSQL
 - Share search results with unique URLs
@@ -58,7 +58,7 @@ cp .env.local.example .env.local
 OPENAI_API_KEY=your_openai_key
 ```
 
-See [supported providers](./docs/CONFIGURATION.md#supported-providers) for other options (Anthropic, Google, Ollama, Vercel AI Gateway).
+See [supported providers](./docs/CONFIGURATION.md#supported-providers) for other options (Anthropic, Google, Ollama, Vercel AI Gateway, OpenAI-compatible providers).
 
 3. Start all services:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -85,6 +85,36 @@ OLLAMA_BASE_URL=http://localhost:11434
 
 When configured, Ollama models are discovered dynamically and appear in the model selector.
 
+#### OpenAI-Compatible Providers
+
+Use OpenAI-compatible endpoints for providers such as DeepSeek, Moonshot, Zhipu, Together, or a self-hosted gateway that exposes the OpenAI chat completions API.
+
+```bash
+OPENAI_COMPATIBLE_API_KEY=[YOUR_API_KEY]
+OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com
+```
+
+Morphic sends chat requests to `/v1/chat/completions`. You can provide either a base URL with or without `/v1`; both of these resolve to the same endpoint:
+
+```bash
+OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com
+OPENAI_COMPATIBLE_API_BASE_URL=https://api.deepseek.com/v1
+```
+
+The model selector tries to load models from `/v1/models`. If your provider does not expose that endpoint, or you want to restrict the choices shown in the UI, set a comma-separated model list:
+
+```bash
+OPENAI_COMPATIBLE_MODELS=deepseek-chat,deepseek-reasoner
+```
+
+You can also customize the provider label shown in the model selector:
+
+```bash
+OPENAI_COMPATIBLE_PROVIDER_NAME=DeepSeek
+```
+
+This value is only a UI display name. The internal provider id remains `openai-compatible`.
+
 ## Search Providers
 
 ### SearXNG Configuration

--- a/lib/models/__tests__/fetch-models.test.ts
+++ b/lib/models/__tests__/fetch-models.test.ts
@@ -284,8 +284,7 @@ describe('fetch-models', () => {
       mockIsProviderEnabled.mockImplementation(
         providerId => providerId === 'openai-compatible'
       )
-      process.env.OPENAI_COMPATIBLE_API_BASE_URL =
-        'https://api.example.com/v1/'
+      process.env.OPENAI_COMPATIBLE_API_BASE_URL = 'https://api.example.com/v1/'
       process.env.OPENAI_COMPATIBLE_API_KEY = 'test-key'
 
       const fetchMock = vi.fn().mockResolvedValue({

--- a/lib/utils/registry.ts
+++ b/lib/utils/registry.ts
@@ -20,7 +20,9 @@ const providers: Record<string, any> = {
   anthropic,
   google,
   'openai-compatible': createOpenAICompatible({
-    name: process.env.OPENAI_COMPATIBLE_PROVIDER_NAME || 'openai-compatible',
+    // Keep the SDK provider key stable. OPENAI_COMPATIBLE_PROVIDER_NAME is
+    // only a UI label used by the model selector.
+    name: 'openai-compatible',
     apiKey: process.env.OPENAI_COMPATIBLE_API_KEY,
     baseURL: normalizeOpenAICompatibleBaseURL(
       process.env.OPENAI_COMPATIBLE_API_BASE_URL || ''


### PR DESCRIPTION
## Summary

- Keep the OpenAI-compatible SDK provider key fixed as `openai-compatible`
- Clarify that `OPENAI_COMPATIBLE_PROVIDER_NAME` is only the model selector display label
- Document OpenAI-compatible provider setup, `/v1` base URL normalization, and static model lists
- Update the README provider list and apply Prettier to the newly merged fetch-models test

## Validation

- `bun typecheck`
- `bun lint`
- `bun run test lib/models/__tests__/fetch-models.test.ts`
- targeted Prettier check
- `git diff --check`