### PR TITLE
Remove note save button shown event

### DIFF
--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import Link from 'next/link'
 
 import { UseChatHelpers } from '@ai-sdk/react'
@@ -80,19 +80,6 @@ export function MessageActions({
   const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false)
   const isLoading = status === 'submitted' || status === 'streaming'
   const showSaveButton = libraryAvailable && (!isGuest || isCloudDeployment)
-  const saveButtonShownRef = useRef(false)
-
-  useEffect(() => {
-    if (!visible || !showSaveButton || saveButtonShownRef.current) return
-
-    saveButtonShownRef.current = true
-    captureClient('note_save_button_shown', {
-      source: 'message_action',
-      chatId,
-      isGuest,
-      isCloudDeployment
-    })
-  }, [chatId, isCloudDeployment, isGuest, showSaveButton, visible])
 
   // Keep the element mounted during loading to preserve layout; otherwise skip rendering.
   if (!visible && !isLoading) {


### PR DESCRIPTION
## Summary

Removes the `note_save_button_shown` analytics event because it is tied to message rendering and creates noisy exposure logs.

## Validation

- `bun typecheck`
- `bun lint`
- `bun run test components/__tests__/render-message.test.tsx`
- Targeted Prettier check for `components/message-actions.tsx`