### PR TITLE
Add PostHog product analytics

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -169,6 +169,21 @@ ANONYMOUS_USER_ID=anonymous-user
 # MORPHIC_CLOUD_DEPLOYMENT=true
 
 # -----------------------------------------------------------------------------
+# PostHog (product analytics)
+# -----------------------------------------------------------------------------
+# Only sent when MORPHIC_CLOUD_DEPLOYMENT=true. US Cloud.
+# Client-facing project key (phc_...) is safe to expose in the browser.
+# NEXT_PUBLIC_POSTHOG_KEY=[YOUR_POSTHOG_PROJECT_KEY]
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# POSTHOG_KEY=[YOUR_POSTHOG_PROJECT_KEY]
+#
+# Management API (server-only) — required only for person deletion on
+# account_deleted. Use a dedicated personal API key scoped to person:write.
+# POSTHOG_PERSONAL_API_KEY=[YOUR_PERSONAL_API_KEY]
+# POSTHOG_PROJECT_ID=[YOUR_POSTHOG_PROJECT_ID]
+# POSTHOG_API_HOST=https://us.posthog.com
+
+# -----------------------------------------------------------------------------
 # Advanced
 # -----------------------------------------------------------------------------
 # Feedback Notifications (Slack)

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,7 +2,11 @@ import { revalidateTag } from 'next/cache'
 import { cookies } from 'next/headers'
 
 import { loadChat } from '@/lib/actions/chat'
-import { calculateConversationTurn, trackChatEvent } from '@/lib/analytics'
+import {
+  calculateConversationTurn,
+  deriveQueryShape,
+  trackChatEvent
+} from '@/lib/analytics'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import { checkAndEnforceAdaptiveLimit } from '@/lib/rate-limit/adaptive-limit'
 import { checkAndEnforceOverallChatLimit } from '@/lib/rate-limit/chat-limits'
@@ -14,6 +18,7 @@ import {
 import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'
 import { createEphemeralChatStreamResponse } from '@/lib/streaming/create-ephemeral-chat-stream-response'
 import { SearchMode } from '@/lib/types/search'
+import { getTextFromParts } from '@/lib/utils/message-utils'
 import { selectModel } from '@/lib/utils/model-selection'
 import { perfLog, perfTime } from '@/lib/utils/perf-logging'
 import { resetAllCounters } from '@/lib/utils/perf-tracking'
@@ -192,17 +197,24 @@ export async function POST(req: Request) {
         }
 
         if (!isGuest && userId) {
+          const resolvedTrigger =
+            (trigger as 'submit-message' | 'regenerate-message') ??
+            'submit-message'
+          const queryShape =
+            resolvedTrigger === 'submit-message' && message?.parts
+              ? deriveQueryShape(getTextFromParts(message.parts))
+              : undefined
+
           await trackChatEvent({
             searchMode,
             conversationTurn,
             isNewChat: isNewChat ?? false,
-            trigger:
-              (trigger as 'submit-message' | 'regenerate-message') ??
-              'submit-message',
+            trigger: resolvedTrigger,
             chatId,
             userId,
             providerId: selectedModel.providerId,
-            modelId: selectedModel.id
+            modelId: selectedModel.id,
+            queryShape
           })
         }
       } catch (error) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import AppSidebar from '@/components/app-sidebar'
 import ArtifactRoot from '@/components/artifact/artifact-root'
 import Header from '@/components/header'
 import { KeyboardShortcutHandler } from '@/components/keyboard-shortcut-handler'
+import { PostHogProvider } from '@/components/posthog-provider'
 import { ThemeProvider } from '@/components/theme-provider'
 
 import './globals.css'
@@ -83,18 +84,20 @@ export default async function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <UserProvider hasUser={!!userId}>
-            <SidebarProvider defaultOpen={false}>
-              {userId && <AppSidebar />}
-              <KeyboardShortcutHandler />
-              <div className="flex flex-col flex-1 min-w-0">
-                <Header user={user} />
-                <main className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
-                  <ArtifactRoot>{children}</ArtifactRoot>
-                </main>
-              </div>
-            </SidebarProvider>
-          </UserProvider>
+          <PostHogProvider userId={user?.id ?? null}>
+            <UserProvider hasUser={!!userId}>
+              <SidebarProvider defaultOpen={false}>
+                {userId && <AppSidebar />}
+                <KeyboardShortcutHandler />
+                <div className="flex flex-col flex-1 min-w-0">
+                  <Header user={user} />
+                  <main className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
+                    <ArtifactRoot>{children}</ArtifactRoot>
+                  </main>
+                </div>
+              </SidebarProvider>
+            </UserProvider>
+          </PostHogProvider>
           <Toaster />
           <Analytics />
         </ThemeProvider>

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "next": "^16.2.6",
         "node-html-parser": "^6.1.13",
         "postgres": "^3.4.5",
+        "posthog-node": "^5.36.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-textarea-autosize": "^8.5.3",
@@ -473,6 +474,10 @@
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.2.2", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA=="],
+
+    "@posthog/core": ["@posthog/core@1.30.10", "", { "dependencies": { "@posthog/types": "1.382.0" } }, "sha512-R7Z5jDB3ugwfSujMmRd5osPPR6L6BqfcaSNcYOekzRMZ4Jklq74p05xByP09EnUvKXb5czI+RQVCITTWRWuFXw=="],
+
+    "@posthog/types": ["@posthog/types@1.382.0", "", {}, "sha512-iK4OcSgvtmS9FZ9EUpvwlRZmHCLXaZ3+6dbRjkE7q9LL0zHLewxJH84H6uGvCw8aGzxs5rIliZqPHgimTcQEaw=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1865,6 +1870,8 @@
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "postgres": ["postgres@3.4.7", "", {}, "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="],
+
+    "posthog-node": ["posthog-node@5.36.4", "", { "dependencies": { "@posthog/core": "1.30.10" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-N+1WiypMHf3SO3NNoXTUFRzX98TuM5w4bDCm8RenYPf0rvX6r8v+yH6IzL1g/Me+wWA5+sfE1JZ6kGV6pWTZyQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "next": "^16.2.6",
         "node-html-parser": "^6.1.13",
         "postgres": "^3.4.5",
+        "posthog-js": "^1.382.0",
         "posthog-node": "^5.36.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1133,6 +1134,8 @@
 
     "cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
     "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
@@ -1378,6 +1381,8 @@
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
+
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
@@ -1871,7 +1876,11 @@
 
     "postgres": ["postgres@3.4.7", "", {}, "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="],
 
+    "posthog-js": ["posthog-js@1.382.0", "", { "dependencies": { "@posthog/core": "1.30.10", "@posthog/types": "1.382.0", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-lXwVlNdPLkhDft48ZgLQ5Jf4RsuQVwz7Hr7luD4DAG+4wDGA+k9eE2no36r3Z1w4uK0EmIf9lmav6+4RsmP7nA=="],
+
     "posthog-node": ["posthog-node@5.36.4", "", { "dependencies": { "@posthog/core": "1.30.10" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-N+1WiypMHf3SO3NNoXTUFRzX98TuM5w4bDCm8RenYPf0rvX6r8v+yH6IzL1g/Me+wWA5+sfE1JZ6kGV6pWTZyQ=="],
+
+    "preact": ["preact@10.29.2", "", {}, "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1884,6 +1893,8 @@
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -2180,6 +2191,8 @@
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -7,6 +7,8 @@ import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport } from 'ai'
 import { toast } from 'sonner'
 
+import { summarizeGenui } from '@/lib/analytics/genui-summary'
+import { captureClient } from '@/lib/analytics/posthog-client'
 import { ChatProvider } from '@/lib/contexts/chat-context'
 import { generateId } from '@/lib/db/schema'
 import {
@@ -29,6 +31,7 @@ import {
 import type { ModelSelectorData } from '@/lib/types/model-selector'
 import { cn } from '@/lib/utils'
 import { getCookie } from '@/lib/utils/cookies'
+import { getTextFromParts } from '@/lib/utils/message-utils'
 
 import { useFileDropzone } from '@/hooks/use-file-dropzone'
 
@@ -163,9 +166,14 @@ export function Chat({
       }
     }),
     messages: savedMessages,
-    onFinish: () => {
+    onFinish: ({ message }) => {
       isStreamingRef.current = false
       window.dispatchEvent(new CustomEvent('chat-history-updated'))
+
+      const summary = summarizeGenui(getTextFromParts(message.parts))
+      if (summary) {
+        captureClient('genui_component_shown', { chatId, ...summary })
+      }
     },
     onError: error => {
       isStreamingRef.current = false

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+import {
+  captureClient,
+  identify,
+  initPostHog,
+  reset
+} from '@/lib/analytics/posthog-client'
+
+export function PostHogProvider({
+  userId,
+  children
+}: {
+  userId: string | null
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    initPostHog()
+  }, [])
+
+  useEffect(() => {
+    if (userId) {
+      identify(userId)
+    } else {
+      reset()
+    }
+  }, [userId])
+
+  const pathname = usePathname()
+  useEffect(() => {
+    captureClient('$pageview')
+  }, [pathname])
+
+  return <>{children}</>
+}

--- a/components/spec-block.tsx
+++ b/components/spec-block.tsx
@@ -5,9 +5,15 @@ import { useMemo } from 'react'
 import { ActionProvider, JSONUIProvider, Renderer } from '@json-render/react'
 import { toast } from 'sonner'
 
+import { captureClient, chatIdFromPath } from '@/lib/analytics/posthog-client'
 import { useChatContext } from '@/lib/contexts/chat-context'
 import { registry } from '@/lib/render/registry'
 import type { SpecFenceResult } from '@/lib/render/spec-fence'
+
+function currentChatId(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  return chatIdFromPath(window.location.pathname)
+}
 
 type SpecBlockProps = {
   result: SpecFenceResult
@@ -31,6 +37,8 @@ export function SpecBlock({ result }: SpecBlockProps) {
           toast.info('Please wait for the current response to finish.')
           return
         }
+
+        captureClient('related_question_clicked', { chatId: currentChatId() })
 
         chatContext.sendMessage({
           role: 'user',

--- a/lib/actions/account.ts
+++ b/lib/actions/account.ts
@@ -71,7 +71,7 @@ export async function deleteAccount(): Promise<{
     }
 
     revalidateTag('chat', 'max')
-    await trackAccountDeleted()
+    await trackAccountDeleted(user.id)
 
     return { success: true }
   } catch (error) {

--- a/lib/analytics/__tests__/dispatch.test.ts
+++ b/lib/analytics/__tests__/dispatch.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCaptureServerEvent = vi.hoisted(() => vi.fn())
+const mockDeletePerson = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/analytics/providers/posthog-server', () => ({
+  captureServerEvent: (...args: unknown[]) => mockCaptureServerEvent(...args),
+  deletePerson: (...args: unknown[]) => mockDeletePerson(...args)
+}))
+
+import {
+  capture,
+  deleteAnalyticsPerson,
+  isAnalyticsEnabled
+} from '@/lib/analytics/dispatch'
+
+const original = process.env.MORPHIC_CLOUD_DEPLOYMENT
+
+describe('analytics dispatch', () => {
+  beforeEach(() => {
+    mockCaptureServerEvent.mockReset().mockResolvedValue(undefined)
+    mockDeletePerson.mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = original
+  })
+
+  it('is a no-op outside cloud deployment', async () => {
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'false'
+
+    expect(isAnalyticsEnabled()).toBe(false)
+    await capture({ event: 'e', distinctId: 'u' })
+    await deleteAnalyticsPerson('u')
+
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled()
+    expect(mockDeletePerson).not.toHaveBeenCalled()
+  })
+
+  it('forwards to the provider in cloud deployment', async () => {
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'true'
+
+    await capture({ event: 'e', distinctId: 'u', properties: { a: 1 } })
+    await deleteAnalyticsPerson('u')
+
+    expect(mockCaptureServerEvent).toHaveBeenCalledWith({
+      event: 'e',
+      distinctId: 'u',
+      properties: { a: 1 }
+    })
+    expect(mockDeletePerson).toHaveBeenCalledWith('u')
+  })
+
+  it('never throws when the provider fails', async () => {
+    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'true'
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockCaptureServerEvent.mockRejectedValue(new Error('down'))
+
+    await expect(
+      capture({ event: 'e', distinctId: 'u' })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/lib/analytics/__tests__/genui-summary.test.ts
+++ b/lib/analytics/__tests__/genui-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { summarizeGenui } from '@/lib/analytics/genui-summary'
+
+const imageBlock = [
+  '```spec',
+  '{"op":"add","path":"/root","value":"grid"}',
+  '{"op":"add","path":"/elements/grid","value":{"type":"Grid","props":{"columns":2},"children":["img1","img2"]}}',
+  '{"op":"add","path":"/elements/img1","value":{"type":"Image","props":{"src":"https://example.com/a.jpg"},"children":[]}}',
+  '{"op":"add","path":"/elements/img2","value":{"type":"Image","props":{"src":"https://example.com/b.jpg"},"children":[]}}',
+  '```'
+].join('\n')
+
+const relatedBlock = [
+  '```spec',
+  '{"op":"add","path":"/root","value":"main"}',
+  '{"op":"add","path":"/elements/main","value":{"type":"Stack","props":{},"children":["q1"]}}',
+  '{"op":"add","path":"/elements/q1","value":{"type":"Button","props":{"text":"Q1","variant":"link"},"children":[]}}',
+  '```'
+].join('\n')
+
+describe('summarizeGenui', () => {
+  it('returns null when there are no spec blocks', () => {
+    expect(summarizeGenui('just some markdown text')).toBeNull()
+  })
+
+  it('counts images in content blocks and excludes the related block', () => {
+    const text = `Here are some photos.\n\n${imageBlock}\n\nMore text.\n\n${relatedBlock}`
+    const summary = summarizeGenui(text)
+
+    expect(summary).toEqual({
+      blockCount: 2,
+      contentBlockCount: 1,
+      imageCount: 2,
+      hasImage: true,
+      hasRelated: true,
+      componentTypes: ['Grid', 'Image']
+    })
+  })
+
+  it('reports no image when only a related block is present', () => {
+    const summary = summarizeGenui(`Answer.\n\n${relatedBlock}`)
+
+    expect(summary).toMatchObject({
+      blockCount: 1,
+      contentBlockCount: 0,
+      imageCount: 0,
+      hasImage: false,
+      hasRelated: true
+    })
+  })
+})

--- a/lib/analytics/__tests__/track-account-event.test.ts
+++ b/lib/analytics/__tests__/track-account-event.test.ts
@@ -1,54 +1,29 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockTrack = vi.hoisted(() => vi.fn())
+const mockCapture = vi.hoisted(() => vi.fn())
+const mockDeletePerson = vi.hoisted(() => vi.fn())
 
-vi.mock('@vercel/analytics/server', () => ({
-  track: (...args: unknown[]) => mockTrack(...args)
+vi.mock('@/lib/analytics/dispatch', () => ({
+  capture: (...args: unknown[]) => mockCapture(...args),
+  deleteAnalyticsPerson: (...args: unknown[]) => mockDeletePerson(...args)
 }))
 
 import { trackAccountDeleted } from '@/lib/analytics/track-account-event'
 
-const originalCloudDeployment = process.env.MORPHIC_CLOUD_DEPLOYMENT
-
 describe('trackAccountDeleted', () => {
   beforeEach(() => {
-    mockTrack.mockReset()
-    mockTrack.mockResolvedValue(undefined)
-    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'true'
+    mockCapture.mockReset().mockResolvedValue(undefined)
+    mockDeletePerson.mockReset().mockResolvedValue(undefined)
   })
 
-  afterEach(() => {
-    process.env.MORPHIC_CLOUD_DEPLOYMENT = originalCloudDeployment
-  })
+  it('captures an anonymous deletion event and deletes the person', async () => {
+    await trackAccountDeleted('user-123')
 
-  it('tracks an anonymous account deletion event in cloud deployment', async () => {
-    await trackAccountDeleted()
-
-    expect(mockTrack).toHaveBeenCalledTimes(1)
-    expect(mockTrack).toHaveBeenCalledWith('account_deleted')
-  })
-
-  it('does not track outside cloud deployment', async () => {
-    process.env.MORPHIC_CLOUD_DEPLOYMENT = 'false'
-
-    await trackAccountDeleted()
-
-    expect(mockTrack).not.toHaveBeenCalled()
-  })
-
-  it('does not throw when analytics tracking fails', async () => {
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined)
-    mockTrack.mockRejectedValue(new Error('Analytics unavailable'))
-
-    await expect(trackAccountDeleted()).resolves.toBeUndefined()
-
-    expect(consoleError).toHaveBeenCalledWith(
-      'Failed to track account deletion event:',
-      expect.any(Error)
-    )
-
-    consoleError.mockRestore()
+    expect(mockCapture).toHaveBeenCalledTimes(1)
+    expect(mockCapture).toHaveBeenCalledWith({
+      event: 'account_deleted',
+      distinctId: 'account-lifecycle'
+    })
+    expect(mockDeletePerson).toHaveBeenCalledWith('user-123')
   })
 })

--- a/lib/analytics/__tests__/utils.test.ts
+++ b/lib/analytics/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveQueryShape } from '@/lib/analytics/utils'
+
+describe('deriveQueryShape', () => {
+  it('buckets query length and never returns raw text', () => {
+    expect(deriveQueryShape('hi').queryLenBucket).toBe('0-20')
+    expect(deriveQueryShape('a'.repeat(40)).queryLenBucket).toBe('21-50')
+    expect(deriveQueryShape('a'.repeat(100)).queryLenBucket).toBe('51-120')
+    expect(deriveQueryShape('a'.repeat(200)).queryLenBucket).toBe('120+')
+  })
+
+  it('detects URLs', () => {
+    expect(deriveQueryShape('see https://example.com').hasUrl).toBe(true)
+    expect(deriveQueryShape('no link here').hasUrl).toBe(false)
+  })
+
+  it('detects coarse language', () => {
+    expect(deriveQueryShape('日本語のクエリ').lang).toBe('ja')
+    expect(deriveQueryShape('english query').lang).toBe('en')
+    expect(deriveQueryShape('12345').lang).toBe('other')
+  })
+})

--- a/lib/analytics/__tests__/utils.test.ts
+++ b/lib/analytics/__tests__/utils.test.ts
@@ -16,8 +16,9 @@ describe('deriveQueryShape', () => {
   })
 
   it('detects coarse language', () => {
-    expect(deriveQueryShape('日本語のクエリ').lang).toBe('ja')
     expect(deriveQueryShape('english query').lang).toBe('en')
+    expect(deriveQueryShape('日本語のクエリ').lang).toBe('other')
+    expect(deriveQueryShape('日本語 with latin').lang).toBe('other')
     expect(deriveQueryShape('12345').lang).toBe('other')
   })
 })

--- a/lib/analytics/dispatch.ts
+++ b/lib/analytics/dispatch.ts
@@ -1,0 +1,29 @@
+import {
+  captureServerEvent,
+  deletePerson,
+  type ServerEvent
+} from './providers/posthog-server'
+
+export function isAnalyticsEnabled(): boolean {
+  return process.env.MORPHIC_CLOUD_DEPLOYMENT === 'true'
+}
+
+export async function capture(event: ServerEvent): Promise<void> {
+  if (!isAnalyticsEnabled()) return
+
+  try {
+    await captureServerEvent(event)
+  } catch (error) {
+    console.error('Failed to capture analytics event:', error)
+  }
+}
+
+export async function deleteAnalyticsPerson(distinctId: string): Promise<void> {
+  if (!isAnalyticsEnabled()) return
+
+  try {
+    await deletePerson(distinctId)
+  } catch (error) {
+    console.error('Failed to delete analytics person:', error)
+  }
+}

--- a/lib/analytics/genui-summary.ts
+++ b/lib/analytics/genui-summary.ts
@@ -1,0 +1,65 @@
+import { parseSpecBlock } from '@/lib/render/parse-spec-block'
+
+const SPEC_FENCE = /```spec\s*\n([\s\S]*?)```/g
+
+export interface GenuiSummary {
+  /** Number of spec fences in the message. */
+  blockCount: number
+  /** Spec blocks that are not the related-questions block. */
+  contentBlockCount: number
+  imageCount: number
+  hasImage: boolean
+  hasRelated: boolean
+  /** Distinct element types across content blocks. */
+  componentTypes: string[]
+}
+
+/**
+ * Summarize the GenUI rendered in a finished assistant message.
+ * A block containing Button elements is treated as the related-questions
+ * block (tracked separately via clicks) and excluded from content metrics.
+ * Returns null when the message contains no spec blocks.
+ */
+export function summarizeGenui(text: string): GenuiSummary | null {
+  const sources: string[] = []
+  SPEC_FENCE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = SPEC_FENCE.exec(text)) !== null) {
+    sources.push(match[1])
+  }
+  if (sources.length === 0) return null
+
+  let contentBlockCount = 0
+  let imageCount = 0
+  let hasRelated = false
+  const componentTypes = new Set<string>()
+
+  for (const source of sources) {
+    let types: string[]
+    try {
+      types = Object.values(parseSpecBlock(source).elements).map(el => el.type)
+    } catch {
+      continue
+    }
+
+    if (types.includes('Button')) {
+      hasRelated = true
+      continue
+    }
+
+    contentBlockCount++
+    for (const type of types) {
+      componentTypes.add(type)
+      if (type === 'Image') imageCount++
+    }
+  }
+
+  return {
+    blockCount: sources.length,
+    contentBlockCount,
+    imageCount,
+    hasImage: imageCount > 0,
+    hasRelated,
+    componentTypes: Array.from(componentTypes)
+  }
+}

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -1,9 +1,7 @@
 /**
  * Analytics module
  *
- * Provides a unified interface for tracking analytics events.
- * Currently uses Vercel Analytics, but designed to be provider-agnostic
- * for future extensibility.
+ * Unified interface for tracking product analytics events via PostHog.
  *
  * @module analytics
  */
@@ -14,5 +12,10 @@ export {
   trackAdaptiveLimitEvent
 } from './track-adaptive-limit-event'
 export { trackChatEvent } from './track-chat-event'
-export type { AnalyticsProvider, ChatEventData } from './types'
-export { calculateConversationTurn } from './utils'
+export type {
+  ChatEventData,
+  QueryLang,
+  QueryLenBucket,
+  QueryShape
+} from './types'
+export { calculateConversationTurn, deriveQueryShape } from './utils'

--- a/lib/analytics/posthog-client.ts
+++ b/lib/analytics/posthog-client.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import posthog from 'posthog-js'
+
+let initialized = false
+
+function clientKey(): string | undefined {
+  return process.env.NEXT_PUBLIC_POSTHOG_KEY
+}
+
+export function initPostHog(): void {
+  if (initialized || typeof window === 'undefined') return
+
+  const key = clientKey()
+  if (!key) return
+
+  posthog.init(key, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    autocapture: false,
+    capture_pageview: false,
+    disable_session_recording: true,
+    session_recording: { maskAllInputs: true }
+  })
+  initialized = true
+}
+
+export function identify(distinctId: string): void {
+  if (!clientKey()) return
+  posthog.identify(distinctId)
+}
+
+export function reset(): void {
+  if (!clientKey()) return
+  posthog.reset()
+}
+
+export function captureClient(
+  event: string,
+  properties?: Record<string, unknown>
+): void {
+  if (!clientKey()) return
+  posthog.capture(event, properties)
+}
+
+/** Extract the chat id from a /search/:id pathname. */
+export function chatIdFromPath(pathname: string): string | undefined {
+  return /^\/search\/([^/]+)/.exec(pathname)?.[1]
+}

--- a/lib/analytics/providers/posthog-server.ts
+++ b/lib/analytics/providers/posthog-server.ts
@@ -1,0 +1,65 @@
+import { PostHog } from 'posthog-node'
+
+let client: PostHog | null = null
+
+function getClient(): PostHog | null {
+  const key = process.env.POSTHOG_KEY
+  if (!key) return null
+
+  if (!client) {
+    client = new PostHog(key, {
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+      flushAt: 1,
+      flushInterval: 0
+    })
+  }
+
+  return client
+}
+
+export interface ServerEvent {
+  event: string
+  distinctId: string
+  properties?: Record<string, unknown>
+}
+
+export async function captureServerEvent({
+  event,
+  distinctId,
+  properties
+}: ServerEvent): Promise<void> {
+  const ph = getClient()
+  if (!ph) return
+
+  ph.capture({ distinctId, event, properties })
+  await ph.flush()
+}
+
+/**
+ * Delete a person and their events via the management API.
+ * Requires a dedicated personal API key scoped to person:write.
+ * No-op when the key or project id is not configured.
+ */
+export async function deletePerson(distinctId: string): Promise<void> {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY
+  const projectId = process.env.POSTHOG_PROJECT_ID
+  const apiHost = process.env.POSTHOG_API_HOST
+
+  if (!apiKey || !projectId || !apiHost) return
+
+  const res = await fetch(
+    `${apiHost}/api/environments/${projectId}/persons/bulk_delete`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ distinct_ids: [distinctId], delete_events: true })
+    }
+  )
+
+  if (!res.ok) {
+    throw new Error(`PostHog person deletion failed: ${res.status}`)
+  }
+}

--- a/lib/analytics/track-account-event.ts
+++ b/lib/analytics/track-account-event.ts
@@ -1,19 +1,19 @@
-import { track } from '@vercel/analytics/server'
+import { capture, deleteAnalyticsPerson } from './dispatch'
+
+/** Distinct id for the anonymous deletion counter (no link to the user). */
+const ACCOUNT_LIFECYCLE_DISTINCT_ID = 'account-lifecycle'
 
 /**
- * Track successful account deletion.
+ * Track a successful account deletion.
  *
- * Keep this event anonymous: the account has just been deleted, and the only
- * metric we need is the aggregate deletion count.
+ * Records an anonymous aggregate count, then removes the deleted user's
+ * person and events from analytics.
  */
-export async function trackAccountDeleted(): Promise<void> {
-  if (process.env.MORPHIC_CLOUD_DEPLOYMENT !== 'true') {
-    return
-  }
+export async function trackAccountDeleted(userId: string): Promise<void> {
+  await capture({
+    event: 'account_deleted',
+    distinctId: ACCOUNT_LIFECYCLE_DISTINCT_ID
+  })
 
-  try {
-    await track('account_deleted')
-  } catch (error) {
-    console.error('Failed to track account deletion event:', error)
-  }
+  await deleteAnalyticsPerson(userId)
 }

--- a/lib/analytics/track-adaptive-limit-event.ts
+++ b/lib/analytics/track-adaptive-limit-event.ts
@@ -1,4 +1,4 @@
-import { track } from '@vercel/analytics/server'
+import { capture } from './dispatch'
 
 export interface AdaptiveLimitEventData {
   /** Outcome of the adaptive-mode rate-limit check */
@@ -19,24 +19,15 @@ export interface AdaptiveLimitEventData {
  *   can plot daily usage distribution and percentiles.
  * - `outcome: "blocked"` when the request is denied, so we can monitor the
  *   429 hit-rate over time and decide whether to relax / tighten the cap.
- *
- * No-op outside cloud deployment; never throws.
  */
 export async function trackAdaptiveLimitEvent(
   data: AdaptiveLimitEventData
 ): Promise<void> {
-  if (process.env.MORPHIC_CLOUD_DEPLOYMENT !== 'true') {
-    return
-  }
+  const { userId, outcome, used, limit } = data
 
-  try {
-    await track('adaptive_limit_check', {
-      outcome: data.outcome,
-      userId: data.userId,
-      used: data.used,
-      limit: data.limit
-    })
-  } catch (error) {
-    console.error('Failed to track adaptive limit event:', error)
-  }
+  await capture({
+    event: 'adaptive_limit_check',
+    distinctId: userId,
+    properties: { outcome, userId, used, limit }
+  })
 }

--- a/lib/analytics/track-chat-event.ts
+++ b/lib/analytics/track-chat-event.ts
@@ -1,53 +1,22 @@
-import { track } from '@vercel/analytics/server'
-
+import { capture } from './dispatch'
 import type { ChatEventData } from './types'
 
 /**
- * Track a chat event to analytics provider
+ * Track a chat event.
  *
- * Currently uses Vercel Analytics. Only sends events when MORPHIC_CLOUD_DEPLOYMENT=true.
- * Errors are logged but do not interrupt the application flow.
- *
- * Future extensibility: This function can be modified to support multiple providers
- * by checking an environment variable (e.g., ANALYTICS_PROVIDER) and routing to
- * the appropriate provider implementation.
- *
- * @param data - Chat event data to track
- *
- * @example
- * ```typescript
- * await trackChatEvent({
- *   searchMode: 'quick',
- *   conversationTurn: 1,
- *   isNewChat: true,
- *   trigger: 'submit-message',
- *   chatId: 'clx3k2j5m0000qzrmn4y8b9wy',
- *   userId: '550e8400-e29b-41d4-a716-446655440000',
- *   providerId: 'openai',
- *   modelId: 'gpt-4'
- * })
- * ```
+ * Sent only when MORPHIC_CLOUD_DEPLOYMENT=true. The raw query is never sent;
+ * only the derived query shape is included.
  */
 export async function trackChatEvent(data: ChatEventData): Promise<void> {
-  // Only track events in cloud deployment environment
-  if (process.env.MORPHIC_CLOUD_DEPLOYMENT !== 'true') {
-    return
-  }
+  const { userId, queryShape, ...rest } = data
 
-  try {
-    // Send event to Vercel Analytics
-    await track('chat_message_sent', {
-      searchMode: data.searchMode,
-      conversationTurn: data.conversationTurn,
-      isNewChat: data.isNewChat,
-      trigger: data.trigger,
-      chatId: data.chatId, // CUID2 - safe for tracking
-      userId: data.userId, // Supabase UUID - pseudonymized identifier
-      providerId: data.providerId,
-      modelId: data.modelId
-    })
-  } catch (error) {
-    // Log error but don't throw - analytics should never break the app
-    console.error('Failed to track analytics event:', error)
-  }
+  await capture({
+    event: 'chat_message_sent',
+    distinctId: userId,
+    properties: {
+      ...rest,
+      userId,
+      ...queryShape
+    }
+  })
 }

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -1,9 +1,22 @@
 /**
  * Analytics module types
- *
- * This module provides type definitions for analytics tracking.
- * The interfaces are provider-agnostic to allow future extensibility.
  */
+
+/** Length bucket of the user query. Avoids sending the raw text. */
+export type QueryLenBucket = '0-20' | '21-50' | '51-120' | '120+'
+
+/** Coarse language of the user query. */
+export type QueryLang = 'ja' | 'en' | 'other'
+
+/**
+ * Privacy-preserving "shape" of a user query. The raw query stays in the DB;
+ * only these derived signals are sent to analytics.
+ */
+export interface QueryShape {
+  queryLenBucket: QueryLenBucket
+  hasUrl: boolean
+  lang: QueryLang
+}
 
 /**
  * Chat event data structure
@@ -26,17 +39,6 @@ export interface ChatEventData {
   providerId: string
   /** Model identifier used for the chat */
   modelId: string
-}
-
-/**
- * Analytics provider interface
- * Future extensibility point: implement this interface for other providers
- * (e.g., PostHog, DataBuddy, custom analytics)
- */
-export interface AnalyticsProvider {
-  /**
-   * Track a chat event
-   * @param data - Chat event data to track
-   */
-  trackChatEvent(data: ChatEventData): Promise<void>
+  /** Derived query shape (omitted for regenerate, where no new query exists) */
+  queryShape?: QueryShape
 }

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -6,7 +6,7 @@
 export type QueryLenBucket = '0-20' | '21-50' | '51-120' | '120+'
 
 /** Coarse language of the user query. */
-export type QueryLang = 'ja' | 'en' | 'other'
+export type QueryLang = 'en' | 'other'
 
 /**
  * Privacy-preserving "shape" of a user query. The raw query stays in the DB;

--- a/lib/analytics/utils.ts
+++ b/lib/analytics/utils.ts
@@ -14,8 +14,7 @@ function lenBucket(length: number): QueryLenBucket {
 }
 
 function detectLang(text: string): QueryLang {
-  if (JAPANESE_PATTERN.test(text)) return 'ja'
-  if (LATIN_PATTERN.test(text)) return 'en'
+  if (LATIN_PATTERN.test(text) && !JAPANESE_PATTERN.test(text)) return 'en'
   return 'other'
 }
 

--- a/lib/analytics/utils.ts
+++ b/lib/analytics/utils.ts
@@ -1,5 +1,37 @@
 import type { UIMessage } from 'ai'
 
+import type { QueryLang, QueryLenBucket, QueryShape } from './types'
+
+const URL_PATTERN = /https?:\/\//i
+const JAPANESE_PATTERN = /[぀-ヿ㐀-鿿]/
+const LATIN_PATTERN = /[a-z]/i
+
+function lenBucket(length: number): QueryLenBucket {
+  if (length <= 20) return '0-20'
+  if (length <= 50) return '21-50'
+  if (length <= 120) return '51-120'
+  return '120+'
+}
+
+function detectLang(text: string): QueryLang {
+  if (JAPANESE_PATTERN.test(text)) return 'ja'
+  if (LATIN_PATTERN.test(text)) return 'en'
+  return 'other'
+}
+
+/**
+ * Derive a privacy-preserving shape from a raw user query.
+ * The raw text is never returned or sent onward.
+ */
+export function deriveQueryShape(text: string): QueryShape {
+  const trimmed = text.trim()
+  return {
+    queryLenBucket: lenBucket(trimmed.length),
+    hasUrl: URL_PATTERN.test(trimmed),
+    lang: detectLang(trimmed)
+  }
+}
+
 /**
  * Calculate the conversation turn number from message history
  *

--- a/lib/rate-limit/__tests__/adaptive-limit.test.ts
+++ b/lib/rate-limit/__tests__/adaptive-limit.test.ts
@@ -15,8 +15,8 @@ vi.mock('@upstash/redis', () => ({
   })
 }))
 
-vi.mock('@vercel/analytics/server', () => ({
-  track: (...args: unknown[]) => mockTrack(...args)
+vi.mock('@/lib/analytics/dispatch', () => ({
+  capture: (...args: unknown[]) => mockTrack(...args)
 }))
 
 describe('checkAndEnforceAdaptiveLimit', () => {
@@ -105,11 +105,15 @@ describe('checkAndEnforceAdaptiveLimit', () => {
     await new Promise(resolve => setImmediate(resolve))
 
     expect(mockTrack).toHaveBeenCalledTimes(1)
-    expect(mockTrack).toHaveBeenCalledWith('adaptive_limit_check', {
-      outcome: 'allowed',
-      userId: 'user-7',
-      used: 7,
-      limit: 30
+    expect(mockTrack).toHaveBeenCalledWith({
+      event: 'adaptive_limit_check',
+      distinctId: 'user-7',
+      properties: {
+        outcome: 'allowed',
+        userId: 'user-7',
+        used: 7,
+        limit: 30
+      }
     })
   })
 
@@ -122,11 +126,15 @@ describe('checkAndEnforceAdaptiveLimit', () => {
     await new Promise(resolve => setImmediate(resolve))
 
     expect(mockTrack).toHaveBeenCalledTimes(1)
-    expect(mockTrack).toHaveBeenCalledWith('adaptive_limit_check', {
-      outcome: 'blocked',
-      userId: 'user-8',
-      used: 31,
-      limit: 30
+    expect(mockTrack).toHaveBeenCalledWith({
+      event: 'adaptive_limit_check',
+      distinctId: 'user-8',
+      properties: {
+        outcome: 'blocked',
+        userId: 'user-8',
+        used: 31,
+        limit: 30
+      }
     })
   })
 

--- a/lib/render/components/image.tsx
+++ b/lib/render/components/image.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 
 import type { ComponentFn } from '@json-render/react'
 
+import { captureClient, chatIdFromPath } from '@/lib/analytics/posthog-client'
 import { cn } from '@/lib/utils'
 
 import {
@@ -36,7 +37,18 @@ export const Image: ComponentFn<CatalogType, 'Image'> = ({ props }) => {
   const alt = title || description || 'Image'
 
   return (
-    <Dialog>
+    <Dialog
+      onOpenChange={open => {
+        if (!open) return
+        captureClient('genui_component_clicked', {
+          type: 'image',
+          chatId:
+            typeof window === 'undefined'
+              ? undefined
+              : chatIdFromPath(window.location.pathname)
+        })
+      }}
+    >
       <DialogTrigger asChild>
         <button
           type="button"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "next": "^16.2.6",
     "node-html-parser": "^6.1.13",
     "postgres": "^3.4.5",
+    "posthog-node": "^5.36.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-textarea-autosize": "^8.5.3",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "next": "^16.2.6",
     "node-html-parser": "^6.1.13",
     "postgres": "^3.4.5",
+    "posthog-js": "^1.382.0",
     "posthog-node": "^5.36.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
Integrate PostHog for product analytics (server + client).

- Server: analytics dispatch layer + posthog-node; migrate chat, adaptive-limit and account events off Vercel Analytics. Chat event carries a derived query shape (no raw query). Delete the analytics person on account deletion.
- Client: posthog-js with identify/reset and pageview capture. Track GenUI image clicks, related question clicks, and a per-message GenUI summary on finish.
- Vercel `<Analytics/>` stays for top-line traffic only.

Gated by `MORPHIC_CLOUD_DEPLOYMENT` (server) and `NEXT_PUBLIC_POSTHOG_KEY` presence (client). Autocapture and session recording are disabled; inputs masked.