### PR TITLE
Fix /search?q= handoff sending an empty message

### DIFF
--- a/components/__tests__/chat-panel.test.tsx
+++ b/components/__tests__/chat-panel.test.tsx
@@ -81,7 +81,7 @@ describe('ChatPanel', () => {
     await waitFor(() => {
       expect(append).toHaveBeenCalledWith({
         role: 'user',
-        content: 'latest news'
+        parts: [{ type: 'text', text: 'latest news' }]
       })
     })
     expect(onAdaptiveModeAuthRequired).not.toHaveBeenCalled()

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -202,7 +202,7 @@ export function ChatPanel({
 
       append({
         role: 'user',
-        content: query
+        parts: [{ type: 'text', text: query }]
       })
       isFirstRender.current = false
     }


### PR DESCRIPTION
The initial-query auto-submit on `/search?q=` passed a v4-style `{ role: 'user', content: query }` message. AI SDK v5 ignores `content` (it expects `parts`), so the user message rendered nothing and the request reached the provider empty — surfacing "We could not generate a response.".

Fix: send `{ role: 'user', parts: [{ type: 'text', text: query }] }`, matching the normal submit path.

Verified locally at `/search?q=hello`: user message renders, response generates, `/api/chat` returns 200 (incl. guest + adaptive→quick fallback). Updated the existing test to assert the parts shape.