### PR TITLE
feat: add fastCRW search provider

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -74,6 +74,12 @@ TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]
 # Get your API key at: https://www.firecrawl.dev/app
 # FIRECRAWL_API_KEY=[YOUR_FIRECRAWL_API_KEY]
 
+# Option 4: fastCRW (Firecrawl-compatible web scraper; single binary, self-host or cloud)
+# Get your API key at: https://fastcrw.com
+# CRW_API_KEY=[YOUR_CRW_API_KEY]
+# Override the base URL to point at a self-hosted instance (default: https://fastcrw.com/api)
+# CRW_API_URL=http://localhost:3000
+
 # Brave Search (Optional - video/image support for general searches)
 # Get your API key at: https://brave.com/search/api/
 # BRAVE_SEARCH_API_KEY=[YOUR_BRAVE_SEARCH_API_KEY]
@@ -113,7 +119,7 @@ ANONYMOUS_USER_ID=anonymous-user
 # Search Configuration
 # -----------------------------------------------------------------------------
 # Select search provider (default: tavily)
-# SEARCH_API=tavily  # Options: tavily, searxng, exa, firecrawl
+# SEARCH_API=tavily  # Options: tavily, searxng, exa, firecrawl, crw
 
 # SearXNG (Self-hosted)
 # SEARXNG_API_URL=http://localhost:8080

--- a/lib/crw/client.ts
+++ b/lib/crw/client.ts
@@ -1,0 +1,107 @@
+import {
+  CrwImageSearchOptions,
+  CrwImageSearchResponse,
+  CrwSearchOptions,
+  CrwSearchResponse
+} from './types'
+
+// fastCRW is a Firecrawl-compatible web data engine (single binary; self-host
+// or cloud). It exposes the same request/response shapes as Firecrawl, so the
+// client mirrors the Firecrawl client and only swaps the base URL. The cloud
+// base URL is https://fastcrw.com/api; CRW_API_URL overrides it for self-host.
+const DEFAULT_BASE_URL = 'https://fastcrw.com/api'
+
+export class CrwClient {
+  private readonly apiKey: string
+  private readonly baseUrl: string
+
+  constructor(apiKey: string, baseUrl?: string) {
+    this.apiKey = apiKey
+    this.baseUrl = (
+      baseUrl ||
+      process.env.CRW_API_URL ||
+      DEFAULT_BASE_URL
+    ).replace(/\/$/, '')
+  }
+
+  async search(options: CrwSearchOptions): Promise<CrwSearchResponse> {
+    const body = JSON.stringify({
+      query: options.query,
+      sources: options.sources || ['web'],
+      limit: options.limit || 10,
+      location: options.location,
+      tbs: options.tbs,
+      scrapeOptions: {
+        formats: ['markdown'],
+        proxy: 'auto',
+        blockAds: true
+      }
+    })
+    const response = await fetch(`${this.baseUrl}/v1/search`, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body
+    })
+
+    return this.handleResponse<CrwSearchResponse>(response)
+  }
+
+  async searchImages(
+    options: CrwImageSearchOptions
+  ): Promise<CrwImageSearchResponse> {
+    const body = JSON.stringify({
+      query: options.query,
+      sources: ['images'],
+      limit: options.limit || 8
+    })
+
+    const response = await fetch(`${this.baseUrl}/v1/search`, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body
+    })
+
+    return this.handleResponse<CrwImageSearchResponse>(response)
+  }
+
+  async getImagesForQuery(
+    query: string,
+    maxResults: number = 8
+  ): Promise<{ url: string; description: string }[]> {
+    try {
+      const searchResponse = await this.searchImages({
+        query,
+        limit: maxResults
+      })
+
+      const data = searchResponse.data
+
+      if (!searchResponse.success || !data.images) return []
+
+      return data.images.map(image => ({
+        url: image.imageUrl,
+        description: image.title ?? ''
+      }))
+    } catch (error) {
+      console.error('CRW image search error:', error)
+      return []
+    }
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`
+    }
+  }
+
+  private async handleResponse<T>(response: Response): Promise<T> {
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(
+        `CRW status: ${response.status}, reason error: ${errorText}`
+      )
+    }
+    return response.json()
+  }
+}

--- a/lib/crw/index.ts
+++ b/lib/crw/index.ts
@@ -1,0 +1,2 @@
+export * from './client'
+export * from './types'

--- a/lib/crw/types.ts
+++ b/lib/crw/types.ts
@@ -1,0 +1,59 @@
+export type CrwSource = 'web' | 'news' | 'images'
+
+export type CrwSearchOptions = {
+  query: string
+  sources?: CrwSource[]
+  limit?: number
+  location?: string
+  tbs?: string
+}
+
+export type CrwImageSearchOptions = {
+  query: string
+  sources?: ['images']
+  limit?: number
+}
+
+export type CrwImageResult = {
+  title: string
+  imageUrl: string
+  imageWidth: number
+  imageHeight: number
+  url: string
+  position: number
+}
+
+export type CrwWebResult = {
+  url: string
+  title: string
+  description: string
+  markdown: string
+  position: number
+}
+
+export type CrwNewsResult = {
+  title: string
+  url: string
+  snippet: string
+  date: string
+  position: number
+}
+
+type CrwSearchResponseData = {
+  web?: CrwWebResult[]
+  news?: CrwNewsResult[]
+  images?: CrwImageResult[]
+}
+export type CrwSearchResponse = {
+  success: boolean
+  data: CrwSearchResponseData
+}
+
+type CrwImageSearchResponseData = {
+  images?: CrwImageResult[]
+}
+
+export type CrwImageSearchResponse = {
+  success: boolean
+  data: CrwImageSearchResponseData
+}

--- a/lib/tools/search/providers/__tests__/crw.test.ts
+++ b/lib/tools/search/providers/__tests__/crw.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CrwSearchProvider } from '@/lib/tools/search/providers/crw'
+
+describe('CrwSearchProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRW_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.CRW_API_KEY
+    delete process.env.CRW_API_URL
+  })
+
+  it('throws when CRW_API_KEY is not set', async () => {
+    delete process.env.CRW_API_KEY
+    const provider = new CrwSearchProvider()
+    await expect(provider.search('hello world')).rejects.toThrow(
+      'CRW_API_KEY is not set in the environment variables'
+    )
+  })
+
+  it('maps web/news results and images into SearchResults', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        success: true,
+        data: {
+          web: [
+            {
+              url: 'https://example.com/a',
+              title: 'Example A',
+              description: 'desc a',
+              markdown: 'markdown a',
+              position: 1
+            }
+          ],
+          news: [
+            {
+              url: 'https://example.com/b',
+              title: 'Example B',
+              snippet: 'snippet b',
+              date: '2024-01-01',
+              position: 1
+            }
+          ],
+          images: [
+            {
+              title: 'Image C',
+              imageUrl: 'https://example.com/c.png',
+              imageWidth: 100,
+              imageHeight: 100,
+              url: 'https://example.com/c',
+              position: 1
+            }
+          ]
+        }
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new CrwSearchProvider()
+    const result = await provider.search('example query', 5, 'advanced')
+
+    // Defaults to the cloud base URL and the /v1/search endpoint.
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://fastcrw.com/api/v1/search',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-key'
+        })
+      })
+    )
+
+    expect(result.query).toBe('example query')
+    expect(result.number_of_results).toBe(2)
+    expect(result.results).toEqual([
+      {
+        title: 'Example A',
+        url: 'https://example.com/a',
+        content: 'markdown a'
+      },
+      {
+        title: 'Example B',
+        url: 'https://example.com/b',
+        content: 'snippet b'
+      }
+    ])
+    expect(result.images).toEqual([
+      { url: 'https://example.com/c.png', description: 'Image C' }
+    ])
+  })
+
+  it('honors CRW_API_URL for self-hosted instances', async () => {
+    process.env.CRW_API_URL = 'http://localhost:3000/'
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ success: true, data: {} })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new CrwSearchProvider()
+    await provider.search('hello world')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/search',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('throws on non-ok responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'boom'
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new CrwSearchProvider()
+    await expect(provider.search('hello world')).rejects.toThrow(
+      'CRW status: 500, reason error: boom'
+    )
+  })
+})

--- a/lib/tools/search/providers/crw.ts
+++ b/lib/tools/search/providers/crw.ts
@@ -1,0 +1,71 @@
+import {
+  CrwClient,
+  CrwImageResult,
+  CrwNewsResult,
+  CrwWebResult
+} from '@/lib/crw'
+import { BaseSearchProvider } from '@/lib/tools/search/providers/base'
+import { SearchResults } from '@/lib/types'
+
+export class CrwSearchProvider extends BaseSearchProvider {
+  async search(
+    query: string,
+    maxResults: number = 10,
+    searchDepth: 'basic' | 'advanced' = 'basic',
+    includeDomains: string[] = [],
+    excludeDomains: string[] = []
+  ): Promise<SearchResults> {
+    const apiKey = process.env.CRW_API_KEY
+    this.validateApiKey(apiKey, 'CRW')
+
+    const crw = new CrwClient(apiKey)
+
+    const sources: ('web' | 'news' | 'images')[] = ['web']
+    if (searchDepth === 'advanced') {
+      sources.push('news')
+    }
+    sources.push('images')
+
+    const response = await crw.search({
+      query,
+      sources,
+      limit: maxResults
+      // Note: CRW Search API does not support includeDomains/excludeDomains yet...
+    })
+
+    const resources: (CrwWebResult | CrwNewsResult)[] = [
+      ...(response.data?.web || []),
+      ...(response.data?.news || [])
+    ]
+
+    const results = resources.map(resource => {
+      if ('markdown' in resource) {
+        const markdown = resource.markdown.slice(0, 1000)
+        return {
+          title: resource.title || '',
+          url: resource.url,
+          content: markdown || resource.description || ''
+        }
+      }
+
+      return {
+        title: resource.title || '',
+        url: resource.url,
+        content: resource.snippet || ''
+      }
+    })
+
+    const images =
+      response.data?.images?.map((img: CrwImageResult) => ({
+        url: img.imageUrl,
+        description: img.title || ''
+      })) || []
+
+    return {
+      results,
+      query,
+      images,
+      number_of_results: results.length
+    }
+  }
+}

--- a/lib/tools/search/providers/index.ts
+++ b/lib/tools/search/providers/index.ts
@@ -1,5 +1,6 @@
 import { SearchProvider } from './base'
 import { BraveSearchProvider } from './brave'
+import { CrwSearchProvider } from './crw'
 import { ExaSearchProvider } from './exa'
 import { FirecrawlSearchProvider } from './firecrawl'
 import { SearXNGSearchProvider } from './searxng'
@@ -10,6 +11,7 @@ export type SearchProviderType =
   | 'exa'
   | 'searxng'
   | 'firecrawl'
+  | 'crw'
   | 'brave'
 export const DEFAULT_PROVIDER: SearchProviderType = 'tavily'
 
@@ -30,6 +32,8 @@ export function createSearchProvider(
       return new BraveSearchProvider()
     case 'firecrawl':
       return new FirecrawlSearchProvider()
+    case 'crw':
+      return new CrwSearchProvider()
     default:
       // Default to TavilySearchProvider if an unknown provider is specified
       return new TavilySearchProvider()
@@ -37,6 +41,7 @@ export function createSearchProvider(
 }
 
 export { BraveSearchProvider } from './brave'
+export type { CrwSearchProvider } from './crw'
 export type { ExaSearchProvider } from './exa'
 export type { FirecrawlSearchProvider } from './firecrawl'
 export { SearXNGSearchProvider } from './searxng'


### PR DESCRIPTION
## What
Adds **fastCRW** as a search provider, alongside Tavily / SearXNG / Exa / Firecrawl. Selectable via `SEARCH_API=crw`.

## Why
[fastCRW](https://fastcrw.com) is a Firecrawl-API-compatible web engine in a **single ~8MB binary** — self-host free or managed cloud. Flat pricing (1 credit = 1 page; no 4x stealth surcharge, no billed-on-failure), free anti-bot stealth. For anyone on the Firecrawl provider it's a one-setting swap.

## Changes (additive only)
- `lib/crw/`: client + types (mirrors the sibling provider client).
- `lib/tools/search/providers/crw.ts` + registered in `providers/index.ts`.
- `.env.local.example`: `crw` added to `SEARCH_API`.
- `lib/tools/search/providers/__tests__/crw.test.ts`.

## Config
`SEARCH_API=crw`, `CRW_API_KEY` from https://fastcrw.com/dashboard (free tier); base URL overridable for self-host.

Happy to adjust — I maintain the integration and can provide free credits.
