### PR TITLE
fix: card pasted content by size only, not line count

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -57,10 +57,10 @@ import { UploadedFileList } from './uploaded-file-list'
 
 // Constants for timing delays
 const INPUT_UPDATE_DELAY_MS = 10 // Delay to ensure input value is updated before form submission
-// Only paste events at/over this size (or line count) become a content card,
-// so short/normal pastes stay inline.
+// Only paste events at/over this size become a content card, so short/normal
+// pastes stay inline. Sized by chars, not lines — a line-count trigger carded
+// short, many-line pastes that read fine inline and were mostly reverted.
 const PASTE_CARD_MIN_CHARS = 400
-const PASTE_CARD_MIN_LINES = 6
 // A paste that is a single bare URL becomes a lightweight favicon chip.
 // L0 prototype: client-only, no fetch — the URL rides into the query at send
 // time so the existing fetch tool picks it up.
@@ -498,16 +498,12 @@ export function ChatPanel({
                 captureClient('url_card_created')
                 return
               }
-              const lineCount = text.split('\n').length
-              if (
-                text.length >= PASTE_CARD_MIN_CHARS ||
-                lineCount >= PASTE_CARD_MIN_LINES
-              ) {
+              if (text.length >= PASTE_CARD_MIN_CHARS) {
                 e.preventDefault()
                 setContentCards(prev => [...prev, text])
                 captureClient('content_card_created', {
                   chars: text.length,
-                  lines: lineCount
+                  lines: text.split('\n').length
                 })
               }
             }}


### PR DESCRIPTION
## What

Drop the line-count trigger for turning a paste into a content card. A paste now becomes a card only when it reaches the size threshold (`PASTE_CARD_MIN_CHARS = 400`); the `>= 6 lines` condition is removed.

## Why

The line-count condition carded short, many-line pastes — snippets, lists, short logs — regardless of their total length. These read fine inline, and users frequently reverted them back to inline text via the card's expand/escape hatch. Sizing the card by character count alone matches the feature's intent (lifting large pasted work artifacts out of the composer) and stops the over-eager carding of small pastes.

## Changes

- Remove `PASTE_CARD_MIN_LINES` and the line-count branch in the paste handler (`components/chat-panel.tsx`).
- Keep emitting the line count on the `content_card_created` analytics event (computed inline) so adoption tracking is unaffected.

## Test plan

- `bun typecheck` ✅
- `bun lint` ✅
- `bun run test chat-panel` ✅
- Manual: pasting a short 6+ line snippet stays inline; pasting 400+ chars still becomes a card.