### PR TITLE
Refine mobile follow-up search previews

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -34,6 +34,10 @@ interface ChatMessagesProps {
   error?: Error | string | null | undefined
 }
 
+const DESKTOP_LATEST_SECTION_OFFSET = 196
+const MOBILE_LATEST_SECTION_OFFSET_FALLBACK = 180
+const MOBILE_FOLLOW_UP_TOP_CLEARANCE_FALLBACK = 56
+
 export function ChatMessages({
   sections,
   status,
@@ -53,9 +57,34 @@ export function ChatMessages({
   const toolCountCacheRef = useRef<Map<string, number>>(new Map())
   const isLoading = status === 'submitted' || status === 'streaming'
   const isMobile = useMediaQuery('(max-width: 767px)')
+  const [scrollViewportHeight, setScrollViewportHeight] = useState(0)
+  const [mobileFollowUpTopClearance, setMobileFollowUpTopClearance] = useState(
+    MOBILE_FOLLOW_UP_TOP_CLEARANCE_FALLBACK
+  )
 
   // Tool types definition - moved outside function for performance
   const toolTypes = ['tool-search', 'tool-fetch', 'tool-askQuestion']
+
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    const updateMetrics = () => {
+      const { paddingTop } = getComputedStyle(container)
+      setScrollViewportHeight(container.clientHeight)
+      setMobileFollowUpTopClearance(
+        parseFloat(paddingTop) || MOBILE_FOLLOW_UP_TOP_CLEARANCE_FALLBACK
+      )
+    }
+    updateMetrics()
+
+    if (typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(updateMetrics)
+    observer.observe(container)
+
+    return () => observer.disconnect()
+  }, [scrollContainerRef])
 
   // Clear cache during streaming to ensure accurate tool counts
   useEffect(() => {
@@ -65,11 +94,14 @@ export function ChatMessages({
     }
   }, [isLoading])
 
-  // Calculate the offset height based on device type
-  // Note: pt-14 (56px) on scroll-container must be included in desktop offset
-  const offsetHeight = isMobile
-    ? 208 // Mobile: larger offset for mobile header/input (pt-14 = 56px)
-    : 196 // Desktop: smaller offset (140px) + pt-14 (56px)
+  const latestSectionMinHeight =
+    isMobile && scrollViewportHeight > 0
+      ? `${Math.max(0, scrollViewportHeight - mobileFollowUpTopClearance)}px`
+      : `calc(100dvh - ${
+          isMobile
+            ? MOBILE_LATEST_SECTION_OFFSET_FALLBACK
+            : DESKTOP_LATEST_SECTION_OFFSET
+        }px)`
 
   // Extract citation maps from all messages in all sections
   const allCitationMaps = useMemo(() => {
@@ -175,7 +207,7 @@ export function ChatMessages({
             className="chat-section scroll-mt-14 pb-4 md:pb-14"
             style={
               sectionIndex === sections.length - 1
-                ? { minHeight: `calc(100dvh - ${offsetHeight}px)` }
+                ? { minHeight: latestSectionMinHeight }
                 : {}
             }
           >

--- a/components/search-results-image.tsx
+++ b/components/search-results-image.tsx
@@ -387,5 +387,5 @@ export const SearchResultsImageSection: React.FC<
   }
 
   const previewImages = displayImages.slice(0, 4)
-  return renderImageGrid(previewImages, 'grid grid-cols-2 md:grid-cols-4 gap-2')
+  return renderImageGrid(previewImages, 'grid grid-cols-4 gap-2')
 }

--- a/components/search-results-image.tsx
+++ b/components/search-results-image.tsx
@@ -319,7 +319,7 @@ export const SearchResultsImageSection: React.FC<
             </DialogTrigger>
             <DialogContent className="max-w-[90vw] sm:max-w-[90vw] max-h-[90vh] overflow-auto border border-white/10 bg-black/60 shadow-2xl backdrop-blur-md">
               <DialogHeader>
-                <DialogTitle className="text-white">Images</DialogTitle>
+                <DialogTitle className="sr-only">Images</DialogTitle>
                 <DialogDescription className="text-sm text-white/70">
                   {query}
                 </DialogDescription>

--- a/components/search-results.tsx
+++ b/components/search-results.tsx
@@ -78,16 +78,16 @@ export function SearchResults({
 
   // --- Grid Mode Rendering (Existing Logic) ---
   return (
-    <div className="flex flex-wrap -m-1">
+    <div className="flex flex-col gap-1 md:-m-1 md:flex-row md:flex-wrap md:gap-0">
       {displayedGridResults.map((result, index) => (
-        <div className="w-1/2 md:w-1/4 p-1 min-w-0" key={index}>
+        <div className="min-w-0 md:w-1/4 md:p-1" key={index}>
           <Link href={result.url} passHref target="_blank">
-            <Card className="flex-1 h-full hover:bg-muted/50 transition-colors">
-              <CardContent className="p-2 flex flex-col justify-between h-full min-w-0">
-                <p className="text-xs line-clamp-2 min-h-8">
+            <Card className="h-full flex-1 rounded-md hover:bg-muted/50 transition-colors">
+              <CardContent className="flex h-full min-w-0 items-center justify-between gap-2 p-2 md:flex-col md:items-stretch">
+                <p className="min-w-0 flex-1 line-clamp-1 text-xs md:min-h-8 md:line-clamp-2">
                   {result.title || result.content}
                 </p>
-                <div className="mt-2 flex items-center space-x-1 min-w-0">
+                <div className="flex max-w-[42%] shrink-0 items-center space-x-1 min-w-0 md:mt-2 md:max-w-full md:shrink">
                   <Avatar className="h-4 w-4 shrink-0">
                     <AvatarImage
                       src={`https://www.google.com/s2/favicons?domain=${
@@ -109,18 +109,14 @@ export function SearchResults({
         </div>
       ))}
       {!showAllResults && additionalResultsCount > 0 && (
-        <div className="w-1/2 md:w-1/4 p-1">
-          <Card className="flex-1 flex h-full items-center justify-center">
-            <CardContent className="p-2">
-              <Button
-                variant={'link'}
-                className="text-muted-foreground"
-                onClick={handleViewMore}
-              >
-                View {additionalResultsCount} more
-              </Button>
-            </CardContent>
-          </Card>
+        <div className="flex justify-center py-1 md:w-1/4 md:p-1">
+          <Button
+            variant="link"
+            className="h-auto px-2 py-1 text-muted-foreground"
+            onClick={handleViewMore}
+          >
+            View {additionalResultsCount} more
+          </Button>
         </div>
       )}
     </div>

--- a/components/search-results.tsx
+++ b/components/search-results.tsx
@@ -109,15 +109,30 @@ export function SearchResults({
         </div>
       ))}
       {!showAllResults && additionalResultsCount > 0 && (
-        <div className="flex justify-center py-1 md:w-1/4 md:p-1">
-          <Button
-            variant="link"
-            className="h-auto px-2 py-1 text-muted-foreground"
-            onClick={handleViewMore}
-          >
-            View {additionalResultsCount} more
-          </Button>
-        </div>
+        <>
+          <div className="flex justify-center py-1 md:hidden">
+            <Button
+              variant="link"
+              className="h-auto px-2 py-1 text-muted-foreground"
+              onClick={handleViewMore}
+            >
+              View {additionalResultsCount} more
+            </Button>
+          </div>
+          <div className="hidden md:block md:w-1/4 md:p-1">
+            <Card className="flex h-full flex-1 items-center justify-center">
+              <CardContent className="p-2">
+                <Button
+                  variant="link"
+                  className="text-muted-foreground"
+                  onClick={handleViewMore}
+                >
+                  View {additionalResultsCount} more
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- Align the latest mobile follow-up section using the actual scroll viewport and top padding, so the follow-up section lands at the top while previous assistant actions are hidden above it.
- Make chat search image previews one compact 4-column row on mobile.
- Compact mobile source results into slim rows and make the "View more" affordance a text button on mobile while preserving the existing card treatment on desktop.
- Hide the visible "Images" heading in the image dialog while keeping an accessible dialog title.

## Validation

- `bun lint`
- `bun typecheck`
- `bun run build` (passed after allowing network for Google Fonts)
- `bun run test`
- `./node_modules/.bin/prettier --check components/search-results.tsx components/search-results-image.tsx components/chat-messages.tsx`
- In-app browser checks at mobile width for follow-up alignment, compact search previews, text-only mobile view-more button, and hidden image-dialog title