### PR TITLE
fix: handle compound TLDs in citation domain display

### DIFF
--- a/lib/utils/__tests__/domain.test.ts
+++ b/lib/utils/__tests__/domain.test.ts
@@ -58,6 +58,15 @@ describe('displayUrlName', () => {
     expect(displayUrlName('https://techcrunch.com/article')).toBe('techcrunch')
   })
 
+  it('handles compound TLDs (ccTLD second-level domains)', () => {
+    expect(displayUrlName('https://www.saudiauto.com.sa')).toBe('saudiauto')
+    expect(displayUrlName('https://example.com.au')).toBe('example')
+    expect(displayUrlName('https://www.test.co.nz')).toBe('test')
+    expect(displayUrlName('https://website.co.jp')).toBe('website')
+    expect(displayUrlName('https://www.bbc.co.uk/news')).toBe('bbc')
+    expect(displayUrlName('https://news.example.co.uk')).toBe('example')
+  })
+
   it('handles stack overflow and similar domains', () => {
     expect(displayUrlName('https://stackoverflow.com/questions/123')).toBe(
       'stackoverflow'

--- a/lib/utils/domain.ts
+++ b/lib/utils/domain.ts
@@ -1,3 +1,27 @@
+// Second-level labels used in compound TLDs (e.g. "com" in "com.au", "co" in "co.uk").
+// When preceded by these and followed by a 2-letter country code, the last two
+// labels are treated as a single TLD unit.
+const COMPOUND_TLD_SECOND_LEVELS = new Set([
+  'com',
+  'co',
+  'org',
+  'net',
+  'gov',
+  'edu',
+  'ac',
+  'or',
+  'ne',
+  'go',
+  'gob',
+  'gouv',
+  'mil',
+  'sch',
+  'ltd',
+  'plc',
+  'me',
+  'nic'
+])
+
 /**
  * Extract display name from URL by removing TLD and www/subdomain
  * This is a pure client-safe utility function without Next.js dependencies
@@ -7,17 +31,32 @@
  * displayUrlName("https://www.google.com") // "google"
  * displayUrlName("https://docs.github.com") // "github"
  * displayUrlName("https://en.wikipedia.org") // "wikipedia"
+ * displayUrlName("https://www.saudiauto.com.sa") // "saudiauto"
+ * displayUrlName("https://example.co.uk") // "example"
  */
 export const displayUrlName = (url: string): string => {
   try {
     const hostname = new URL(url).hostname
     const parts = hostname.split('.')
 
-    // For hostnames like "www.google.com" or "docs.github.com"
-    // Extract the main domain name (second-to-last part)
-    // parts.length > 2: ["www", "google", "com"] -> "google"
-    // parts.length <= 2: ["localhost"] or ["example", "com"] -> "example"
-    return parts.length > 2 ? parts.slice(1, -1).join('.') : parts[0]
+    // Detect compound TLDs like "com.au" / "co.uk" so the country code and its
+    // second-level label are dropped together rather than leaving "saudiauto.com".
+    const lastPart = parts[parts.length - 1]
+    const secondToLast = parts[parts.length - 2]
+    const hasCompoundTld =
+      parts.length >= 3 &&
+      lastPart.length === 2 &&
+      COMPOUND_TLD_SECOND_LEVELS.has(secondToLast)
+    // Single-label hosts (e.g. "localhost") have no TLD to strip.
+    const tldLength = parts.length < 2 ? 0 : hasCompoundTld ? 2 : 1
+
+    // Labels remaining after stripping the TLD (subdomains + registrable name).
+    const nonTld = parts.slice(0, parts.length - tldLength)
+
+    // Drop the leading subdomain (www, docs, en, ...) when present.
+    // ["www", "google"] -> "google", ["sub", "domain", "example"] -> "domain.example"
+    // ["example"] -> "example", ["localhost"] -> "localhost"
+    return nonTld.length > 1 ? nonTld.slice(1).join('.') : nonTld[0]
   } catch {
     // Fallback for invalid URLs
     return 'source'


### PR DESCRIPTION
## What

Fix citation domain display for compound TLDs such as `.com.au`, `.com.sa`, and `.co.uk`.

`displayUrlName` (`lib/utils/domain.ts`) assumed the TLD was always a single trailing segment, so it mangled multi-part country-code TLDs:

| URL | Before | After |
|-----|--------|-------|
| `https://www.saudiauto.com.sa` | `saudiauto.com` | `saudiauto` |
| `https://example.com.au` | `com` | `example` |
| `https://www.test.co.nz` | `test.co` | `test` |
| `https://www.bbc.co.uk/news` | `bbc.co` | `bbc` |

## Why

The citation chip/popover showed broken domain names (e.g. the reported `hoge.com.au` case), which looks unpolished and erodes trust in sources.

## How

- Detect compound TLDs by checking for a known second-level label (`com`, `co`, `org`, ...) followed by a 2-letter country code, and treat the last two labels as one TLD unit.
- Refactored the slicing into "strip TLD → drop leading subdomain" so behavior stays consistent across single and compound TLDs.
- Single-label hosts (`localhost`) are preserved.

## Notes for reviewer

- This is a heuristic (no full Public Suffix List dependency) to keep the util pure and client-safe. The second-level label set covers the common cases; an exotic TLD outside the set would just fall back to the previous single-segment behavior.
- Added test cases for compound TLDs. All 11 tests in `domain.test.ts` pass.
