### PR TITLE
Use signed URLs for uploaded files

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -5,9 +5,9 @@ import { PutObjectCommand } from '@aws-sdk/client-s3'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import {
   getR2Client,
+  getSignedFileUrl,
   isObjectStorageConfigured,
-  R2_BUCKET_NAME,
-  R2_PUBLIC_URL
+  R2_BUCKET_NAME
 } from '@/lib/storage/r2-client'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
         {
           error: 'File upload storage is not configured',
           message:
-            'Set R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_PUBLIC_URL, and either R2_ACCOUNT_ID or S3_ENDPOINT.'
+            'Set R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and either R2_ACCOUNT_ID or S3_ENDPOINT.'
         },
         { status: 400 }
       )
@@ -92,11 +92,12 @@ async function uploadFileToR2(file: File, userId: string, chatId: string) {
       })
     )
 
-    const publicUrl = `${R2_PUBLIC_URL.replace(/\/+$/, '')}/${filePath}`
+    const signedUrl = await getSignedFileUrl(filePath)
 
     return {
       filename: file.name,
-      url: publicUrl,
+      key: filePath,
+      url: signedUrl,
       mediaType: file.type,
       type: 'file'
     }

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,8 @@
         "@ai-sdk/openai": "^3.0.63",
         "@ai-sdk/openai-compatible": "^2.0.47",
         "@ai-sdk/react": "^3.0.182",
-        "@aws-sdk/client-s3": "^3.850.0",
+        "@aws-sdk/client-s3": "3.859.0",
+        "@aws-sdk/s3-request-presigner": "3.859.0",
         "@json-render/core": "^0.16.0",
         "@json-render/react": "^0.16.0",
         "@opentelemetry/api-logs": "0.57.2",
@@ -180,6 +181,8 @@
 
     "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.840.0", "", { "dependencies": { "@aws-sdk/types": "3.840.0", "@smithy/node-config-provider": "^4.1.3", "@smithy/types": "^4.3.1", "@smithy/util-config-provider": "^4.0.0", "@smithy/util-middleware": "^4.0.4", "tslib": "^2.6.2" } }, "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA=="],
 
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.859.0", "", { "dependencies": { "@aws-sdk/signature-v4-multi-region": "3.858.0", "@aws-sdk/types": "3.840.0", "@aws-sdk/util-format-url": "3.840.0", "@smithy/middleware-endpoint": "^4.1.17", "@smithy/protocol-http": "^5.1.2", "@smithy/smithy-client": "^4.4.9", "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-YpMv8I0h27ua74j+hVmsRQn+mDz/8Gb75i8KED3rYgrpoeob9xKlx4JdDaMVHHdFa8entoV7moI8uRrQxPD8Zw=="],
+
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.858.0", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "3.858.0", "@aws-sdk/types": "3.840.0", "@smithy/protocol-http": "^5.1.2", "@smithy/signature-v4": "^5.1.2", "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-WtQvCtIz8KzTqd/OhjziWb5nAFDEZ0pE1KJsWBZ0j6Ngvp17ORSY37U96buU0SlNNflloGT7ZIlDkdFh73YktA=="],
 
     "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.859.0", "", { "dependencies": { "@aws-sdk/core": "3.858.0", "@aws-sdk/nested-clients": "3.858.0", "@aws-sdk/types": "3.840.0", "@smithy/property-provider": "^4.0.4", "@smithy/shared-ini-file-loader": "^4.0.4", "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-6P2wlvm9KBWOvRNn0Pt8RntnXg8fzOb5kEShvWsOsAocZeqKNaYbihum5/Onq1ZPoVtkdb++8eWDocDnM4k85Q=="],
@@ -189,6 +192,8 @@
     "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.804.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ=="],
 
     "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.848.0", "", { "dependencies": { "@aws-sdk/types": "3.840.0", "@smithy/types": "^4.3.1", "@smithy/url-parser": "^4.0.4", "@smithy/util-endpoints": "^3.0.6", "tslib": "^2.6.2" } }, "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww=="],
+
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.840.0", "", { "dependencies": { "@aws-sdk/types": "3.840.0", "@smithy/querystring-builder": "^4.0.4", "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-VB1PWyI1TQPiPvg4w7tgUGGQER1xxXPNUqfh3baxUSFi1Oh8wHrDnFywkxLm3NMmgDmnLnSZ5Q326qAoyqKLSg=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.804.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A=="],
 
@@ -2247,6 +2252,10 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-sdk/s3-request-presigner/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/util-format-url/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
 
     "@babel/core/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 

--- a/components/attachment-preview.tsx
+++ b/components/attachment-preview.tsx
@@ -4,10 +4,10 @@ import React from 'react'
 
 interface Attachment {
   name: string | undefined
-  url: string
+  url?: string
   contentType: string
 }
-;[]
+
 interface AttachmentPreviewProps {
   attachments: Attachment[]
 }
@@ -22,19 +22,24 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
       {attachments.map((att, index) => {
         const isImage = att.contentType.startsWith('image/')
         const isPdf = att.contentType === 'application/pdf'
+        const url = att.url
 
         return (
           <div key={index} className="max-w-xs break-words">
-            {isImage ? (
+            {!url ? (
+              <div className="rounded-md border px-3 py-2 text-xs text-muted-foreground">
+                {att.name ?? 'File'} unavailable
+              </div>
+            ) : isImage ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img
-                src={att.url}
+                src={url}
                 alt={att.name}
                 className="rounded-md border max-h-16 object-contain"
               />
             ) : isPdf ? (
               <a
-                href={att.url}
+                href={url}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 underline"
@@ -43,7 +48,7 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
               </a>
             ) : (
               <a
-                href={att.url}
+                href={url}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 underline"

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -315,7 +315,9 @@ export function ChatPanel({
                 type: 'file',
                 url: f.url!,
                 filename: f.name!,
-                mediaType: f.file.type
+                mediaType:
+                  f.mediaType ?? f.file?.type ?? 'application/octet-stream',
+                key: f.key
               })),
               ...(input.trim() ? [{ type: 'text', text: input }] : [])
             ]
@@ -618,7 +620,7 @@ export function ChatPanel({
                     await Promise.all(
                       newFiles.map(async uf => {
                         const formData = new FormData()
-                        formData.append('file', uf.file)
+                        formData.append('file', uf.file!)
                         formData.append('chatId', chatId)
                         try {
                           const res = await fetch('/api/upload', {
@@ -639,13 +641,16 @@ export function ChatPanel({
                                     status: 'uploaded',
                                     url: uploaded.url,
                                     name: uploaded.filename,
-                                    key: uploaded.key
+                                    key: uploaded.key,
+                                    mediaType: uploaded.mediaType
                                   }
                                 : f
                             )
                           )
                         } catch (e) {
-                          toast.error(`Failed to upload ${uf.file.name}`)
+                          toast.error(
+                            `Failed to upload ${uf.file?.name ?? 'file'}`
+                          )
                           setUploadedFiles(prev =>
                             prev.map(f =>
                               f.file === uf.file ? { ...f, status: 'error' } : f

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -489,7 +489,8 @@ export function Chat({
           type: 'file',
           url: f.url!,
           filename: f.name!,
-          mediaType: f.file.type
+          mediaType: f.mediaType ?? f.file?.type ?? 'application/octet-stream',
+          key: f.key
         })
       })
 

--- a/components/uploaded-file-list.tsx
+++ b/components/uploaded-file-list.tsx
@@ -19,47 +19,60 @@ export const UploadedFileList = React.memo(function UploadedFileList({
   return (
     <div className="w-full flex p-4 max-w-3xl mx-auto">
       <div className="flex gap-6 overflow-x-auto">
-        {files.map((it, index) => (
-          <div
-            key={index}
-            className="relative w-20 shrink-0 flex flex-col items-center"
-          >
-            <div className="relative w-20 aspect-7/5 rounded-lg overflow-hidden shadow-sm border bg-muted/20 dark:bg-muted/10">
-              {it.file.type.startsWith('image/') ? (
-                <Image
-                  src={URL.createObjectURL(it.file)}
-                  alt={`file-${index}`}
-                  fill
-                  className="object-cover"
-                  sizes="112px"
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-sm font-semibold bg-gray-300 dark:bg-gray-700">
-                  {it.file.name.split('.').pop()?.toUpperCase()}
-                </div>
-              )}
+        {files.map((it, index) => {
+          const mediaType = it.mediaType ?? it.file?.type ?? ''
+          const filename = it.name ?? it.file?.name ?? 'file'
+          const isImage = mediaType.startsWith('image/')
 
-              {/* Spinner overlay while uploading */}
-              {it.status === 'uploading' && (
-                <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-10">
-                  <Loader2 className="animate-spin text-white" size={20} />
-                </div>
-              )}
+          return (
+            <div
+              key={index}
+              className="relative w-20 shrink-0 flex flex-col items-center"
+            >
+              <div className="relative w-20 aspect-7/5 rounded-lg overflow-hidden shadow-sm border bg-muted/20 dark:bg-muted/10">
+                {isImage && it.file ? (
+                  <Image
+                    src={URL.createObjectURL(it.file)}
+                    alt={`file-${index}`}
+                    fill
+                    className="object-cover"
+                    sizes="112px"
+                  />
+                ) : isImage && it.url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={it.url}
+                    alt={`file-${index}`}
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-sm font-semibold bg-gray-300 dark:bg-gray-700">
+                    {filename.split('.').pop()?.toUpperCase()}
+                  </div>
+                )}
 
-              <button
-                type="button"
-                onClick={() => onRemove(index)}
-                className="absolute top-1 right-1 bg-black/40 hover:bg-red-600 text-white rounded-full p-1 z-20"
-              >
-                <X size={12} />
-              </button>
+                {/* Spinner overlay while uploading */}
+                {it.status === 'uploading' && (
+                  <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-10">
+                    <Loader2 className="animate-spin text-white" size={20} />
+                  </div>
+                )}
+
+                <button
+                  type="button"
+                  onClick={() => onRemove(index)}
+                  className="absolute top-1 right-1 bg-black/40 hover:bg-red-600 text-white rounded-full p-1 z-20"
+                >
+                  <X size={12} />
+                </button>
+              </div>
+
+              <div className="mt-2 text-xs text-center text-foreground truncate w-full">
+                {filename}
+              </div>
             </div>
-
-            <div className="mt-2 text-xs text-center text-foreground truncate w-full">
-              {it.name || it.file.name}
-            </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -276,7 +276,8 @@ R2_SECRET_ACCESS_KEY=[YOUR_SECRET_KEY]
 R2_ACCOUNT_ID=[YOUR_ACCOUNT_ID]  # For Cloudflare R2
 # S3_ENDPOINT=[YOUR_S3_ENDPOINT]  # Optional: generic S3-compatible endpoint
 R2_BUCKET_NAME=[YOUR_BUCKET_NAME]
-R2_PUBLIC_URL=[YOUR_PUBLIC_BASE_URL]
+# Optional: signed GET URL lifetime in seconds (default: 3600)
+R2_SIGNED_URL_EXPIRES_SECONDS=3600
 ```
 
 If storage variables are not configured, `/api/upload` returns `400` and uploads are disabled.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -73,8 +73,9 @@ File upload requires externally reachable object storage. Docker Compose does no
 
 Required environment variables:
 
-- `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_PUBLIC_URL`
+- `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`
 - One of: `R2_ACCOUNT_ID` (Cloudflare R2) or `S3_ENDPOINT` (generic S3-compatible)
+- `R2_BUCKET_NAME`
 
 If these are not set, upload is disabled.
 

--- a/drizzle/0013_library_files.sql
+++ b/drizzle/0013_library_files.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS "files" (
+  "id" varchar(191) PRIMARY KEY NOT NULL,
+  "user_id" varchar(255) NOT NULL,
+  "chat_id" varchar(191),
+  "filename" text NOT NULL,
+  "url" text NOT NULL,
+  "media_type" varchar(256) NOT NULL,
+  "size" integer,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "files_chat_id_chats_id_fk"
+    FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id")
+    ON DELETE SET NULL ON UPDATE NO ACTION
+);
+
+CREATE INDEX IF NOT EXISTS "files_user_id_idx" ON "files" USING btree ("user_id");
+CREATE INDEX IF NOT EXISTS "files_user_id_updated_at_idx" ON "files" USING btree ("user_id", "updated_at" DESC);
+CREATE INDEX IF NOT EXISTS "files_chat_id_idx" ON "files" USING btree ("chat_id");
+CREATE INDEX IF NOT EXISTS "files_media_type_idx" ON "files" USING btree ("media_type");
+
+ALTER TABLE "files" ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'files' AND policyname = 'users_manage_own_files'
+  ) THEN
+    CREATE POLICY "users_manage_own_files" ON "files"
+      AS PERMISSIVE
+      FOR ALL
+      TO public
+      USING (user_id = current_setting('app.current_user_id', true))
+      WITH CHECK (user_id = current_setting('app.current_user_id', true));
+  END IF;
+END $$;

--- a/drizzle/0014_private_file_object_keys.sql
+++ b/drizzle/0014_private_file_object_keys.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "parts" ADD COLUMN IF NOT EXISTS "file_key" text;
+ALTER TABLE "files" ADD COLUMN IF NOT EXISTS "object_key" text;
+
+CREATE INDEX IF NOT EXISTS "files_object_key_idx" ON "files" USING btree ("object_key");
+
+ALTER TABLE "parts" DROP CONSTRAINT IF EXISTS "file_fields_required";
+ALTER TABLE "parts" ADD CONSTRAINT "file_fields_required"
+  CHECK (
+    (type != 'file')
+    OR (
+      file_media_type IS NOT NULL
+      AND file_filename IS NOT NULL
+      AND (file_key IS NOT NULL OR file_url IS NOT NULL)
+    )
+  );

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,20 @@
       "when": 1781635200000,
       "tag": "0012_knowledge_library_notes",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1782230400000,
+      "tag": "0013_library_files",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1782345600000,
+      "tag": "0014_private_file_object_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/relations.ts
+++ b/drizzle/relations.ts
@@ -1,6 +1,6 @@
 import { relations } from 'drizzle-orm/relations'
 
-import { chats, messages, notes, parts } from './schema'
+import { chats, files, messages, notes, parts } from './schema'
 
 export const messagesRelations = relations(messages, ({ one, many }) => ({
   chat: one(chats, {
@@ -12,7 +12,8 @@ export const messagesRelations = relations(messages, ({ one, many }) => ({
 
 export const chatsRelations = relations(chats, ({ many }) => ({
   messages: many(messages),
-  notes: many(notes)
+  notes: many(notes),
+  files: many(files)
 }))
 
 export const partsRelations = relations(parts, ({ one }) => ({
@@ -25,6 +26,13 @@ export const partsRelations = relations(parts, ({ one }) => ({
 export const notesRelations = relations(notes, ({ one }) => ({
   chat: one(chats, {
     fields: [notes.chatId],
+    references: [chats.id]
+  })
+}))
+
+export const filesRelations = relations(files, ({ one }) => ({
+  chat: one(chats, {
+    fields: [files.chatId],
     references: [chats.id]
   })
 }))

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -112,6 +112,7 @@ export const parts = pgTable(
     fileMediaType: varchar('file_media_type', { length: 256 }),
     fileFilename: varchar('file_filename', { length: 1024 }),
     fileUrl: text('file_url'),
+    fileKey: text('file_key'),
     sourceUrlSourceId: varchar('source_url_source_id', { length: 256 }),
     sourceUrlUrl: text('source_url_url'),
     sourceUrlTitle: text('source_url_title'),
@@ -191,7 +192,7 @@ export const parts = pgTable(
     ),
     check(
       'file_fields_required',
-      sql`((type)::text <> 'file'::text) OR ((file_media_type IS NOT NULL) AND (file_filename IS NOT NULL) AND (file_url IS NOT NULL))`
+      sql`((type)::text <> 'file'::text) OR ((file_media_type IS NOT NULL) AND (file_filename IS NOT NULL) AND ((file_key IS NOT NULL) OR (file_url IS NOT NULL)))`
     ),
     check(
       'tool_state_valid',
@@ -244,6 +245,61 @@ export const notes = pgTable(
       name: 'notes_chat_id_chats_id_fk'
     }).onDelete('set null'),
     pgPolicy('users_manage_own_notes', {
+      as: 'permissive',
+      for: 'all',
+      to: ['public'],
+      using: sql`user_id = current_setting('app.current_user_id', true)`,
+      withCheck: sql`user_id = current_setting('app.current_user_id', true)`
+    })
+  ]
+)
+
+export const files = pgTable(
+  'files',
+  {
+    id: varchar({ length: 191 }).primaryKey().notNull(),
+    userId: varchar('user_id', { length: 255 }).notNull(),
+    chatId: varchar('chat_id', { length: 191 }),
+    filename: text().notNull(),
+    url: text().notNull(),
+    objectKey: text('object_key'),
+    mediaType: varchar('media_type', { length: 256 }).notNull(),
+    size: integer(),
+    createdAt: timestamp('created_at', { mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'string' })
+      .defaultNow()
+      .notNull()
+  },
+  table => [
+    index('files_chat_id_idx').using(
+      'btree',
+      table.chatId.asc().nullsLast().op('text_ops')
+    ),
+    index('files_media_type_idx').using(
+      'btree',
+      table.mediaType.asc().nullsLast().op('text_ops')
+    ),
+    index('files_object_key_idx').using(
+      'btree',
+      table.objectKey.asc().nullsLast().op('text_ops')
+    ),
+    index('files_user_id_idx').using(
+      'btree',
+      table.userId.asc().nullsLast().op('text_ops')
+    ),
+    index('files_user_id_updated_at_idx').using(
+      'btree',
+      table.userId.asc().nullsLast().op('text_ops'),
+      table.updatedAt.desc().nullsLast().op('timestamp_ops')
+    ),
+    foreignKey({
+      columns: [table.chatId],
+      foreignColumns: [chats.id],
+      name: 'files_chat_id_chats_id_fk'
+    }).onDelete('set null'),
+    pgPolicy('users_manage_own_files', {
       as: 'permissive',
       for: 'all',
       to: ['public'],

--- a/hooks/use-file-dropzone.ts
+++ b/hooks/use-file-dropzone.ts
@@ -65,7 +65,7 @@ export function useFileDropzone({
       await Promise.all(
         initialFiles.map(async uf => {
           const formData = new FormData()
-          formData.append('file', uf.file)
+          formData.append('file', uf.file!)
           formData.append('chatId', chatId)
 
           try {
@@ -85,14 +85,15 @@ export function useFileDropzone({
                       ...f,
                       status: 'uploaded',
                       url: uploaded.url,
-                      name: uploaded.name,
-                      key: uploaded.key
+                      name: uploaded.filename,
+                      key: uploaded.key,
+                      mediaType: uploaded.mediaType
                     }
                   : f
               )
             )
           } catch (err) {
-            toast.error(`Failed to upload ${uf.file.name}`)
+            toast.error(`Failed to upload ${uf.file?.name ?? 'file'}`)
             setUploadedFiles(prev =>
               prev.map(f =>
                 f.file === uf.file ? { ...f, status: 'error' } : f

--- a/lib/actions/__tests__/account.test.ts
+++ b/lib/actions/__tests__/account.test.ts
@@ -29,6 +29,9 @@ describe('Account Actions', () => {
     vi.mocked(getCurrentUser).mockResolvedValue(user as any)
     vi.mocked(dbActions.deleteUserChats).mockResolvedValue({ success: true })
     vi.mocked(dbActions.deleteUserNotes).mockResolvedValue({ success: true })
+    vi.mocked(dbActions.deleteUserLibraryFiles).mockResolvedValue({
+      success: true
+    })
     vi.mocked(dbActions.anonymizeUserFeedback).mockResolvedValue({
       success: true
     })
@@ -93,6 +96,7 @@ describe('Account Actions', () => {
     expect(result).toEqual({ success: true })
     expect(dbActions.deleteUserChats).toHaveBeenCalledWith(user.id)
     expect(dbActions.deleteUserNotes).toHaveBeenCalledWith(user.id)
+    expect(dbActions.deleteUserLibraryFiles).toHaveBeenCalledWith(user.id)
     expect(dbActions.anonymizeUserFeedback).toHaveBeenCalledWith(user.id)
     expect(deleteUserObjects).toHaveBeenCalledWith(user.id)
     expect(deleteUser).toHaveBeenCalledWith(user.id)
@@ -151,6 +155,23 @@ describe('Account Actions', () => {
     expect(trackAccountDeleted).not.toHaveBeenCalled()
   })
 
+  it('stops before storage and auth deletion when library file deletion fails', async () => {
+    vi.mocked(dbActions.deleteUserLibraryFiles).mockResolvedValue({
+      success: false,
+      error: 'Failed to delete user files'
+    })
+
+    const result = await deleteAccount()
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to delete user files'
+    })
+    expect(deleteUserObjects).not.toHaveBeenCalled()
+    expect(deleteUser).not.toHaveBeenCalled()
+    expect(trackAccountDeleted).not.toHaveBeenCalled()
+  })
+
   it('stops before auth deletion when uploaded file deletion fails', async () => {
     vi.mocked(deleteUserObjects).mockRejectedValue(new Error('Storage error'))
 
@@ -162,6 +183,7 @@ describe('Account Actions', () => {
     })
     expect(dbActions.deleteUserChats).toHaveBeenCalledWith(user.id)
     expect(dbActions.deleteUserNotes).toHaveBeenCalledWith(user.id)
+    expect(dbActions.deleteUserLibraryFiles).toHaveBeenCalledWith(user.id)
     expect(deleteUser).not.toHaveBeenCalled()
     expect(trackAccountDeleted).not.toHaveBeenCalled()
   })

--- a/lib/actions/account.ts
+++ b/lib/actions/account.ts
@@ -60,6 +60,14 @@ export async function deleteAccount(): Promise<{
       }
     }
 
+    const deleteFilesResult = await dbActions.deleteUserLibraryFiles(user.id)
+    if (!deleteFilesResult.success) {
+      return {
+        success: false,
+        error: deleteFilesResult.error ?? 'Failed to delete account data'
+      }
+    }
+
     const anonymizeFeedbackResult = await dbActions.anonymizeUserFeedback(
       user.id
     )

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -7,6 +7,7 @@ import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import type { Chat, Message } from '@/lib/db/schema'
 import { generateId } from '@/lib/db/schema'
+import { signFilePartUrlsInMessages } from '@/lib/storage/r2-client'
 import type { UIMessage } from '@/lib/types/ai'
 import { getTextFromParts } from '@/lib/utils/message-utils'
 
@@ -65,7 +66,13 @@ export async function loadChat(
   requestingUserId?: string
 ): Promise<(Chat & { messages: UIMessage[] }) | null> {
   // Use cached version for individual chat loading
-  return getCachedChatWithMessages(chatId, requestingUserId)
+  const chat = await getCachedChatWithMessages(chatId, requestingUserId)
+  if (!chat) return null
+
+  return {
+    ...chat,
+    messages: await signFilePartUrlsInMessages(chat.messages)
+  }
 }
 
 /**

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -13,7 +13,15 @@ import { perfLog, perfTime } from '@/lib/utils/perf-logging'
 import { incrementDbOperationCount } from '@/lib/utils/perf-tracking'
 
 import type { Chat, Message, NewNote, Note } from './schema'
-import { chats, feedback, generateId, messages, notes, parts } from './schema'
+import {
+  chats,
+  feedback,
+  generateId,
+  libraryFiles,
+  messages,
+  notes,
+  parts
+} from './schema'
 import { withOptionalRLS, withRLS } from './with-rls'
 import { db } from '.'
 
@@ -477,6 +485,20 @@ export async function deleteUserNotes(
   } catch (error) {
     console.error('Error deleting user notes:', error)
     return { success: false, error: 'Failed to delete user notes' }
+  }
+}
+
+export async function deleteUserLibraryFiles(
+  userId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    return withRLS(userId, async tx => {
+      await tx.delete(libraryFiles).where(eq(libraryFiles.userId, userId))
+      return { success: true }
+    })
+  } catch (error) {
+    console.error('Error deleting user library files:', error)
+    return { success: false, error: 'Failed to delete user files' }
   }
 }
 

--- a/lib/db/relations.ts
+++ b/lib/db/relations.ts
@@ -1,10 +1,11 @@
 import { relations } from 'drizzle-orm'
 
-import { chats, messages, notes, parts } from './schema'
+import { chats, libraryFiles, messages, notes, parts } from './schema'
 
 export const chatsRelations = relations(chats, ({ many }) => ({
   messages: many(messages),
-  notes: many(notes)
+  notes: many(notes),
+  files: many(libraryFiles)
 }))
 
 export const messagesRelations = relations(messages, ({ one, many }) => ({
@@ -25,6 +26,13 @@ export const partsRelations = relations(parts, ({ one }) => ({
 export const notesRelations = relations(notes, ({ one }) => ({
   chat: one(chats, {
     fields: [notes.chatId],
+    references: [chats.id]
+  })
+}))
+
+export const libraryFilesRelations = relations(libraryFiles, ({ one }) => ({
+  chat: one(chats, {
+    fields: [libraryFiles.chatId],
     references: [chats.id]
   })
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -142,6 +142,7 @@ export const parts = pgTable(
     file_mediaType: varchar('file_media_type', { length: VARCHAR_LENGTH }),
     file_filename: varchar('file_filename', { length: FILENAME_LENGTH }),
     file_url: text('file_url'),
+    file_key: text('file_key'),
 
     // Source URL parts
     source_url_sourceId: varchar('source_url_source_id', {
@@ -212,7 +213,7 @@ export const parts = pgTable(
     ),
     check(
       'file_fields_required',
-      sql`(type != 'file' OR (file_media_type IS NOT NULL AND file_filename IS NOT NULL AND file_url IS NOT NULL))`
+      sql`(type != 'file' OR (file_media_type IS NOT NULL AND file_filename IS NOT NULL AND (file_key IS NOT NULL OR file_url IS NOT NULL)))`
     ),
     check(
       'tool_state_valid',
@@ -299,6 +300,49 @@ export const notes = pgTable(
 
 export type Note = InferSelectModel<typeof notes>
 export type NewNote = typeof notes.$inferInsert
+
+// Library files table
+export const libraryFiles = pgTable(
+  'files',
+  {
+    id: varchar('id', { length: ID_LENGTH })
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+    userId: varchar('user_id', { length: USER_ID_LENGTH }).notNull(),
+    chatId: varchar('chat_id', { length: ID_LENGTH }).references(
+      () => chats.id,
+      { onDelete: 'set null' }
+    ),
+    filename: text('filename').notNull(),
+    url: text('url').notNull(),
+    objectKey: text('object_key'),
+    mediaType: varchar('media_type', { length: VARCHAR_LENGTH }).notNull(),
+    size: integer('size'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow()
+  },
+  table => [
+    index('files_user_id_idx').on(table.userId),
+    index('files_user_id_updated_at_idx').on(
+      table.userId,
+      table.updatedAt.desc()
+    ),
+    index('files_chat_id_idx').on(table.chatId),
+    index('files_media_type_idx').on(table.mediaType),
+    index('files_object_key_idx').on(table.objectKey),
+
+    pgPolicy('users_manage_own_files', {
+      as: 'permissive',
+      for: 'all',
+      to: 'public',
+      using: sql`user_id = current_setting('app.current_user_id', true)`,
+      withCheck: sql`user_id = current_setting('app.current_user_id', true)`
+    })
+  ]
+).enableRLS()
+
+export type LibraryFile = InferSelectModel<typeof libraryFiles>
+export type NewLibraryFile = typeof libraryFiles.$inferInsert
 
 // Feedback table
 export const feedback = pgTable(

--- a/lib/storage/__tests__/r2-client.test.ts
+++ b/lib/storage/__tests__/r2-client.test.ts
@@ -22,18 +22,33 @@ const s3Mocks = vi.hoisted(() => {
     }
   }
 
+  class GetObjectCommand {
+    input: unknown
+
+    constructor(input: unknown) {
+      this.input = input
+    }
+  }
+
   return {
     DeleteObjectsCommand,
+    GetObjectCommand,
     ListObjectsV2Command,
     S3Client,
+    getSignedUrl: vi.fn(),
     send
   }
 })
 
 vi.mock('@aws-sdk/client-s3', () => ({
   DeleteObjectsCommand: s3Mocks.DeleteObjectsCommand,
+  GetObjectCommand: s3Mocks.GetObjectCommand,
   ListObjectsV2Command: s3Mocks.ListObjectsV2Command,
   S3Client: s3Mocks.S3Client
+}))
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: s3Mocks.getSignedUrl
 }))
 
 const originalEnv = {
@@ -41,6 +56,7 @@ const originalEnv = {
   R2_ACCOUNT_ID: process.env.R2_ACCOUNT_ID,
   R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
   R2_PUBLIC_URL: process.env.R2_PUBLIC_URL,
+  R2_SIGNED_URL_EXPIRES_SECONDS: process.env.R2_SIGNED_URL_EXPIRES_SECONDS,
   R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
   S3_ENDPOINT: process.env.S3_ENDPOINT
 }
@@ -53,12 +69,14 @@ async function importR2Client() {
 describe('R2 client', () => {
   beforeEach(() => {
     s3Mocks.send.mockReset()
+    s3Mocks.getSignedUrl.mockReset()
     s3Mocks.S3Client.mockClear()
 
     process.env.R2_ACCESS_KEY_ID = 'test-access-key'
     process.env.R2_SECRET_ACCESS_KEY = 'test-secret-key'
     process.env.R2_BUCKET_NAME = 'test-bucket'
     process.env.R2_PUBLIC_URL = 'https://uploads.example.com'
+    process.env.R2_SIGNED_URL_EXPIRES_SECONDS = '3600'
     process.env.S3_ENDPOINT = 'https://r2.example.com'
     delete process.env.R2_ACCOUNT_ID
   })
@@ -118,5 +136,32 @@ describe('R2 client', () => {
     await expect(deleteObjectsByPrefix('user-id/')).rejects.toThrow(
       'Failed to delete 1 object(s) from storage: user-id/file-2.png'
     )
+  })
+
+  it('does not require a public URL for object storage configuration', async () => {
+    delete process.env.R2_PUBLIC_URL
+
+    const { isObjectStorageConfigured } = await importR2Client()
+
+    expect(isObjectStorageConfigured()).toBe(true)
+  })
+
+  it('creates signed file URLs from object keys', async () => {
+    s3Mocks.getSignedUrl.mockResolvedValue('https://signed.example.com/file')
+
+    const { getSignedFileUrl } = await importR2Client()
+
+    await expect(getSignedFileUrl('/user-id/file.png')).resolves.toBe(
+      'https://signed.example.com/file'
+    )
+    expect(s3Mocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(s3Mocks.GetObjectCommand),
+      { expiresIn: 3600 }
+    )
+    expect((s3Mocks.getSignedUrl.mock.calls[0][1] as any).input).toEqual({
+      Bucket: 'test-bucket',
+      Key: 'user-id/file.png'
+    })
   })
 })

--- a/lib/storage/__tests__/r2-client.test.ts
+++ b/lib/storage/__tests__/r2-client.test.ts
@@ -164,4 +164,76 @@ describe('R2 client', () => {
       Key: 'user-id/file.png'
     })
   })
+
+  it('preserves existing file URLs when no object key is available', async () => {
+    const { signFilePartUrls } = await importR2Client()
+
+    await expect(
+      signFilePartUrls([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          filename: 'external.png',
+          url: 'https://external.example.com/external.png'
+        }
+      ])
+    ).resolves.toEqual([
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        filename: 'external.png',
+        url: 'https://external.example.com/external.png'
+      }
+    ])
+  })
+
+  it('rejects object keys outside the allowed prefix', async () => {
+    const { signFilePartUrls } = await importR2Client()
+
+    await expect(
+      signFilePartUrls(
+        [
+          {
+            type: 'file',
+            key: 'other-user/chats/chat-123/file.png',
+            mediaType: 'image/png',
+            filename: 'file.png',
+            url: ''
+          }
+        ],
+        { allowedKeyPrefix: 'user-123/chats/chat-123/' }
+      )
+    ).rejects.toThrow('File object key is not allowed for this chat')
+
+    expect(s3Mocks.getSignedUrl).not.toHaveBeenCalled()
+  })
+
+  it('signs object keys inside the allowed prefix', async () => {
+    s3Mocks.getSignedUrl.mockResolvedValue('https://signed.example.com/file')
+
+    const { signFilePartUrls } = await importR2Client()
+
+    await expect(
+      signFilePartUrls(
+        [
+          {
+            type: 'file',
+            key: 'user-123/chats/chat-123/file.png',
+            mediaType: 'image/png',
+            filename: 'file.png',
+            url: ''
+          }
+        ],
+        { allowedKeyPrefix: 'user-123/chats/chat-123/' }
+      )
+    ).resolves.toEqual([
+      {
+        type: 'file',
+        key: 'user-123/chats/chat-123/file.png',
+        mediaType: 'image/png',
+        filename: 'file.png',
+        url: 'https://signed.example.com/file'
+      }
+    ])
+  })
 })

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -80,7 +80,10 @@ function isObjectKeyWithinPrefix(key: string, prefix: string) {
   const normalizedKey = normalizeObjectKey(key)
   const normalizedPrefix = normalizeObjectKey(prefix).replace(/\/+$/, '')
 
-  return normalizedPrefix.length > 0 && normalizedKey.startsWith(`${normalizedPrefix}/`)
+  return (
+    normalizedPrefix.length > 0 &&
+    normalizedKey.startsWith(`${normalizedPrefix}/`)
+  )
 }
 
 export async function getSignedFileUrl(

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -20,6 +20,10 @@ export const R2_SIGNED_URL_EXPIRES_SECONDS =
 
 let _r2Client: S3Client | null = null
 
+type SignFilePartUrlsOptions = {
+  allowedKeyPrefix?: string
+}
+
 export function getR2Client(): S3Client {
   if (_r2Client) {
     return _r2Client
@@ -68,6 +72,17 @@ function normalizeObjectKey(key: string) {
   return key.replace(/^\/+/, '')
 }
 
+export function getChatFileObjectKeyPrefix(userId: string, chatId: string) {
+  return `${normalizeObjectKey(userId)}/chats/${normalizeObjectKey(chatId)}/`
+}
+
+function isObjectKeyWithinPrefix(key: string, prefix: string) {
+  const normalizedKey = normalizeObjectKey(key)
+  const normalizedPrefix = normalizeObjectKey(prefix).replace(/\/+$/, '')
+
+  return normalizedPrefix.length > 0 && normalizedKey.startsWith(`${normalizedPrefix}/`)
+}
+
 export async function getSignedFileUrl(
   key: string,
   expiresIn = R2_SIGNED_URL_EXPIRES_SECONDS
@@ -87,7 +102,10 @@ export async function getSignedFileUrl(
   )
 }
 
-export async function signFilePartUrls(parts: any[] = []) {
+export async function signFilePartUrls(
+  parts: any[] = [],
+  options: SignFilePartUrlsOptions = {}
+) {
   return Promise.all(
     parts.map(async part => {
       if (part?.type !== 'file') {
@@ -95,7 +113,14 @@ export async function signFilePartUrls(parts: any[] = []) {
       }
 
       if (!part.key) {
-        return { ...part, url: '' }
+        return part
+      }
+
+      if (
+        options.allowedKeyPrefix &&
+        !isObjectKeyWithinPrefix(part.key, options.allowedKeyPrefix)
+      ) {
+        throw new Error('File object key is not allowed for this chat')
       }
 
       try {

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -1,11 +1,22 @@
 import {
   DeleteObjectsCommand,
+  GetObjectCommand,
   ListObjectsV2Command,
   S3Client
 } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 
 export const R2_BUCKET_NAME = process.env.R2_BUCKET_NAME || 'user-uploads'
 export const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || ''
+const DEFAULT_SIGNED_URL_EXPIRES_SECONDS = 60 * 60
+const configuredSignedUrlExpiresSeconds = Number(
+  process.env.R2_SIGNED_URL_EXPIRES_SECONDS
+)
+export const R2_SIGNED_URL_EXPIRES_SECONDS =
+  Number.isFinite(configuredSignedUrlExpiresSeconds) &&
+  configuredSignedUrlExpiresSeconds > 0
+    ? configuredSignedUrlExpiresSeconds
+    : DEFAULT_SIGNED_URL_EXPIRES_SECONDS
 
 let _r2Client: S3Client | null = null
 
@@ -49,9 +60,66 @@ export function isObjectStorageConfigured() {
     !!process.env.R2_ACCESS_KEY_ID && !!process.env.R2_SECRET_ACCESS_KEY
   const hasEndpointOrAccount =
     !!process.env.S3_ENDPOINT || !!process.env.R2_ACCOUNT_ID
-  const hasPublicUrl = !!R2_PUBLIC_URL
 
-  return hasCredentials && hasEndpointOrAccount && hasPublicUrl
+  return hasCredentials && hasEndpointOrAccount
+}
+
+function normalizeObjectKey(key: string) {
+  return key.replace(/^\/+/, '')
+}
+
+export async function getSignedFileUrl(
+  key: string,
+  expiresIn = R2_SIGNED_URL_EXPIRES_SECONDS
+) {
+  const normalizedKey = normalizeObjectKey(key)
+  if (!normalizedKey) {
+    throw new Error('Cannot sign an empty object key')
+  }
+
+  return getSignedUrl(
+    getR2Client(),
+    new GetObjectCommand({
+      Bucket: R2_BUCKET_NAME,
+      Key: normalizedKey
+    }),
+    { expiresIn }
+  )
+}
+
+export async function signFilePartUrls(parts: any[] = []) {
+  return Promise.all(
+    parts.map(async part => {
+      if (part?.type !== 'file') {
+        return part
+      }
+
+      if (!part.key) {
+        return { ...part, url: '' }
+      }
+
+      try {
+        return {
+          ...part,
+          url: await getSignedFileUrl(part.key)
+        }
+      } catch (error) {
+        console.error('Failed to sign file URL:', error)
+        return { ...part, url: '' }
+      }
+    })
+  )
+}
+
+export async function signFilePartUrlsInMessages<T extends { parts?: any[] }>(
+  messages: T[]
+): Promise<T[]> {
+  return Promise.all(
+    messages.map(async message => ({
+      ...message,
+      parts: await signFilePartUrls(message.parts)
+    }))
+  )
 }
 
 export async function deleteObjectsByPrefix(prefix: string) {

--- a/lib/streaming/helpers/__tests__/prepare-messages.test.ts
+++ b/lib/streaming/helpers/__tests__/prepare-messages.test.ts
@@ -7,6 +7,7 @@ import {
   upsertMessage
 } from '@/lib/actions/chat'
 import type { Chat } from '@/lib/db/schema'
+import { signFilePartUrls } from '@/lib/storage/r2-client'
 import type { UIMessage } from '@/lib/types/ai'
 
 import { prepareMessages } from '../prepare-messages'
@@ -21,6 +22,12 @@ vi.mock('@/lib/db/schema', async () => {
     generateId: vi.fn(() => 'generated-id-123')
   }
 })
+vi.mock('@/lib/storage/r2-client', () => ({
+  getChatFileObjectKeyPrefix: vi.fn(
+    (userId: string, chatId: string) => `${userId}/chats/${chatId}/`
+  ),
+  signFilePartUrls: vi.fn(async (parts: any[]) => parts)
+}))
 
 describe('prepareMessages', () => {
   const userId = 'user-123'
@@ -373,6 +380,9 @@ describe('prepareMessages', () => {
       expect(context.pendingInitialUserMessage).toEqual({
         ...newMessage,
         id: 'msg-1'
+      })
+      expect(signFilePartUrls).toHaveBeenCalledWith(newMessage.parts, {
+        allowedKeyPrefix: 'user-123/chats/chat-123/'
       })
     })
 

--- a/lib/streaming/helpers/prepare-messages.ts
+++ b/lib/streaming/helpers/prepare-messages.ts
@@ -8,6 +8,7 @@ import {
   upsertMessage
 } from '@/lib/actions/chat'
 import { generateId } from '@/lib/db/schema'
+import { signFilePartUrls } from '@/lib/storage/r2-client'
 import { perfLog, perfTime } from '@/lib/utils/perf-logging'
 
 import type { StreamContext } from './types'
@@ -85,7 +86,8 @@ export async function prepareMessages(
 
     const messageWithId = {
       ...message,
-      id: message.id || generateId()
+      id: message.id || generateId(),
+      parts: await signFilePartUrls(message.parts)
     }
 
     // Optimize for new chats: create chat and save message together

--- a/lib/streaming/helpers/prepare-messages.ts
+++ b/lib/streaming/helpers/prepare-messages.ts
@@ -8,7 +8,10 @@ import {
   upsertMessage
 } from '@/lib/actions/chat'
 import { generateId } from '@/lib/db/schema'
-import { signFilePartUrls } from '@/lib/storage/r2-client'
+import {
+  getChatFileObjectKeyPrefix,
+  signFilePartUrls
+} from '@/lib/storage/r2-client'
 import { perfLog, perfTime } from '@/lib/utils/perf-logging'
 
 import type { StreamContext } from './types'
@@ -87,7 +90,9 @@ export async function prepareMessages(
     const messageWithId = {
       ...message,
       id: message.id || generateId(),
-      parts: await signFilePartUrls(message.parts)
+      parts: await signFilePartUrls(message.parts, {
+        allowedKeyPrefix: getChatFileObjectKeyPrefix(userId, chatId)
+      })
     }
 
     // Optimize for new chats: create chat and save message together

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -95,9 +95,11 @@ export type SearXNGSearchResults = {
 }
 
 export type UploadedFile = {
-  file: File
+  file?: File
   status: 'uploading' | 'uploaded' | 'error'
   url?: string
   name?: string
   key?: string
+  mediaType?: string
+  libraryFileId?: string
 }

--- a/lib/utils/message-mapping.ts
+++ b/lib/utils/message-mapping.ts
@@ -24,6 +24,7 @@ type FileUIPart = {
   mediaType: string
   filename?: string
   url: string
+  key?: string
 }
 type SourceUrlUIPart = {
   type: 'source-url'
@@ -154,7 +155,8 @@ export function mapUIMessagePartsToDBParts(
           ...basePart,
           file_mediaType: part.mediaType,
           file_filename: part.filename,
-          file_url: part.url
+          file_url: part.key ? undefined : part.url,
+          file_key: part.key
         }
 
       case 'source-url':
@@ -363,7 +365,8 @@ export function mapDBPartToUIMessagePart(
         type: 'file',
         mediaType: part.file_mediaType || '',
         filename: part.file_filename || '',
-        url: part.file_url || ''
+        url: part.file_key ? '' : part.file_url || '',
+        key: part.file_key || undefined
       }
 
     case 'source-url':

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "migrate": "bun run lib/db/migrate.ts",
+    "backfill:file-keys": "bun run scripts/backfill-file-object-keys.ts",
     "test": "NODE_ENV=test vitest run",
     "test:watch": "vitest --watch",
     "chat": "bun run scripts/chat-cli.ts"
@@ -23,7 +24,8 @@
     "@ai-sdk/openai": "^3.0.63",
     "@ai-sdk/openai-compatible": "^2.0.47",
     "@ai-sdk/react": "^3.0.182",
-    "@aws-sdk/client-s3": "^3.850.0",
+    "@aws-sdk/client-s3": "3.859.0",
+    "@aws-sdk/s3-request-presigner": "3.859.0",
     "@json-render/core": "^0.16.0",
     "@json-render/react": "^0.16.0",
     "@opentelemetry/api-logs": "0.57.2",

--- a/scripts/backfill-file-object-keys.ts
+++ b/scripts/backfill-file-object-keys.ts
@@ -1,0 +1,181 @@
+import * as dotenv from 'dotenv'
+import postgres from 'postgres'
+
+import 'dotenv/config'
+
+if (!process.env.DATABASE_URL) {
+  dotenv.config({ path: '.env.local' })
+}
+
+type BackfillTarget = {
+  id: string
+  url: string
+}
+
+const args = new Set(process.argv.slice(2))
+const apply = args.has('--apply')
+const allowSkipped = args.has('--allow-skipped')
+const explicitBaseUrl = process.argv
+  .slice(2)
+  .find(arg => arg.startsWith('--base-url='))
+  ?.slice('--base-url='.length)
+const baseUrls = [
+  explicitBaseUrl,
+  process.env.R2_PUBLIC_URL,
+  process.env.LEGACY_R2_PUBLIC_URL
+]
+  .filter((value): value is string => Boolean(value))
+  .map(value => value.replace(/\/+$/, ''))
+
+if (baseUrls.length === 0) {
+  console.error(
+    'Set R2_PUBLIC_URL, LEGACY_R2_PUBLIC_URL, or pass --base-url=https://...'
+  )
+  process.exit(1)
+}
+
+if (!process.env.DATABASE_URL) {
+  console.error('DATABASE_URL is required')
+  process.exit(1)
+}
+
+function keyFromUrl(url: string) {
+  for (const baseUrl of baseUrls) {
+    if (url === baseUrl) return null
+    if (url.startsWith(`${baseUrl}/`)) {
+      return decodeURIComponent(url.slice(baseUrl.length + 1))
+    }
+  }
+
+  return null
+}
+
+async function tableExists(sql: postgres.Sql, tableName: string) {
+  const [row] = await sql<{ exists: boolean }[]>`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name = ${tableName}
+    ) AS "exists"
+  `
+
+  return Boolean(row?.exists)
+}
+
+async function backfillParts(sql: postgres.Sql) {
+  const rows = await sql<BackfillTarget[]>`
+    SELECT id, file_url AS url
+    FROM parts
+    WHERE type = 'file'
+      AND file_key IS NULL
+      AND file_url IS NOT NULL
+  `
+
+  let converted = 0
+  let skipped = 0
+
+  for (const row of rows) {
+    const key = keyFromUrl(row.url)
+    if (!key) {
+      skipped++
+      continue
+    }
+
+    converted++
+    if (apply) {
+      await sql`
+        UPDATE parts
+        SET file_key = ${key}
+        WHERE id = ${row.id}
+          AND file_key IS NULL
+      `
+    }
+  }
+
+  return { total: rows.length, converted, skipped }
+}
+
+async function backfillFiles(sql: postgres.Sql) {
+  if (!(await tableExists(sql, 'files'))) {
+    return { total: 0, converted: 0, skipped: 0, missing: true }
+  }
+
+  const rows = await sql<BackfillTarget[]>`
+    SELECT id, url
+    FROM files
+    WHERE object_key IS NULL
+      AND url IS NOT NULL
+  `
+
+  let converted = 0
+  let skipped = 0
+
+  for (const row of rows) {
+    const key = keyFromUrl(row.url)
+    if (!key) {
+      skipped++
+      continue
+    }
+
+    converted++
+    if (apply) {
+      await sql`
+        UPDATE files
+        SET object_key = ${key}
+        WHERE id = ${row.id}
+          AND object_key IS NULL
+      `
+    }
+  }
+
+  return { total: rows.length, converted, skipped, missing: false }
+}
+
+async function main() {
+  const sql = postgres(process.env.DATABASE_URL!, {
+    ssl:
+      process.env.DATABASE_SSL_DISABLED === 'true'
+        ? false
+        : { rejectUnauthorized: false },
+    prepare: false
+  })
+
+  try {
+    const [partsResult, filesResult] = await Promise.all([
+      backfillParts(sql),
+      backfillFiles(sql)
+    ])
+
+    console.log(
+      JSON.stringify(
+        {
+          mode: apply ? 'apply' : 'dry-run',
+          baseUrls,
+          parts: partsResult,
+          files: filesResult
+        },
+        null,
+        2
+      )
+    )
+
+    if (!apply) {
+      console.log('Re-run with --apply to update rows.')
+    }
+
+    const skipped = partsResult.skipped + filesResult.skipped
+    if (apply && skipped > 0 && !allowSkipped) {
+      throw new Error(
+        `Backfill left ${skipped} URL(s) without object keys. Add the missing --base-url value and rerun, or pass --allow-skipped to accept unavailable legacy attachments.`
+      )
+    }
+  } finally {
+    await sql.end()
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
Summary:
- Store R2 object keys for uploaded files and generate signed URLs at read time.
- Add migrations and a backfill script for existing file URLs.
- Cover shared chats and account cleanup paths.

Validation:
- bun typecheck
- bun lint
- bun run test
- bun run build
- Production DB backfill completed with zero remaining R2 file URLs without keys.