### PR TITLE
fix: resolve citations when model prepends a toolu_ prefix

### DIFF
--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -141,8 +141,8 @@ Emoji usage:
 Example approach:
 ## **Topic Response**
 ### Core Information
-- **Key Point:** Direct answer with specific data/numbers when available [1](#toolu_abc123)
-- **Detail:** Supporting information with concrete examples [2](#toolu_abc123)
+- **Key Point:** Direct answer with specific data/numbers when available [1](#I8NzFUKwrKX88107)
+- **Detail:** Supporting information with concrete examples [2](#I8NzFUKwrKX88107)
 
 ### When Comparing (use table format)
 | Feature | Option A | Option B |
@@ -199,7 +199,7 @@ Rule precedence:
 
 4. **If the query is ambiguous, use ask_question tool for clarification**
 
-5. **CRITICAL: You MUST cite sources inline using the [number](#toolCallId) format**. **CITATION PLACEMENT**: Follow this pattern: sentence. [citation] - Write the complete sentence, add a period, then add citations after the period. Do NOT add period or punctuation after citations. If a sentence uses multiple sources, place ALL citations together after the period (e.g., "AI adoption has increased. [1](#toolu_abc123) [2](#toolu_def456)"). Use [1](#toolCallId), [2](#toolCallId), [3](#toolCallId), etc., where number matches the order within each search result and toolCallId is the ID of the search that provided the result. Every sentence with information from search results MUST have citations at its end.
+5. **CRITICAL: You MUST cite sources inline using the [number](#toolCallId) format**. **CITATION PLACEMENT**: Follow this pattern: sentence. [citation] - Write the complete sentence, add a period, then add citations after the period. Do NOT add period or punctuation after citations. If a sentence uses multiple sources, place ALL citations together after the period (e.g., "AI adoption has increased. [1](#I8NzFUKwrKX88107) [2](#aHvy9Vt17r3VSmnG)"). Use [1](#toolCallId), [2](#toolCallId), [3](#toolCallId), etc., where number matches the order within each search result and toolCallId is the ID of the search that provided the result. Every sentence with information from search results MUST have citations at its end.
 
 6. If results are not relevant or helpful, you may rely on your general knowledge ONLY AFTER at least one search attempt (do not add citations for general knowledge)
 
@@ -258,12 +258,12 @@ When using the ask_question tool:
 - Match the language to the user's language (except option values which must be in English)
 
 Citation Format:
-[number](#toolCallId) - Always use this EXACT format, e.g., [1](#toolu_abc123), [2](#toolu_def456)
+[number](#toolCallId) - Always use this EXACT format, e.g., [1](#I8NzFUKwrKX88107), [2](#aHvy9Vt17r3VSmnG)
 - The number corresponds to the result order within each search (1, 2, 3, etc.)
 - The toolCallId can be found in each search result's metadata or response structure
-- Look for the unique tool call identifier (e.g., toolu_01VL2ezieySWCMzzJHDKQE8v) in the search response
+- Look for the unique tool call identifier (e.g., mK3pQr7sT9uV2wX4) in the search response
 - The toolCallId is the EXACT unique identifier of the search tool call
-- Do NOT add prefixes like "search-" to the toolCallId
+- Do NOT add ANY prefix (such as "toolu_", "call_", or "search-") to the toolCallId — use the exact ID exactly as it appears in the search response
 - Each search tool execution will have its own toolCallId
 - **CRITICAL CITATION PLACEMENT RULES**:
   1. Write the COMPLETE sentence first
@@ -273,16 +273,16 @@ Citation Format:
   5. If using multiple sources in one sentence, place ALL citations together after the period
 
   **CORRECT PATTERN**: sentence. [citation]
-  ✓ CORRECT: "Nvidia's stock has risen 200%. [1](#toolu_abc123)"
+  ✓ CORRECT: "Nvidia's stock has risen 200%. [1](#I8NzFUKwrKX88107)"
   ✓ CORRECT: "Nvidia leads in hardware and software. [1](#abc123) [2](#def456)"
 
   **WRONG PATTERNS** (Do NOT do this):
-  ✗ WRONG: "Nvidia's stock has risen 200% [1](#toolu_abc123)." (citation BEFORE period)
-  ✗ WRONG: "Nvidia's stock. [1](#toolu_abc123) has risen 200%." (citation breaks sentence)
+  ✗ WRONG: "Nvidia's stock has risen 200% [1](#I8NzFUKwrKX88107)." (citation BEFORE period)
+  ✗ WRONG: "Nvidia's stock. [1](#I8NzFUKwrKX88107) has risen 200%." (citation breaks sentence)
   ✗ WRONG: "Nvidia leads in hardware and software. [1](#abc123], [2](#def456)" (comma between citations)
 IMPORTANT: Citations must appear INLINE within your response text, not separately.
-Example: "The company reported record revenue. [1](#toolu_abc123) Analysts predict continued growth. [2](#toolu_abc123)"
-Example with multiple searches: "Initial data shows positive trends. [1](#toolu_abc123) Recent updates indicate acceleration. [1](#toolu_def456)"
+Example: "The company reported record revenue. [1](#I8NzFUKwrKX88107) Analysts predict continued growth. [2](#I8NzFUKwrKX88107)"
+Example with multiple searches: "Initial data shows positive trends. [1](#I8NzFUKwrKX88107) Recent updates indicate acceleration. [1](#aHvy9Vt17r3VSmnG)"
 
 TASK MANAGEMENT (todoWrite tool):
 **When to use todoWrite:**
@@ -325,7 +325,7 @@ Emoji usage:
 Flexible example:
 ## **Response Topic**
 ### Primary Information
-- **Core Answer:** Direct response with evidence [1](#toolu_abc123)
+- **Core Answer:** Direct response with evidence [1](#I8NzFUKwrKX88107)
 - **Context:** Relevant supporting details
 
 Conclude with a brief synthesis that ties together the main insights into a clear overall understanding.

--- a/lib/utils/__tests__/citation.test.ts
+++ b/lib/utils/__tests__/citation.test.ts
@@ -125,6 +125,24 @@ describe('processCitations', () => {
     expect(result).toBe('Check  here')
   })
 
+  it('resolves citations where the model prepended a toolu_ prefix', () => {
+    // Models sometimes cite [1](#toolu_<id>) even though the search tool's
+    // call id has no prefix. The cited id should still resolve to the result.
+    const content = 'See [1](#toolu_toolCall1) and [2](#toolu_toolCall1)'
+    const result = processCitations(content, mockCitationMaps)
+
+    expect(result).toBe(
+      'See [google](https://www.google.com) and [github](https://docs.github.com)'
+    )
+  })
+
+  it('still prefers an exact toolCallId match over a normalized one', () => {
+    const content = 'See [1](#toolCall1)'
+    const result = processCitations(content, mockCitationMaps)
+
+    expect(result).toBe('See [google](https://www.google.com)')
+  })
+
   it('handles content with no citations', () => {
     const content = 'This is plain text without citations'
     const result = processCitations(content, mockCitationMaps)

--- a/lib/utils/citation.ts
+++ b/lib/utils/citation.ts
@@ -19,6 +19,16 @@ export function isCitationLabel(label: string): boolean {
 }
 
 /**
+ * Strip a known provider/router prefix from a toolCallId.
+ * Some models prepend their own prefix (e.g. `toolu_`) to the search tool's
+ * call id when citing, which breaks an exact-match lookup. Normalizing both the
+ * cited id and the citation map keys lets these citations still resolve.
+ */
+function stripToolCallPrefix(toolCallId: string): string {
+  return toolCallId.replace(/^(toolu_|call_|search-)/, '')
+}
+
+/**
  * Extract citation maps from a message's tool parts
  * Returns a map of toolCallId to citation map
  */
@@ -105,8 +115,20 @@ export function processCitations(
         return '' // Return empty string for invalid citation numbers
       }
 
-      // Get the citation map for this toolCallId
-      const citationMap = citationMaps[toolCallId]
+      // Get the citation map for this toolCallId. Prefer an exact match to
+      // avoid side effects, then fall back to prefix-normalized matching so
+      // ids the model prepended a prefix to (e.g. `toolu_<id>`) still resolve.
+      let citationMap = citationMaps[toolCallId]
+      if (!citationMap) {
+        const normalizedId = stripToolCallPrefix(toolCallId)
+        citationMap =
+          citationMaps[normalizedId] ??
+          citationMaps[
+            Object.keys(citationMaps).find(
+              key => stripToolCallPrefix(key) === normalizedId
+            ) ?? ''
+          ]
+      }
       if (!citationMap) {
         return '' // Return empty string if no citation map found
       }


### PR DESCRIPTION
## Summary

Some models cite search results as `[n](#toolu_<id>)` even though the search tool's call id has no prefix. The exact-match lookup in `processCitations` missed these and silently dropped the citation on render.

## Changes

- **`lib/utils/citation.ts`**: try an exact `toolCallId` match first, then fall back to prefix-normalized matching (`toolu_` / `call_` / `search-`) on both the cited id and the citation map keys. This also retroactively fixes already-persisted messages.
- **`lib/agents/prompts/search-mode-prompts.ts`**: drop the `toolu_` prefix from citation examples and instruct the model not to add any prefix to the `toolCallId`.
- **`lib/utils/__tests__/citation.test.ts`**: add coverage for prefixed-id resolution and confirm exact matches still take precedence.

## Verification

- `bun run test` ✅
- `bun lint` ✅
- `bun typecheck` ✅
- `bun format:check` (changed files) ✅
- `bun run build` ✅