### PR TITLE
Match search skeleton to results layout

### DIFF
--- a/components/default-skeleton.tsx
+++ b/components/default-skeleton.tsx
@@ -15,12 +15,14 @@ export const DefaultSkeleton = () => {
 export function SearchSkeleton() {
   return (
     <div className="py-2">
-      <div className="mb-2 inline-flex h-5 items-center gap-1.5 rounded-full bg-secondary px-2">
-        <Skeleton className="size-4 rounded-sm bg-muted-foreground/20" />
-        <Skeleton className="h-3 w-12 bg-muted-foreground/20" />
-      </div>
-      <div className="flex flex-col gap-1 pb-0.5 md:-m-1 md:flex-row md:flex-wrap md:gap-0">
+      <div className="grid grid-cols-4 gap-2 pb-4">
         {[...Array(4)].map((_, index) => (
+          <Skeleton key={index} className="aspect-video w-full rounded-md" />
+        ))}
+      </div>
+      <Skeleton className="mb-2 h-5 w-24 rounded-full" />
+      <div className="flex flex-col gap-1 pb-0.5 md:-m-1 md:flex-row md:flex-wrap md:gap-0">
+        {[...Array(3)].map((_, index) => (
           <div className="min-w-0 md:w-1/4 md:p-1" key={index}>
             <div className="rounded-md border bg-card p-2">
               <div className="flex min-w-0 items-center justify-between gap-2 md:flex-col md:items-stretch">
@@ -40,6 +42,14 @@ export function SearchSkeleton() {
             </div>
           </div>
         ))}
+        <div className="flex justify-center py-1 md:hidden">
+          <Skeleton className="h-5 w-24" />
+        </div>
+        <div className="hidden md:block md:w-1/4 md:p-1">
+          <div className="flex h-full min-h-[68px] items-center justify-center rounded-md border bg-card p-2">
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Add image placeholder rows to the search loading skeleton.
- Simplify the Sources badge placeholder to a plain gray pill.
- Match the source card count and View more placeholder layout across desktop and mobile.

## Validation
- bun lint
- bun typecheck
- bunx prettier --check components/default-skeleton.tsx
- git diff --cached --check