### PR TITLE
fix(context-window): add gemini-3 models to the context-window table

### DIFF
--- a/lib/utils/__tests__/context-window.test.ts
+++ b/lib/utils/__tests__/context-window.test.ts
@@ -48,6 +48,14 @@ describe('context-window', () => {
       const maxTokens = getMaxAllowedTokens(mockModel)
       expect(maxTokens).toBeGreaterThanOrEqual(1000)
     })
+
+    test('uses the real ~1M window for production Gemini models', () => {
+      // (1048576 - 65536) - floor(1048576 * 0.1) = 983040 - 104857 = 878183
+      for (const id of ['gemini-3-flash-preview', 'gemini-3.1-flash-lite']) {
+        const maxTokens = getMaxAllowedTokens({ ...mockModel, id })
+        expect(maxTokens).toBe(878183)
+      }
+    })
   })
 
   describe('shouldTruncateMessages', () => {

--- a/lib/utils/context-window.ts
+++ b/lib/utils/context-window.ts
@@ -24,6 +24,8 @@ const MODEL_CONTEXT_WINDOWS: Record<string, ModelContextInfo> = {
   'claude-3-5-haiku-20241022': { contextWindow: 200000, outputTokens: 8192 },
 
   // Google Models
+  'gemini-3-flash-preview': { contextWindow: 1048576, outputTokens: 65536 },
+  'gemini-3.1-flash-lite': { contextWindow: 1048576, outputTokens: 65536 },
   'gemini-2.5-flash': { contextWindow: 1048576, outputTokens: 65536 },
   'gemini-2.5-pro': { contextWindow: 1048576, outputTokens: 65536 },
 
@@ -55,7 +57,9 @@ const MODEL_TO_ENCODING: Record<string, TiktokenEncoding> = {
   'claude-3-7-sonnet': 'cl100k_base',
   'claude-3-7-sonnet-20250219': 'cl100k_base',
   'claude-3-5-haiku-20241022': 'cl100k_base',
-  'gemini-2.5-flash': 'cl100k_base', // Use GPT-4 tokenizer as approximation for Gemini
+  'gemini-3-flash-preview': 'cl100k_base', // Use GPT-4 tokenizer as approximation for Gemini
+  'gemini-3.1-flash-lite': 'cl100k_base',
+  'gemini-2.5-flash': 'cl100k_base',
   'gemini-2.5-pro': 'cl100k_base',
   'grok-4-0709': 'cl100k_base', // Use GPT-4 tokenizer as approximation for Grok
   'grok-3': 'cl100k_base',


### PR DESCRIPTION
## What
Adds `gemini-3-flash-preview` and `gemini-3.1-flash-lite` to `MODEL_CONTEXT_WINDOWS` (and the encoder map) with their real `1,048,576 / 65,536` limits.

## Why
These production Gemini models were absent from the table, so `getModelContextInfo` fell back to the `16,384` default → `getMaxAllowedTokens` ≈ 10,650. That budgets ~1M-context models as if they had a 16K window, which can truncate conversation history far too aggressively on long sessions.

## Notes
- The hardcoded table is maintained manually for now; replacing it with a live source (e.g. models.dev, which also carries pricing) is a separate follow-up.
- Test added asserting these models resolve to the ~1M budget (`getMaxAllowedTokens` = 878,183), not the 16K default.

## Verified
typecheck / lint / format / test (248) / build pass.