### PR TITLE
Separate large pastes into a content card from the instruction

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -55,8 +55,8 @@ import { UploadedFileList } from './uploaded-file-list'
 
 // Constants for timing delays
 const INPUT_UPDATE_DELAY_MS = 10 // Delay to ensure input value is updated before form submission
-// Prototype: only paste events at/over this size (or line count) become a
-// content card, so short/normal pastes stay inline.
+// Only paste events at/over this size (or line count) become a content card,
+// so short/normal pastes stay inline.
 const PASTE_CARD_MIN_CHARS = 400
 const PASTE_CARD_MIN_LINES = 6
 
@@ -121,8 +121,8 @@ export function ChatPanel({
   const [isComposing, setIsComposing] = useState(false) // Composition state
   const [enterDisabled, setEnterDisabled] = useState(false) // Disable Enter after composition ends
   const [isInputFocused, setIsInputFocused] = useState(false) // Track input focus
-  // Prototype: large pastes become separate "content cards" (the target),
-  // keeping the textarea for the instruction. See PASTE_CARD_MIN_CHARS.
+  // Large pastes become separate "content cards" (the target), keeping the
+  // textarea for the instruction. See PASTE_CARD_MIN_CHARS.
   const [contentCards, setContentCards] = useState<string[]>([])
   const { close: closeArtifact } = useArtifact()
   const isLoading = status === 'submitted' || status === 'streaming'
@@ -262,8 +262,8 @@ export function ChatPanel({
       )}
       <form
         onSubmit={e => {
-          // Prototype: fold content cards (target) + input (instruction) into
-          // one message, then re-submit through the normal path.
+          // Fold content cards (target) + input (instruction) into one
+          // message, then re-submit through the normal path.
           if (contentCards.length > 0) {
             e.preventDefault()
             const combined = [

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -47,6 +47,10 @@ import { UploadedFileList } from './uploaded-file-list'
 
 // Constants for timing delays
 const INPUT_UPDATE_DELAY_MS = 10 // Delay to ensure input value is updated before form submission
+// Prototype: only paste events at/over this size (or line count) become a
+// content card, so short/normal pastes stay inline.
+const PASTE_CARD_MIN_CHARS = 400
+const PASTE_CARD_MIN_LINES = 6
 
 function getSearchModeSnapshot(): SearchMode {
   return getCookie('searchMode') === 'adaptive' ? 'adaptive' : 'quick'
@@ -109,6 +113,9 @@ export function ChatPanel({
   const [isComposing, setIsComposing] = useState(false) // Composition state
   const [enterDisabled, setEnterDisabled] = useState(false) // Disable Enter after composition ends
   const [isInputFocused, setIsInputFocused] = useState(false) // Track input focus
+  // Prototype: large pastes become separate "content cards" (the target),
+  // keeping the textarea for the instruction. See PASTE_CARD_MIN_CHARS.
+  const [contentCards, setContentCards] = useState<string[]>([])
   const { close: closeArtifact } = useArtifact()
   const isLoading = status === 'submitted' || status === 'streaming'
   const hasAvailableModels =
@@ -247,6 +254,28 @@ export function ChatPanel({
       )}
       <form
         onSubmit={e => {
+          // Prototype: fold content cards (target) + input (instruction) into
+          // one message, then re-submit through the normal path.
+          if (contentCards.length > 0) {
+            e.preventDefault()
+            const combined = [
+              ...contentCards.map(
+                c => `<pasted-content>\n${c}\n</pasted-content>`
+              ),
+              input
+            ]
+              .filter(s => s && s.trim())
+              .join('\n\n')
+            setContentCards([])
+            handleInputChange({
+              target: { value: combined }
+            } as React.ChangeEvent<HTMLTextAreaElement>)
+            setTimeout(
+              () => inputRef.current?.form?.requestSubmit(),
+              INPUT_UPDATE_DELAY_MS
+            )
+            return
+          }
           if (adaptiveModeSubmitBlocked) {
             e.preventDefault()
             onAdaptiveModeAuthRequired?.()
@@ -308,6 +337,56 @@ export function ChatPanel({
               'ring-1 ring-ring/20 ring-offset-1 ring-offset-background/50'
           )}
         >
+          {contentCards.length > 0 && (
+            <div className="flex flex-col gap-1.5 px-3 pt-3">
+              {contentCards.map((card, i) => (
+                <div
+                  key={i}
+                  className="relative rounded-xl border border-input bg-background px-3 py-2"
+                >
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Pasted content · {card.length.toLocaleString()} chars
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                        onClick={() => {
+                          setContentCards(prev =>
+                            prev.filter((_, j) => j !== i)
+                          )
+                          handleInputChange({
+                            target: {
+                              value: input ? `${input}\n\n${card}` : card
+                            }
+                          } as React.ChangeEvent<HTMLTextAreaElement>)
+                          inputRef.current?.focus()
+                        }}
+                      >
+                        Expand to text
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="Remove pasted content"
+                        className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                        onClick={() =>
+                          setContentCards(prev =>
+                            prev.filter((_, j) => j !== i)
+                          )
+                        }
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  </div>
+                  <p className="line-clamp-2 whitespace-pre-wrap break-words text-xs text-muted-foreground/80">
+                    {card}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
           <Textarea
             ref={inputRef}
             name="input"
@@ -324,6 +403,17 @@ export function ChatPanel({
             disabled={isLoading || isToolInvocationInProgress()}
             className="resize-none w-full min-h-12 bg-transparent border-0 p-3 md:p-4 text-sm placeholder:text-muted-foreground focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
             onChange={handleInputChange}
+            onPaste={e => {
+              const text = e.clipboardData.getData('text')
+              const lineCount = text.split('\n').length
+              if (
+                text.length >= PASTE_CARD_MIN_CHARS ||
+                lineCount >= PASTE_CARD_MIN_LINES
+              ) {
+                e.preventDefault()
+                setContentCards(prev => [...prev, text])
+              }
+            }}
             onKeyDown={e => {
               // e.nativeEvent.isComposing stays true on the keydown that
               // confirms an IME candidate, even after React-level

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -40,6 +40,12 @@ import {
 import { useArtifact } from './artifact/artifact-context'
 import { Button } from './ui/button'
 import { IconBlinkingLogo } from './ui/icons'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from './ui/tooltip'
 import { ActionButtons } from './action-buttons'
 import { FileUploadButton } from './file-upload-button'
 import { MessageNavigationDots } from './message-navigation-dots'
@@ -351,23 +357,33 @@ export function ChatPanel({
                       <FileText className="size-3.5 shrink-0" />
                       Pasted content · {card.length.toLocaleString()} chars
                     </span>
-                    <button
-                      type="button"
-                      title="Expand to text"
-                      aria-label="Expand to text"
-                      className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                      onClick={() => {
-                        setContentCards(prev => prev.filter((_, j) => j !== i))
-                        handleInputChange({
-                          target: {
-                            value: input ? `${input}\n\n${card}` : card
-                          }
-                        } as React.ChangeEvent<HTMLTextAreaElement>)
-                        inputRef.current?.focus()
-                      }}
-                    >
-                      <ArrowsDiagonal className="size-3.5" />
-                    </button>
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label="Expand to text"
+                            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                            onClick={() => {
+                              setContentCards(prev =>
+                                prev.filter((_, j) => j !== i)
+                              )
+                              handleInputChange({
+                                target: {
+                                  value: input ? `${input}\n\n${card}` : card
+                                }
+                              } as React.ChangeEvent<HTMLTextAreaElement>)
+                              inputRef.current?.focus()
+                            }}
+                          >
+                            <ArrowsDiagonal className="size-3.5" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent className="text-xs">
+                          Expand to text
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                   </div>
                   <p className="line-clamp-2 whitespace-pre-wrap break-words text-xs text-muted-foreground/80">
                     {card}

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -21,6 +21,7 @@ import {
 } from '@tabler/icons-react'
 import { toast } from 'sonner'
 
+import { captureClient } from '@/lib/analytics/posthog-client'
 import { SHORTCUT_EVENTS } from '@/lib/keyboard-shortcuts'
 import {
   isAdaptiveModeAuthBlocked,
@@ -272,6 +273,10 @@ export function ChatPanel({
             ]
               .filter(s => s && s.trim())
               .join('\n\n')
+            captureClient('content_card_submitted', {
+              cardCount: contentCards.length,
+              chars: contentCards.reduce((sum, c) => sum + c.length, 0)
+            })
             setContentCards([])
             handleInputChange({
               target: { value: combined }
@@ -363,6 +368,9 @@ export function ChatPanel({
                             aria-label="Expand to text"
                             className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
                             onClick={() => {
+                              captureClient('content_card_expanded', {
+                                chars: card.length
+                              })
                               setContentCards(prev =>
                                 prev.filter((_, j) => j !== i)
                               )
@@ -415,6 +423,10 @@ export function ChatPanel({
               ) {
                 e.preventDefault()
                 setContentCards(prev => [...prev, text])
+                captureClient('content_card_created', {
+                  chars: text.length,
+                  lines: lineCount
+                })
               }
             }}
             onKeyDown={e => {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -14,6 +14,7 @@ import { UseChatHelpers } from '@ai-sdk/react'
 import {
   IconArrowUp as ArrowUp,
   IconChevronDown as ChevronDown,
+  IconFileText as FileText,
   IconMessageCirclePlus as MessageCirclePlus,
   IconSquare as Square
 } from '@tabler/icons-react'
@@ -345,7 +346,8 @@ export function ChatPanel({
                   className="relative rounded-xl border border-input bg-background px-3 py-2"
                 >
                   <div className="mb-1 flex items-center justify-between gap-2">
-                    <span className="text-xs font-medium text-muted-foreground">
+                    <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                      <FileText className="size-3.5 shrink-0" />
                       Pasted content · {card.length.toLocaleString()} chars
                     </span>
                     <div className="flex items-center gap-1">

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/navigation'
 
 import { UseChatHelpers } from '@ai-sdk/react'
 import {
+  IconArrowsDiagonal as ArrowsDiagonal,
   IconArrowUp as ArrowUp,
   IconChevronDown as ChevronDown,
   IconFileText as FileText,
@@ -350,37 +351,23 @@ export function ChatPanel({
                       <FileText className="size-3.5 shrink-0" />
                       Pasted content · {card.length.toLocaleString()} chars
                     </span>
-                    <div className="flex items-center gap-1">
-                      <button
-                        type="button"
-                        className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-                        onClick={() => {
-                          setContentCards(prev =>
-                            prev.filter((_, j) => j !== i)
-                          )
-                          handleInputChange({
-                            target: {
-                              value: input ? `${input}\n\n${card}` : card
-                            }
-                          } as React.ChangeEvent<HTMLTextAreaElement>)
-                          inputRef.current?.focus()
-                        }}
-                      >
-                        Expand to text
-                      </button>
-                      <button
-                        type="button"
-                        aria-label="Remove pasted content"
-                        className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-                        onClick={() =>
-                          setContentCards(prev =>
-                            prev.filter((_, j) => j !== i)
-                          )
-                        }
-                      >
-                        ✕
-                      </button>
-                    </div>
+                    <button
+                      type="button"
+                      title="Expand to text"
+                      aria-label="Expand to text"
+                      className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                      onClick={() => {
+                        setContentCards(prev => prev.filter((_, j) => j !== i))
+                        handleInputChange({
+                          target: {
+                            value: input ? `${input}\n\n${card}` : card
+                          }
+                        } as React.ChangeEvent<HTMLTextAreaElement>)
+                        inputRef.current?.focus()
+                      }}
+                    >
+                      <ArrowsDiagonal className="size-3.5" />
+                    </button>
                   </div>
                   <p className="line-clamp-2 whitespace-pre-wrap break-words text-xs text-muted-foreground/80">
                     {card}

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -267,9 +267,7 @@ export function ChatPanel({
           if (contentCards.length > 0) {
             e.preventDefault()
             const combined = [
-              ...contentCards.map(
-                c => `<pasted-content>\n${c}\n</pasted-content>`
-              ),
+              ...contentCards.map(c => `<user-content>\n${c}\n</user-content>`),
               input
             ]
               .filter(s => s && s.trim())

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -8,6 +8,7 @@ import {
   IconChevronDown as ChevronDown,
   IconChevronUp as ChevronUp,
   IconCopy as Copy,
+  IconFileText as FileText,
   IconPencil as Pencil
 } from '@tabler/icons-react'
 
@@ -15,6 +16,51 @@ import { cn } from '@/lib/utils'
 
 import { Button } from './ui/button'
 import { CollapsibleMessage } from './collapsible-message'
+
+// Prototype: messages may carry pasted target content wrapped in
+// <pasted-content> tags (see chat-panel). Split it out so we can render it as
+// a collapsed card and keep the instruction as the prominent text.
+const PASTED_RE = /<pasted-content>\n?([\s\S]*?)\n?<\/pasted-content>/g
+
+function splitPastedContent(content: string): {
+  cards: string[]
+  rest: string
+} {
+  const cards: string[] = []
+  const rest = content
+    .replace(PASTED_RE, (_, body: string) => {
+      cards.push(body)
+      return ''
+    })
+    .trim()
+  return { cards, rest }
+}
+
+function PastedContentCard({ text }: { text: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-xl border border-input bg-background/60 px-3 py-2">
+      <button
+        type="button"
+        className="flex w-full items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+        onClick={() => setOpen(o => !o)}
+      >
+        <FileText className="size-3.5 shrink-0" />
+        Pasted content · {text.length.toLocaleString()} chars
+        {open ? (
+          <ChevronUp className="ml-auto size-3.5 shrink-0" />
+        ) : (
+          <ChevronDown className="ml-auto size-3.5 shrink-0" />
+        )}
+      </button>
+      {open && (
+        <p className="mt-1.5 max-h-60 overflow-auto whitespace-pre-wrap break-words text-xs text-muted-foreground/80">
+          {text}
+        </p>
+      )}
+    </div>
+  )
+}
 
 interface UserTextSectionProps {
   content: string
@@ -35,6 +81,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
   const [isExpanded, setIsExpanded] = useState(false)
   const [isClamped, setIsClamped] = useState(false)
   const enterResetTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const { cards, rest } = splitPastedContent(content)
 
   const contentRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -169,6 +216,13 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
           </div>
         ) : (
           <div className="relative">
+            {cards.length > 0 && (
+              <div className="mb-2 flex flex-col gap-1.5">
+                {cards.map((c, i) => (
+                  <PastedContentCard key={i} text={c} />
+                ))}
+              </div>
+            )}
             <div
               ref={contentRef}
               className={cn(
@@ -176,7 +230,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
                 !isExpanded && 'line-clamp-3'
               )}
             >
-              {content}
+              {rest}
             </div>
             {(isClamped || isExpanded) && (
               <button

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -17,10 +17,10 @@ import { cn } from '@/lib/utils'
 import { Button } from './ui/button'
 import { CollapsibleMessage } from './collapsible-message'
 
-// Prototype: messages may carry pasted target content wrapped in
-// <pasted-content> tags (see chat-panel). Split it out so we can render it as
+// Prototype: messages may carry the user's target material wrapped in
+// <user-content> tags (see chat-panel). Split it out so we can render it as
 // a collapsed card and keep the instruction as the prominent text.
-const PASTED_RE = /<pasted-content>\n?([\s\S]*?)\n?<\/pasted-content>/g
+const PASTED_RE = /<user-content>\n?([\s\S]*?)\n?<\/user-content>/g
 
 function splitPastedContent(content: string): {
   cards: string[]
@@ -125,7 +125,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
 
     // Re-wrap the preserved pasted cards (target) with the edited instruction.
     const wrapped = [
-      ...cards.map(c => `<pasted-content>\n${c}\n</pasted-content>`),
+      ...cards.map(c => `<user-content>\n${c}\n</user-content>`),
       editedContent
     ]
       .filter(s => s && s.trim())

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -73,15 +73,15 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
   messageId,
   onUpdateMessage
 }) => {
+  const { cards, rest } = splitPastedContent(content)
   const [isEditing, setIsEditing] = useState(false)
-  const [editedContent, setEditedContent] = useState(content)
+  const [editedContent, setEditedContent] = useState(rest)
   const [isComposing, setIsComposing] = useState(false)
   const [enterDisabled, setEnterDisabled] = useState(false)
   const [copied, setCopied] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const [isClamped, setIsClamped] = useState(false)
   const enterResetTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const { cards, rest } = splitPastedContent(content)
 
   const contentRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -110,7 +110,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
 
   const handleEditClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
-    setEditedContent(content)
+    setEditedContent(rest)
     setIsEditing(true)
   }
 
@@ -123,8 +123,16 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
 
     setIsEditing(false)
 
+    // Re-wrap the preserved pasted cards (target) with the edited instruction.
+    const wrapped = [
+      ...cards.map(c => `<pasted-content>\n${c}\n</pasted-content>`),
+      editedContent
+    ]
+      .filter(s => s && s.trim())
+      .join('\n\n')
+
     try {
-      await onUpdateMessage(messageId, editedContent)
+      await onUpdateMessage(messageId, wrapped)
     } catch (error) {
       console.error('Failed to save message:', error)
     }
@@ -194,6 +202,13 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
       >
         {isEditing ? (
           <div className="flex flex-col gap-2">
+            {cards.length > 0 && (
+              <div className="flex flex-col gap-1.5">
+                {cards.map((c, i) => (
+                  <PastedContentCard key={i} text={c} />
+                ))}
+              </div>
+            )}
             <TextareaAutosize
               value={editedContent}
               onChange={e => setEditedContent(e.target.value)}

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -17,9 +17,9 @@ import { cn } from '@/lib/utils'
 import { Button } from './ui/button'
 import { CollapsibleMessage } from './collapsible-message'
 
-// Prototype: messages may carry the user's target material wrapped in
-// <user-content> tags (see chat-panel). Split it out so we can render it as
-// a collapsed card and keep the instruction as the prominent text.
+// Messages may carry the user's target material wrapped in <user-content>
+// tags (see chat-panel). Split it out so we can render it as a collapsed card
+// and keep the instruction as the prominent text.
 const PASTED_RE = /<user-content>\n?([\s\S]*?)\n?<\/user-content>/g
 
 function splitPastedContent(content: string): {

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -39,18 +39,18 @@ function splitPastedContent(content: string): {
 function PastedContentCard({ text }: { text: string }) {
   const [open, setOpen] = useState(false)
   return (
-    <div className="rounded-xl border border-input bg-background/60 px-3 py-2">
+    <div>
       <button
         type="button"
-        className="flex w-full items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+        className="flex w-fit items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
         onClick={() => setOpen(o => !o)}
       >
         <FileText className="size-3.5 shrink-0" />
         Pasted content · {text.length.toLocaleString()} chars
         {open ? (
-          <ChevronUp className="ml-auto size-3.5 shrink-0" />
+          <ChevronUp className="size-3.5 shrink-0" />
         ) : (
-          <ChevronDown className="ml-auto size-3.5 shrink-0" />
+          <ChevronDown className="size-3.5 shrink-0" />
         )}
       </button>
       {open && (


### PR DESCRIPTION
Large pastes (>= 400 chars or >= 6 lines) become a collapsible **content card** (the target), keeping the textarea for the instruction. Short pastes and typing stay inline.

- **Input** (`chat-panel.tsx`): paste -> 📄 card with an expand-to-text icon (tooltip). On submit, card(s) + instruction fold into one message, wrapping the target in `<user-content>` so the model can tell target from instruction.
- **User message** (`user-text-section.tsx`): renders the target as a ghost chip (expand to view) + the instruction as the prominent text. Editing edits the instruction only and re-wraps the card on save. Messages without the wrapper render unchanged.

Scope: input/display UX, single turn, frontend-only. Turn-spanning persistence of the target (persistent slot + prompt caching) is a separate follow-up.

Verified locally end-to-end (paste -> card -> submit -> bubble -> the model fact-checks the pasted target against the web). typecheck / lint / format pass.