### PR TITLE
Retire related_q_style_v2 A/B; render follow-ups as inline link

### DIFF
--- a/lib/render/components/button.tsx
+++ b/lib/render/components/button.tsx
@@ -1,20 +1,12 @@
 'use client'
 
-import { useSyncExternalStore } from 'react'
-
 import type { ComponentFn } from '@json-render/react'
 
-import {
-  isFeatureEnabled,
-  subscribeFeatureFlags
-} from '@/lib/analytics/posthog-client'
 import { cn } from '@/lib/utils'
 
 import { Button as UIButton } from '@/components/ui/button'
 
 import { type CatalogType, iconMap } from './shared'
-
-const STYLE_FLAG = 'related_q_style_v2'
 
 /**
  * Generic button spec component. Renders the project's shadcn Button and
@@ -26,33 +18,18 @@ export const Button: ComponentFn<CatalogType, 'Button'> = ({ props, on }) => {
   const Icon = icon ? iconMap[icon] : null
   const handle = on('press')
 
-  // Follow-up suggestions render as link buttons. A/B their style via the
-  // `related_q_style_v2` flag: control = inline muted link, test = pill/chip.
-  // useSyncExternalStore keeps SSR on the control path (no hydration mismatch)
-  // and re-renders once flags load.
-  const isFollowup = variant === 'link'
-  const flagOn = useSyncExternalStore(
-    subscribeFeatureFlags,
-    () => isFeatureEnabled(STYLE_FLAG),
-    () => false
-  )
-  const chip = isFollowup && flagOn
-
-  // Control link: muted color, left-aligned, wrappable text, zero padding.
+  // Follow-up suggestions render as inline muted links: left-aligned,
+  // wrappable text, zero padding.
   const linkOverride =
-    isFollowup && !chip
+    variant === 'link'
       ? 'h-auto w-fit justify-start whitespace-normal text-left px-0 py-0.5 font-semibold text-accent-foreground/50 hover:text-accent-foreground/70'
       : ''
-  // Test chip: bordered pill with higher contrast for a stronger tap affordance.
-  const chipOverride = chip
-    ? 'h-auto w-fit whitespace-normal rounded-full border px-3 py-1.5 text-left text-sm font-medium text-accent-foreground/80 hover:bg-muted hover:text-accent-foreground'
-    : ''
 
   return (
     <UIButton
-      variant={chip ? 'outline' : variant}
+      variant={variant}
       onClick={handle.emit}
-      className={cn('gap-2', linkOverride, chipOverride)}
+      className={cn('gap-2', linkOverride)}
     >
       {Icon && <Icon className="size-4 shrink-0" />}
       {text}


### PR DESCRIPTION
## Summary

The `related_q_style_v2` A/B (control = inline muted link / test = pill/chip)
concluded with the **link control outperforming the chip variant** across the
experiment window. This graduates the experiment: drop the flag-gated chip
branch in the spec `Button` component and render follow-up suggestions as the
inline muted link unconditionally.

## Changes

- `lib/render/components/button.tsx`: remove the `related_q_style_v2` flag
  plumbing (`useSyncExternalStore` / `isFeatureEnabled` / `subscribeFeatureFlags`)
  and the chip styling branch; keep the winning inline-link styling.

## Notes

- The related-questions **prompt improvement** from #878 is unrelated and is
  left untouched (this is not a revert of #878).
- The PostHog feature flag `related_q_style_v2` can now be archived.
- `isFeatureEnabled` / `subscribeFeatureFlags` in `lib/analytics/posthog-client.ts`
  are intentionally kept as general-purpose feature-flag helpers.

## Checks

- `bun lint` ✅  ·  `bun typecheck` ✅  ·  `bun format:check` (button.tsx) ✅
- `bun run test` ✅ (508 passed / 2 skipped)