### PR TITLE
Proxy PostHog through /relay

### DIFF
--- a/lib/analytics/posthog-client.ts
+++ b/lib/analytics/posthog-client.ts
@@ -15,7 +15,8 @@ export function initPostHog(): void {
   if (!key) return
 
   posthog.init(key, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: '/relay',
+    ui_host: 'https://us.posthog.com',
     autocapture: false,
     capture_pageview: false,
     disable_session_recording: true,

--- a/lib/analytics/posthog-client.ts
+++ b/lib/analytics/posthog-client.ts
@@ -14,9 +14,14 @@ export function initPostHog(): void {
   const key = clientKey()
   if (!key) return
 
+  // The /relay reverse proxy (next.config rewrites) only targets US cloud.
+  // EU / self-hosted deployments keep talking to their configured host directly.
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST
+  const useRelay = !host || host.includes('us.i.posthog.com')
+
   posthog.init(key, {
-    api_host: '/relay',
-    ui_host: 'https://us.posthog.com',
+    api_host: useRelay ? '/relay' : host,
+    ...(useRelay ? { ui_host: 'https://us.posthog.com' } : {}),
     autocapture: false,
     capture_pageview: false,
     disable_session_recording: true,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,23 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Reverse proxy for PostHog to reduce tracking-blocker interception.
+  skipTrailingSlashRedirect: true,
+  async rewrites() {
+    return [
+      {
+        source: '/relay/static/:path*',
+        destination: 'https://us-assets.i.posthog.com/static/:path*'
+      },
+      {
+        source: '/relay/array/:path*',
+        destination: 'https://us-assets.i.posthog.com/array/:path*'
+      },
+      {
+        source: '/relay/:path*',
+        destination: 'https://us.i.posthog.com/:path*'
+      }
+    ]
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Route posthog-js through a same-origin /relay path (Next.js rewrites) so client events are less likely to be blocked by tracking blockers. Server-side capture is unchanged.