### PR TITLE
Track onboarding example prompt and category clicks

### DIFF
--- a/components/action-buttons.tsx
+++ b/components/action-buttons.tsx
@@ -12,6 +12,7 @@ import {
   type TablerIcon
 } from '@tabler/icons-react'
 
+import { captureClient } from '@/lib/analytics/posthog-client'
 import { cn } from '@/lib/utils'
 
 import { Button } from './ui/button'
@@ -110,9 +111,14 @@ export function ActionButtons({
   const handleCategoryClick = (category: ActionCategory) => {
     setActiveCategory(category.key)
     onCategoryClick(category.label)
+    captureClient('example_category_opened', { category: category.key })
   }
 
   const handlePromptClick = (prompt: string) => {
+    captureClient('example_prompt_clicked', {
+      category: activeCategory,
+      prompt
+    })
     setActiveCategory(null)
     onSelectPrompt(prompt)
   }


### PR DESCRIPTION
Adds client-side PostHog events so the onboarding suggestions are measurable:

- `example_category_opened` — `{ category }`
- `example_prompt_clicked` — `{ category, prompt }`

Uses the existing `captureClient` path (same as the other client events). No server changes. Single file: `components/action-buttons.tsx`.