### PR TITLE
Improve related questions prompt; A/B follow-up style

### DIFF
--- a/lib/analytics/posthog-client.ts
+++ b/lib/analytics/posthog-client.ts
@@ -64,6 +64,23 @@ export function captureClient(
   posthog.capture(event, properties)
 }
 
+/**
+ * Whether a boolean feature flag is enabled for the current distinct id.
+ * Returns false until flags have loaded (so the control path is the default).
+ */
+export function isFeatureEnabled(key: string): boolean {
+  if (!clientKey()) return false
+  initPostHog()
+  return posthog.isFeatureEnabled?.(key) === true
+}
+
+/** Subscribe to feature-flag loads/changes. Returns an unsubscribe function. */
+export function subscribeFeatureFlags(callback: () => void): () => void {
+  if (!clientKey()) return () => {}
+  initPostHog()
+  return posthog.onFeatureFlags?.(() => callback()) ?? (() => {})
+}
+
 /** Extract the chat id from a /search/:id pathname. */
 export function chatIdFromPath(pathname: string): string | undefined {
   return /^\/search\/([^/]+)/.exec(pathname)?.[1]

--- a/lib/render/components/button.tsx
+++ b/lib/render/components/button.tsx
@@ -1,12 +1,20 @@
 'use client'
 
+import { useSyncExternalStore } from 'react'
+
 import type { ComponentFn } from '@json-render/react'
 
+import {
+  isFeatureEnabled,
+  subscribeFeatureFlags
+} from '@/lib/analytics/posthog-client'
 import { cn } from '@/lib/utils'
 
 import { Button as UIButton } from '@/components/ui/button'
 
 import { type CatalogType, iconMap } from './shared'
+
+const STYLE_FLAG = 'related_q_style_v2'
 
 /**
  * Generic button spec component. Renders the project's shadcn Button and
@@ -18,19 +26,33 @@ export const Button: ComponentFn<CatalogType, 'Button'> = ({ props, on }) => {
   const Icon = icon ? iconMap[icon] : null
   const handle = on('press')
 
-  // For the link variant, tweak layout/color so it reads as an inline
-  // follow-up suggestion: muted color, left-aligned, wrappable text and
-  // zero padding. The shadcn link variant's hover underline is preserved.
+  // Follow-up suggestions render as link buttons. A/B their style via the
+  // `related_q_style_v2` flag: control = inline muted link, test = pill/chip.
+  // useSyncExternalStore keeps SSR on the control path (no hydration mismatch)
+  // and re-renders once flags load.
+  const isFollowup = variant === 'link'
+  const flagOn = useSyncExternalStore(
+    subscribeFeatureFlags,
+    () => isFeatureEnabled(STYLE_FLAG),
+    () => false
+  )
+  const chip = isFollowup && flagOn
+
+  // Control link: muted color, left-aligned, wrappable text, zero padding.
   const linkOverride =
-    variant === 'link'
+    isFollowup && !chip
       ? 'h-auto w-fit justify-start whitespace-normal text-left px-0 py-0.5 font-semibold text-accent-foreground/50 hover:text-accent-foreground/70'
       : ''
+  // Test chip: bordered pill with higher contrast for a stronger tap affordance.
+  const chipOverride = chip
+    ? 'h-auto w-fit whitespace-normal rounded-full border px-3 py-1.5 text-left text-sm font-medium text-accent-foreground/80 hover:bg-muted hover:text-accent-foreground'
+    : ''
 
   return (
     <UIButton
-      variant={variant}
+      variant={chip ? 'outline' : variant}
       onClick={handle.emit}
-      className={cn('gap-2', linkOverride)}
+      className={cn('gap-2', linkOverride, chipOverride)}
     >
       {Icon && <Icon className="size-4 shrink-0" />}
       {text}

--- a/lib/render/prompt.ts
+++ b/lib/render/prompt.ts
@@ -6,8 +6,12 @@ export function getRelatedQuestionsSpecPrompt(): string {
   return `
 RELATED QUESTIONS (MANDATORY):
 After your conclusion, you MUST generate exactly 3 follow-up questions in a \`\`\`spec fenced code block.
-Each question should explore a different aspect of the topic not yet covered.
-Questions must be concise (max 10-12 words) and in the user's language.
+Write the three questions a genuinely curious reader would tap next — not a checklist of "other aspects". Anchor each to THIS answer (use concrete names, options, or numbers from it), and make the three intents distinct:
+- Deepen: go further on the single most interesting or surprising point.
+- Act/decide: the practical next step (e.g. "How do I…", "Which … for …?").
+- Broaden: a useful comparison, trade-off, or related angle.
+Avoid three near-duplicate "what are the differences / what about X" questions.
+Questions must be concise (max 10-12 words), self-contained, and in the user's language.
 
 The spec block uses JSONL (one JSON object per line) with RFC 6902 JSON Patch operations.
 Always include a Heading with title "Related" as the first child element.


### PR DESCRIPTION
Improves the related-questions follow-up prompt (applied to all), and A/B tests the follow-up button style (link vs chip) via the `related_q_style_v2` flag.