### PR TITLE
refactor: pasted content & URLs as structured data parts

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -270,17 +270,30 @@ export function ChatPanel({
       )}
       <form
         onSubmit={e => {
-          // Fold content cards (target) + input (instruction) into one
-          // message, then re-submit through the normal path.
+          // Pasted attachments (content cards / URL chips) are sent as
+          // structured data parts alongside the instruction text part — no
+          // in-band markers. The server maps them to the model prompt.
           if (contentCards.length > 0 || urlCards.length > 0) {
             e.preventDefault()
-            const combined = [
-              ...contentCards.map(c => `<user-content>\n${c}\n</user-content>`),
-              ...urlCards,
-              input
+            if (adaptiveModeSubmitBlocked) {
+              onAdaptiveModeAuthRequired?.()
+              return
+            }
+            if (!hasAvailableModels) {
+              toast.error('No enabled model is available')
+              return
+            }
+            const parts = [
+              ...contentCards.map(text => ({
+                type: 'data-pastedContent',
+                data: { text }
+              })),
+              ...urlCards.map(url => ({
+                type: 'data-sourceUrl',
+                data: { url }
+              })),
+              ...(input.trim() ? [{ type: 'text', text: input }] : [])
             ]
-              .filter(s => s && s.trim())
-              .join('\n\n')
             if (contentCards.length > 0) {
               captureClient('content_card_submitted', {
                 cardCount: contentCards.length,
@@ -295,12 +308,11 @@ export function ChatPanel({
             setContentCards([])
             setUrlCards([])
             handleInputChange({
-              target: { value: combined }
+              target: { value: '' }
             } as React.ChangeEvent<HTMLTextAreaElement>)
-            setTimeout(
-              () => inputRef.current?.form?.requestSubmit(),
-              INPUT_UPDATE_DELAY_MS
-            )
+            append({ role: 'user', parts })
+            setIsInputFocused(false)
+            inputRef.current?.blur()
             return
           }
           if (adaptiveModeSubmitBlocked) {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -283,6 +283,7 @@ export function ChatPanel({
               toast.error('No enabled model is available')
               return
             }
+            const uploaded = uploadedFiles.filter(f => f.status === 'uploaded')
             const parts = [
               ...contentCards.map(text => ({
                 type: 'data-pastedContent',
@@ -291,6 +292,12 @@ export function ChatPanel({
               ...urlCards.map(url => ({
                 type: 'data-sourceUrl',
                 data: { url }
+              })),
+              ...uploaded.map(f => ({
+                type: 'file',
+                url: f.url!,
+                filename: f.name!,
+                mediaType: f.file.type
               })),
               ...(input.trim() ? [{ type: 'text', text: input }] : [])
             ]
@@ -307,6 +314,7 @@ export function ChatPanel({
             }
             setContentCards([])
             setUrlCards([])
+            setUploadedFiles([])
             handleInputChange({
               target: { value: '' }
             } as React.ChangeEvent<HTMLTextAreaElement>)

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -415,9 +415,18 @@ export function Chat({
         if (messageIndex === -1) return prevMessages
 
         const updatedMessages = [...prevMessages]
+        const original = updatedMessages[messageIndex]
+        // Only replace the text part — keep pasted-content / URL / file parts
+        // so editing the instruction doesn't drop the structured context.
+        const oldParts = (original.parts ?? []) as any[]
+        const newParts = oldParts.some((p: any) => p.type === 'text')
+          ? oldParts.map((p: any) =>
+              p.type === 'text' ? { type: 'text', text: newContentText } : p
+            )
+          : [...oldParts, { type: 'text', text: newContentText }]
         updatedMessages[messageIndex] = {
-          ...updatedMessages[messageIndex],
-          parts: [{ type: 'text', text: newContentText }]
+          ...original,
+          parts: newParts
         }
 
         return updatedMessages

--- a/components/pasted-parts.tsx
+++ b/components/pasted-parts.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+
+import {
+  IconChevronDown as ChevronDown,
+  IconChevronUp as ChevronUp,
+  IconFileText as FileText
+} from '@tabler/icons-react'
+
+// Collapsed card for a pasted text blob (a `data-pastedContent` part, or a
+// legacy `<user-content>` block in old messages).
+export function PastedContentCard({ text }: { text: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button
+        type="button"
+        className="flex w-fit items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+        onClick={() => setOpen(o => !o)}
+      >
+        <FileText className="size-3.5 shrink-0" />
+        Pasted content · {text.length.toLocaleString()} chars
+        {open ? (
+          <ChevronUp className="size-3.5 shrink-0" />
+        ) : (
+          <ChevronDown className="size-3.5 shrink-0" />
+        )}
+      </button>
+      {open && (
+        <p className="mt-1.5 max-h-60 overflow-auto whitespace-pre-wrap break-words text-xs text-muted-foreground/80">
+          {text}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// Favicon chip for a pasted URL (a `data-sourceUrl` part). Clickable.
+export function UrlChip({ url }: { url: string }) {
+  let host = url
+  try {
+    host = new URL(url).host.replace(/^www\./, '')
+  } catch {}
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex w-fit items-center gap-1.5 rounded-full border border-input bg-background py-1 pl-2 pr-2.5 text-xs text-muted-foreground hover:text-foreground"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={`https://www.google.com/s2/favicons?domain=${host}&sz=32`}
+        alt=""
+        width={14}
+        height={14}
+        className="size-3.5 shrink-0 rounded-sm"
+      />
+      <span className="max-w-[220px] truncate">{host}</span>
+    </a>
+  )
+}

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -52,9 +52,16 @@ export function RenderMessage({
 
   // Use provided citation maps (from all messages)
   if (message.role === 'user') {
+    const parts = (message.parts ?? []) as any[]
+    // Pasted attachments render below the instruction, indented to line up
+    // with the text column (past the avatar).
+    const attachments = parts.filter(
+      part =>
+        part.type === 'data-pastedContent' || part.type === 'data-sourceUrl'
+    )
     return (
       <>
-        {message.parts?.map((part: any, index: number) => {
+        {parts.map((part: any, index: number) => {
           switch (part.type) {
             case 'text':
               return (
@@ -76,24 +83,30 @@ export function RenderMessage({
                   }}
                 />
               )
-            case 'data-pastedContent':
-              return (
-                <PastedContentCard
-                  key={`${messageId}-user-paste-${index}`}
-                  text={part.data?.text ?? ''}
-                />
-              )
-            case 'data-sourceUrl':
-              return (
-                <UrlChip
-                  key={`${messageId}-user-url-${index}`}
-                  url={part.data?.url ?? ''}
-                />
-              )
             default:
               return null
           }
         })}
+        {attachments.length > 0 && (
+          <div className="flex">
+            <div className="w-5 shrink-0" aria-hidden />
+            <div className="mt-1 flex flex-1 flex-col items-start gap-1.5 px-3">
+              {attachments.map((part: any, index: number) =>
+                part.type === 'data-pastedContent' ? (
+                  <PastedContentCard
+                    key={`${messageId}-user-paste-${index}`}
+                    text={part.data?.text ?? ''}
+                  />
+                ) : (
+                  <UrlChip
+                    key={`${messageId}-user-url-${index}`}
+                    url={part.data?.url ?? ''}
+                  />
+                )
+              )}
+            </div>
+          </div>
+        )}
       </>
     )
   }

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -11,6 +11,7 @@ import type { DynamicToolPart } from '@/lib/types/dynamic-tools'
 
 import { AnswerSection } from './answer-section'
 import { DynamicToolDisplay } from './dynamic-tool-display'
+import { PastedContentCard, UrlChip } from './pasted-parts'
 import ResearchProcessSection from './research-process-section'
 import { UserFileSection } from './user-file-section'
 import { UserTextSection } from './user-text-section'
@@ -73,6 +74,20 @@ export function RenderMessage({
                     url: part.url,
                     contentType: part.mediaType
                   }}
+                />
+              )
+            case 'data-pastedContent':
+              return (
+                <PastedContentCard
+                  key={`${messageId}-user-paste-${index}`}
+                  text={part.data?.text ?? ''}
+                />
+              )
+            case 'data-sourceUrl':
+              return (
+                <UrlChip
+                  key={`${messageId}-user-url-${index}`}
+                  url={part.data?.url ?? ''}
                 />
               )
             default:

--- a/components/render-message.tsx
+++ b/components/render-message.tsx
@@ -11,7 +11,6 @@ import type { DynamicToolPart } from '@/lib/types/dynamic-tools'
 
 import { AnswerSection } from './answer-section'
 import { DynamicToolDisplay } from './dynamic-tool-display'
-import { PastedContentCard, UrlChip } from './pasted-parts'
 import ResearchProcessSection from './research-process-section'
 import { UserFileSection } from './user-file-section'
 import { UserTextSection } from './user-text-section'
@@ -53,59 +52,34 @@ export function RenderMessage({
   // Use provided citation maps (from all messages)
   if (message.role === 'user') {
     const parts = (message.parts ?? []) as any[]
-    // Pasted attachments render below the instruction, indented to line up
-    // with the text column (past the avatar).
-    const attachments = parts.filter(
-      part =>
-        part.type === 'data-pastedContent' || part.type === 'data-sourceUrl'
-    )
+    const textPart = parts.find((part: any) => part.type === 'text')
+    const files = parts.filter((part: any) => part.type === 'file')
+    const pastedTexts = parts
+      .filter((part: any) => part.type === 'data-pastedContent')
+      .map((part: any) => part.data?.text ?? '')
+    const urls = parts
+      .filter((part: any) => part.type === 'data-sourceUrl')
+      .map((part: any) => part.data?.url ?? '')
     return (
       <>
-        {parts.map((part: any, index: number) => {
-          switch (part.type) {
-            case 'text':
-              return (
-                <UserTextSection
-                  key={`${messageId}-user-text-${index}`}
-                  content={part.text}
-                  messageId={messageId}
-                  onUpdateMessage={onUpdateMessage}
-                />
-              )
-            case 'file':
-              return (
-                <UserFileSection
-                  key={`${messageId}-user-file-${index}`}
-                  file={{
-                    name: part.filename || 'Unknown file',
-                    url: part.url,
-                    contentType: part.mediaType
-                  }}
-                />
-              )
-            default:
-              return null
-          }
-        })}
-        {attachments.length > 0 && (
-          <div className="flex">
-            <div className="w-5 shrink-0" aria-hidden />
-            <div className="mt-1 flex flex-1 flex-col items-start gap-1.5 px-3">
-              {attachments.map((part: any, index: number) =>
-                part.type === 'data-pastedContent' ? (
-                  <PastedContentCard
-                    key={`${messageId}-user-paste-${index}`}
-                    text={part.data?.text ?? ''}
-                  />
-                ) : (
-                  <UrlChip
-                    key={`${messageId}-user-url-${index}`}
-                    url={part.data?.url ?? ''}
-                  />
-                )
-              )}
-            </div>
-          </div>
+        {files.map((part: any, index: number) => (
+          <UserFileSection
+            key={`${messageId}-user-file-${index}`}
+            file={{
+              name: part.filename || 'Unknown file',
+              url: part.url,
+              contentType: part.mediaType
+            }}
+          />
+        ))}
+        {(textPart || pastedTexts.length > 0 || urls.length > 0) && (
+          <UserTextSection
+            content={textPart?.text ?? ''}
+            pastedTexts={pastedTexts}
+            urls={urls}
+            messageId={messageId}
+            onUpdateMessage={onUpdateMessage}
+          />
         )}
       </>
     )

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -8,7 +8,6 @@ import {
   IconChevronDown as ChevronDown,
   IconChevronUp as ChevronUp,
   IconCopy as Copy,
-  IconFileText as FileText,
   IconPencil as Pencil
 } from '@tabler/icons-react'
 
@@ -16,10 +15,11 @@ import { cn } from '@/lib/utils'
 
 import { Button } from './ui/button'
 import { CollapsibleMessage } from './collapsible-message'
+import { PastedContentCard } from './pasted-parts'
 
-// Messages may carry the user's target material wrapped in <user-content>
-// tags (see chat-panel). Split it out so we can render it as a collapsed card
-// and keep the instruction as the prominent text.
+// Legacy: old messages carry pasted material wrapped in <user-content> tags
+// (new messages use `data-pastedContent` parts). Split it out so we can render
+// it as a collapsed card and keep the instruction as the prominent text.
 const PASTED_RE = /<user-content>\n?([\s\S]*?)\n?<\/user-content>/g
 
 function splitPastedContent(content: string): {
@@ -36,76 +36,6 @@ function splitPastedContent(content: string): {
   return { cards, rest }
 }
 
-// URL cards (see chat-panel) are folded into the message as bare-URL lines
-// BEFORE the instruction. Only pull the LEADING run of URL lines, so the chip
-// count matches what the composer showed — a URL the user typed inside the
-// instruction body stays as plain text.
-const BARE_URL_RE = /^https?:\/\/\S+$/
-
-function splitUrls(content: string): { urls: string[]; rest: string } {
-  const lines = content.split('\n')
-  const urls: string[] = []
-  let i = 0
-  for (; i < lines.length; i++) {
-    const trimmed = lines[i].trim()
-    if (trimmed === '') continue // blank line between leading chips
-    if (!BARE_URL_RE.test(trimmed)) break // instruction starts here
-    urls.push(trimmed)
-  }
-  return { urls, rest: lines.slice(i).join('\n').trim() }
-}
-
-function UrlChip({ url }: { url: string }) {
-  let host = url
-  try {
-    host = new URL(url).host.replace(/^www\./, '')
-  } catch {}
-  return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex w-fit items-center gap-1.5 rounded-full border border-input bg-background py-1 pl-2 pr-2.5 text-xs text-muted-foreground hover:text-foreground"
-    >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={`https://www.google.com/s2/favicons?domain=${host}&sz=32`}
-        alt=""
-        width={14}
-        height={14}
-        className="size-3.5 shrink-0 rounded-sm"
-      />
-      <span className="max-w-[220px] truncate">{host}</span>
-    </a>
-  )
-}
-
-function PastedContentCard({ text }: { text: string }) {
-  const [open, setOpen] = useState(false)
-  return (
-    <div>
-      <button
-        type="button"
-        className="flex w-fit items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-        onClick={() => setOpen(o => !o)}
-      >
-        <FileText className="size-3.5 shrink-0" />
-        Pasted content · {text.length.toLocaleString()} chars
-        {open ? (
-          <ChevronUp className="size-3.5 shrink-0" />
-        ) : (
-          <ChevronDown className="size-3.5 shrink-0" />
-        )}
-      </button>
-      {open && (
-        <p className="mt-1.5 max-h-60 overflow-auto whitespace-pre-wrap break-words text-xs text-muted-foreground/80">
-          {text}
-        </p>
-      )}
-    </div>
-  )
-}
-
 interface UserTextSectionProps {
   content: string
   messageId?: string
@@ -117,8 +47,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
   messageId,
   onUpdateMessage
 }) => {
-  const { cards, rest: afterCards } = splitPastedContent(content)
-  const { urls, rest } = splitUrls(afterCards)
+  const { cards, rest } = splitPastedContent(content)
   const [isEditing, setIsEditing] = useState(false)
   const [editedContent, setEditedContent] = useState(rest)
   const [isComposing, setIsComposing] = useState(false)
@@ -171,7 +100,6 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
     // Re-wrap the preserved pasted cards (target) with the edited instruction.
     const wrapped = [
       ...cards.map(c => `<user-content>\n${c}\n</user-content>`),
-      ...urls,
       editedContent
     ]
       .filter(s => s && s.trim())
@@ -255,13 +183,6 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
                 ))}
               </div>
             )}
-            {urls.length > 0 && (
-              <div className="flex flex-wrap gap-1.5">
-                {urls.map((u, i) => (
-                  <UrlChip key={i} url={u} />
-                ))}
-              </div>
-            )}
             <TextareaAutosize
               value={editedContent}
               onChange={e => setEditedContent(e.target.value)}
@@ -288,13 +209,6 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
               <div className="mb-2 flex flex-col gap-1.5">
                 {cards.map((c, i) => (
                   <PastedContentCard key={i} text={c} />
-                ))}
-              </div>
-            )}
-            {urls.length > 0 && (
-              <div className="mb-2 flex flex-wrap gap-1.5">
-                {urls.map((u, i) => (
-                  <UrlChip key={i} url={u} />
                 ))}
               </div>
             )}

--- a/components/user-text-section.tsx
+++ b/components/user-text-section.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/lib/utils'
 
 import { Button } from './ui/button'
 import { CollapsibleMessage } from './collapsible-message'
-import { PastedContentCard } from './pasted-parts'
+import { PastedContentCard, UrlChip } from './pasted-parts'
 
 // Legacy: old messages carry pasted material wrapped in <user-content> tags
 // (new messages use `data-pastedContent` parts). Split it out so we can render
@@ -38,16 +38,23 @@ function splitPastedContent(content: string): {
 
 interface UserTextSectionProps {
   content: string
+  // Pasted attachments (new data parts), placed below the instruction.
+  pastedTexts?: string[]
+  urls?: string[]
   messageId?: string
   onUpdateMessage?: (messageId: string, newContent: string) => Promise<void>
 }
 
 export const UserTextSection: React.FC<UserTextSectionProps> = ({
   content,
+  pastedTexts = [],
+  urls = [],
   messageId,
   onUpdateMessage
 }) => {
-  const { cards, rest } = splitPastedContent(content)
+  // Legacy cards live inside the text; new pasted texts arrive as props.
+  const { cards: legacyCards, rest } = splitPastedContent(content)
+  const cards = [...legacyCards, ...pastedTexts]
   const [isEditing, setIsEditing] = useState(false)
   const [editedContent, setEditedContent] = useState(rest)
   const [isComposing, setIsComposing] = useState(false)
@@ -97,9 +104,10 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
 
     setIsEditing(false)
 
-    // Re-wrap the preserved pasted cards (target) with the edited instruction.
+    // Re-wrap only the legacy text-embedded cards; new pasted texts are
+    // separate parts and are not part of the editable text.
     const wrapped = [
-      ...cards.map(c => `<user-content>\n${c}\n</user-content>`),
+      ...legacyCards.map(c => `<user-content>\n${c}\n</user-content>`),
       editedContent
     ]
       .filter(s => s && s.trim())
@@ -168,6 +176,18 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
     }, 50)
   }
 
+  // Pasted attachments (cards + URL chips), placed below the instruction.
+  const attachments = (cards.length > 0 || urls.length > 0) && (
+    <div className="mt-2 flex flex-col items-start gap-1.5">
+      {cards.map((c, i) => (
+        <PastedContentCard key={`card-${i}`} text={c} />
+      ))}
+      {urls.map((u, i) => (
+        <UrlChip key={`url-${i}`} url={u} />
+      ))}
+    </div>
+  )
+
   return (
     <CollapsibleMessage role="user">
       <div
@@ -176,13 +196,6 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
       >
         {isEditing ? (
           <div className="flex flex-col gap-2">
-            {cards.length > 0 && (
-              <div className="flex flex-col gap-1.5">
-                {cards.map((c, i) => (
-                  <PastedContentCard key={i} text={c} />
-                ))}
-              </div>
-            )}
             <TextareaAutosize
               value={editedContent}
               onChange={e => setEditedContent(e.target.value)}
@@ -194,6 +207,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
               minRows={2}
               maxRows={10}
             />
+            {attachments}
             <div className="flex justify-end gap-2">
               <Button variant="secondary" size="sm" onClick={handleCancelClick}>
                 Cancel
@@ -205,13 +219,6 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
           </div>
         ) : (
           <div className="relative">
-            {cards.length > 0 && (
-              <div className="mb-2 flex flex-col gap-1.5">
-                {cards.map((c, i) => (
-                  <PastedContentCard key={i} text={c} />
-                ))}
-              </div>
-            )}
             <div
               ref={contentRef}
               className={cn(
@@ -238,6 +245,7 @@ export const UserTextSection: React.FC<UserTextSectionProps> = ({
                 )}
               </button>
             )}
+            {attachments}
             <div
               className={cn(
                 'absolute -top-1 -right-1 flex items-center gap-0.5 p-0.5 transition-opacity bg-background rounded-full shadow-sm border',

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -25,6 +25,7 @@ import { getTextFromParts } from '../utils/message-utils'
 import { perfLog, perfTime } from '../utils/perf-logging'
 import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
+import { convertDataPart } from './helpers/convert-data-part'
 import { persistStreamResults } from './helpers/persist-stream-results'
 import { prepareMessages } from './helpers/prepare-messages'
 import { stripReasoningParts } from './helpers/strip-reasoning-parts'
@@ -141,7 +142,9 @@ export async function createChatStreamResponse(
       : messagesWithoutSpec
 
     // Convert to model messages and apply context window management
-    let modelMessages = await convertToModelMessages(messagesToConvert)
+    let modelMessages = await convertToModelMessages(messagesToConvert, {
+      convertDataPart
+    })
 
     // Prune messages to reduce token usage while keeping recent context
     modelMessages = pruneMessages({

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/context-window'
 import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
+import { convertDataPart } from './helpers/convert-data-part'
 import { stripReasoningParts } from './helpers/strip-reasoning-parts'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
 import { BaseStreamConfig } from './types'
@@ -73,7 +74,9 @@ export async function createEphemeralChatStreamResponse(
       ? stripReasoningParts(messagesWithoutSpec)
       : messagesWithoutSpec
 
-    let modelMessages = await convertToModelMessages(messagesToConvert)
+    let modelMessages = await convertToModelMessages(messagesToConvert, {
+      convertDataPart
+    })
 
     modelMessages = pruneMessages({
       messages: modelMessages,

--- a/lib/streaming/helpers/convert-data-part.ts
+++ b/lib/streaming/helpers/convert-data-part.ts
@@ -1,0 +1,35 @@
+import type { FilePart, TextPart } from '@ai-sdk/provider-utils'
+import { randomUUID } from 'crypto'
+
+/**
+ * Maps Morphic's user-authored data parts into model input for
+ * `convertToModelMessages({ convertDataPart })`. Returning `undefined` drops
+ * the part from the model message.
+ *
+ * Pasted content is wrapped in a nonce-delimited block so the content itself
+ * can never spoof the boundary — this replaces the old in-band `<user-content>`
+ * marker and removes its prompt-injection / boundary-collision risk.
+ */
+export function convertDataPart(part: {
+  type: string
+  data?: unknown
+}): TextPart | FilePart | undefined {
+  if (part.type === 'data-pastedContent') {
+    const data = part.data as { text?: unknown } | undefined
+    const text = typeof data?.text === 'string' ? data.text : ''
+    if (!text) return undefined
+    const nonce = randomUUID().slice(0, 8)
+    return {
+      type: 'text',
+      text: `[user-pasted-content ${nonce}]\n${text}\n[/user-pasted-content ${nonce}]`
+    }
+  }
+
+  if (part.type === 'data-sourceUrl') {
+    const data = part.data as { url?: unknown } | undefined
+    const url = typeof data?.url === 'string' ? data.url : ''
+    return url ? { type: 'text', text: url } : undefined
+  }
+
+  return undefined
+}

--- a/lib/types/ai.ts
+++ b/lib/types/ai.ts
@@ -27,6 +27,9 @@ export type UIMessage<
 
 export type UIDataTypes = {
   sources?: any[]
+  // User-authored attachments (composer): a pasted text blob and a pasted URL.
+  pastedContent?: { text: string }
+  sourceUrl?: { url: string }
 }
 
 // Create todo tools instance for type inference


### PR DESCRIPTION
Cleans up the `pasted content` implementation: replaces the in-band `<user-content>` marker (and the bare-URL-line convention) with structured AI SDK **data parts**.

## What
- **`data-pastedContent`** / **`data-sourceUrl`** parts instead of folding everything into one text part.
- Composer sends them as message `parts`; `convertToModelMessages({ convertDataPart })` maps them to the model prompt.
- Pasted text is wrapped in a **nonce-delimited** block on the server, so content can't spoof the boundary — removes the old prompt-injection / boundary-collision risk.
- Renderer reads parts by type (cards/chips); `PASTED_RE`/`splitUrls` no longer touch new messages.

## Compatibility
- **Persistence unchanged** — reuses the generic `data_prefix`/`data_content`/`data_id` columns (no migration).
- Old `<user-content>` messages still render via a legacy reader; old bare-URL messages fall back to plain text.

## Verified end-to-end (live)
- **Pasted content**: composer card → model answers with the exact pasted facts → user message renders the collapsed card.
- **Pasted URL**: composer chip → fetch tool retrieves it → model answers about the page → user message renders the favicon chip.
- typecheck ✓ · lint ✓ · format ✓ · tests 247 passed · no console errors.

## Files
- new: `components/pasted-parts.tsx`, `lib/streaming/helpers/convert-data-part.ts`
- edited: `chat-panel.tsx`, `render-message.tsx`, `user-text-section.tsx`, `lib/types/ai.ts`, both streaming responses