### PR TITLE
perf(search): stop producing the redundant citationMap

### DIFF
--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -1,7 +1,7 @@
 import { type JSONValue, tool, UIToolInvocation } from 'ai'
 
 import { getSearchSchemaForModel } from '@/lib/schema/search'
-import { SearchResultItem, SearchResults } from '@/lib/types'
+import { SearchResults } from '@/lib/types'
 import {
   getGeneralSearchProviderType,
   getSearchToolDescription
@@ -142,19 +142,10 @@ export function createSearchTool(fullModel: string) {
         throw error instanceof Error ? error : new Error('Unknown search error')
       }
 
-      // Add citation mapping and toolCallId to search results.
-      // citationMap fully duplicates results (citationMap[i+1] === results[i]);
-      // it is stripped from the model output (see toModelOutput below) but still
-      // lives in the persisted UI payload. Removing it at the source and having
-      // the UI index results[N-1] directly is a separate follow-up (UI +
-      // persisted-shape change, needs a fallback for existing messages).
-      if (searchResult.results && searchResult.results.length > 0) {
-        const citationMap: Record<number, SearchResultItem> = {}
-        searchResult.results.forEach((result, index) => {
-          citationMap[index + 1] = result // Citation numbers start at 1
-        })
-        searchResult.citationMap = citationMap
-      }
+      // No citationMap is attached: it fully duplicated `results`
+      // (citationMap[N] === results[N-1]). The UI derives citations from
+      // `results` by index instead (see extractCitationMaps), with a fallback
+      // for older persisted messages that still carry citationMap.
 
       // Add toolCallId from context
       if (context?.toolCallId) {
@@ -165,7 +156,6 @@ export function createSearchTool(fullModel: string) {
 
       logToolPayload('search', query, {
         results: searchResult.results,
-        citationMap: searchResult.citationMap,
         images: searchResult.images
       })
 
@@ -175,12 +165,11 @@ export function createSearchTool(fullModel: string) {
         ...searchResult
       }
     },
-    // citationMap duplicates `results` (citationMap[i+1] === results[i]) and is
-    // only consumed by the UI for citation rendering; images are display
-    // thumbnails. The model needs neither, so strip them from what it (and every
-    // replayed turn carrying this tool result) sees — this roughly halves the
-    // search payload's token weight. toolCallId MUST stay: the prompt requires
-    // the model to cite as [number](#toolCallId), so it reads the id from here.
+    // Trim the model-facing tool result: images are UI-only thumbnails and
+    // state is a streaming marker. citationMap is no longer produced, but we
+    // still drop it defensively for any older persisted output replayed through
+    // here. toolCallId MUST stay: the prompt cites as [number](#toolCallId), so
+    // the model reads the id from here.
     toModelOutput: ({ output }) => {
       if (!output || typeof output !== 'object') {
         return { type: 'json', value: (output ?? null) as JSONValue }

--- a/lib/utils/__tests__/citation.test.ts
+++ b/lib/utils/__tests__/citation.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import type { SearchResultItem } from '@/lib/types'
+import type { UIMessage } from '@/lib/types/ai'
 
-import { isCitationLabel, processCitations } from '../citation'
+import {
+  extractCitationMaps,
+  isCitationLabel,
+  processCitations
+} from '../citation'
 
 describe('processCitations', () => {
   const mockCitationMaps = {
@@ -180,6 +185,65 @@ describe('processCitations', () => {
     // 0 and 101 are out of bounds (1-100), so they're replaced with empty string
     // -1 doesn't match the regex pattern \d+, so it remains unchanged
     expect(result).toBe('Edge cases:   [-1](#toolCall1)')
+  })
+
+  describe('extractCitationMaps', () => {
+    const results = [
+      { title: 'Google', url: 'https://www.google.com', content: 'a' },
+      { title: 'GitHub', url: 'https://docs.github.com', content: 'b' }
+    ]
+
+    function messageWithSearchPart(output: unknown): UIMessage {
+      return {
+        id: 'm1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-search',
+            state: 'output-available',
+            toolCallId: 'toolCall1',
+            output
+          }
+        ]
+      } as unknown as UIMessage
+    }
+
+    it('derives the citation map from results when citationMap is absent', () => {
+      const maps = extractCitationMaps(
+        messageWithSearchPart({ results, images: [], query: 'q' })
+      )
+
+      expect(maps.toolCall1[1]).toEqual(results[0])
+      expect(maps.toolCall1[2]).toEqual(results[1])
+    })
+
+    it('prefers an existing citationMap (older persisted messages)', () => {
+      const legacy = {
+        1: { title: 'Legacy', url: 'https://legacy.example.com', content: 'c' }
+      }
+      const maps = extractCitationMaps(
+        messageWithSearchPart({ results, citationMap: legacy })
+      )
+
+      expect(maps.toolCall1).toBe(legacy)
+    })
+
+    it('omits tool calls with no results and no citationMap', () => {
+      const maps = extractCitationMaps(
+        messageWithSearchPart({ results: [], images: [], query: 'q' })
+      )
+
+      expect(maps).toEqual({})
+    })
+
+    it('produces a map that processCitations can resolve', () => {
+      const maps = extractCitationMaps(
+        messageWithSearchPart({ results, images: [], query: 'q' })
+      )
+      const result = processCitations('See [1](#toolCall1)', maps)
+
+      expect(result).toBe('See [google](https://www.google.com)')
+    })
   })
 
   describe('isCitationLabel', () => {

--- a/lib/utils/citation.ts
+++ b/lib/utils/citation.ts
@@ -38,9 +38,21 @@ export function extractCitationMaps(
       part.toolCallId
     ) {
       const searchResults = part.output as SearchResults
-      if (searchResults.citationMap) {
+
+      // Prefer citationMap when present (older persisted messages still carry
+      // it). Newer search outputs omit the redundant citationMap, so derive it
+      // from results by index (citation N -> results[N-1]).
+      let citationMap = searchResults.citationMap
+      if (!citationMap && Array.isArray(searchResults.results)) {
+        citationMap = {}
+        searchResults.results.forEach((result, index) => {
+          citationMap![index + 1] = result // Citation numbers start at 1
+        })
+      }
+
+      if (citationMap && Object.keys(citationMap).length > 0) {
         // Store citation map with toolCallId as key
-        citationMaps[part.toolCallId] = searchResults.citationMap
+        citationMaps[part.toolCallId] = citationMap
       }
     }
   })


### PR DESCRIPTION
## What
The search tool attached a `citationMap` that fully duplicates `results` (`citationMap[N] === results[N-1]`) to every search output. This removes it: `extractCitationMaps` now derives the citation lookup from `results` by index.

## Why
`citationMap` doubled the stored/streamed UI payload for no added information. A prior PR (#882) stopped sending it to the model; this removes the duplication on the UI/persistence side too — smaller DB rows and client transfer.

## Backward compatibility
Older persisted messages still carry `citationMap`. `extractCitationMaps` prefers it when present and falls back to deriving from `results` otherwise, so existing chats render unchanged.

## Verified
- typecheck / lint / format / test (246) / build pass.
- Live: a new search (no citationMap) renders citations from results; an old persisted chat (with citationMap) still renders via the fallback.