### PR TITLE
Fix dotted citation labels

### DIFF
--- a/components/citation-link.tsx
+++ b/components/citation-link.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 
 import type { SearchResultItem } from '@/lib/types'
 import { cn } from '@/lib/utils'
+import { isCitationLabel } from '@/lib/utils/citation'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
@@ -37,8 +38,7 @@ export const CitationLink = memo(function CitationLink({
 }: CitationLinkProps) {
   const [open, setOpen] = useState(false)
   const childrenText = children?.toString() || ''
-  // Match domain names (alphanumeric and hyphens) or numbers for backward compatibility
-  const isCitation = /^[\w-]+$/.test(childrenText)
+  const isCitation = isCitationLabel(childrenText)
 
   const linkClasses = cn(
     isCitation

--- a/components/custom-link.tsx
+++ b/components/custom-link.tsx
@@ -1,7 +1,7 @@
 import { AnchorHTMLAttributes, DetailedHTMLProps } from 'react'
 
 import type { SearchResultItem } from '@/lib/types'
-import { cn } from '@/lib/utils'
+import { isCitationLabel } from '@/lib/utils/citation'
 
 import { useCitation } from './citation-context'
 import { CitationLink } from './citation-link'
@@ -19,8 +19,7 @@ export function Citing({
 }: CustomLinkProps) {
   const { citationMaps } = useCitation()
   const childrenText = children?.toString() || ''
-  // Match domain names (alphanumeric and hyphens) or numbers for backward compatibility
-  const isCitation = /^[\w-]+$/.test(childrenText)
+  const isCitation = isCitationLabel(childrenText)
 
   // Get citation data if this is a citation
   let citationData: SearchResultItem | undefined = undefined

--- a/lib/utils/__tests__/citation.test.ts
+++ b/lib/utils/__tests__/citation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SearchResultItem } from '@/lib/types'
 
-import { processCitations } from '../citation'
+import { isCitationLabel, processCitations } from '../citation'
 
 describe('processCitations', () => {
   const mockCitationMaps = {
@@ -62,6 +62,30 @@ describe('processCitations', () => {
 
     expect(result).toBe(
       'Try [google](https://www.google.com/search) or [google](https://www.google.com/maps)'
+    )
+  })
+
+  it('converts citations with dotted display labels', () => {
+    const citationMaps = {
+      toolCall1: {
+        1: {
+          title: 'Global News',
+          url: 'https://topics.global.example.com/portal/news/page.html',
+          content: 'News article'
+        },
+        2: {
+          title: 'World Report',
+          url: 'https://articles.world.example.net/articles/-/123',
+          content: 'News article'
+        }
+      } as Record<number, SearchResultItem>
+    }
+
+    const content = 'Sources [1](#toolCall1) [2](#toolCall1)'
+    const result = processCitations(content, citationMaps)
+
+    expect(result).toBe(
+      'Sources [global.example](https://topics.global.example.com/portal/news/page.html) [world.example](https://articles.world.example.net/articles/-/123)'
     )
   })
 
@@ -156,5 +180,21 @@ describe('processCitations', () => {
     // 0 and 101 are out of bounds (1-100), so they're replaced with empty string
     // -1 doesn't match the regex pattern \d+, so it remains unchanged
     expect(result).toBe('Edge cases:   [-1](#toolCall1)')
+  })
+
+  describe('isCitationLabel', () => {
+    it('accepts numeric, simple domain, and dotted domain labels', () => {
+      expect(isCitationLabel('1')).toBe(true)
+      expect(isCitationLabel('youtube')).toBe(true)
+      expect(isCitationLabel('global.example')).toBe(true)
+      expect(isCitationLabel('world.example')).toBe(true)
+    })
+
+    it('rejects punctuation and whitespace outside the label', () => {
+      expect(isCitationLabel('')).toBe(false)
+      expect(isCitationLabel('global.example.')).toBe(false)
+      expect(isCitationLabel('.global.example')).toBe(false)
+      expect(isCitationLabel('global example')).toBe(false)
+    })
   })
 })

--- a/lib/utils/citation.ts
+++ b/lib/utils/citation.ts
@@ -14,6 +14,10 @@ function isValidUrl(url: string): boolean {
   }
 }
 
+export function isCitationLabel(label: string): boolean {
+  return /^[\w-]+(?:\.[\w-]+)*$/.test(label)
+}
+
 /**
  * Extract citation maps from a message's tool parts
  * Returns a map of toolCallId to citation map


### PR DESCRIPTION
## Summary

- Allow dotted source labels such as `global.example` to render as citation links.
- Reuse one citation label detector in both link rendering paths.
- Add regression coverage for dotted citation labels.

## Root Cause

Citation markdown was converted to domain-style labels, but labels containing dots did not match the UI citation detector. That caused citation data lookup and pill styling to be skipped for those links.

## Validation

- `bun run test lib/utils/__tests__/citation.test.ts`
- `bun lint components/custom-link.tsx components/citation-link.tsx lib/utils/citation.ts lib/utils/__tests__/citation.test.ts`
- `bun typecheck`