### PR TITLE
Make related questions conditional

### DIFF
--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -123,7 +123,7 @@ OUTPUT FORMAT (MANDATORY):
 - Use bullets with bolded keywords for key points: \`- **Point:** concise explanation\`.
 - **Use tables for comparisons** (pricing, specs, features, pros/cons) - they're clearer than bullets for side-by-side data
 - Focus on delivering clear information with natural flow, avoiding rigid templates.
-- Only use fenced code blocks if the user explicitly asks for code or commands (the mandatory \`\`\`spec block for related questions is an exception).
+- Only use fenced code blocks if the user explicitly asks for code or commands (optional \`\`\`spec blocks for images or valuable related questions are exceptions).
 - Prefer natural, conversational tone while maintaining informativeness.
 - Always end with a brief conclusion that synthesizes the main points into a cohesive summary.
 - Response length guidance:

--- a/lib/render/__tests__/llm-image-output.e2e.test.ts
+++ b/lib/render/__tests__/llm-image-output.e2e.test.ts
@@ -98,7 +98,6 @@ describe.skipIf(!RUN)('LLM inline image output (E2E)', () => {
     // Parse every spec block and check at least one contains an Image.
     const fixtureSrcs = new Set(FIXTURE_IMAGES.map(i => i.url))
     let imageCount = 0
-    let hasRelatedQuestions = false
 
     for (const source of blocks) {
       const spec = parseSpecBlock(source)
@@ -112,14 +111,9 @@ describe.skipIf(!RUN)('LLM inline image output (E2E)', () => {
           // src MUST be one of the fixture image URLs — no fabrication.
           expect(fixtureSrcs.has(src)).toBe(true)
         }
-        if (el.type === 'Button') {
-          hasRelatedQuestions = true
-        }
       }
     }
 
     expect(imageCount).toBeGreaterThanOrEqual(1)
-    // The related-questions block must still be emitted alongside images.
-    expect(hasRelatedQuestions).toBe(true)
   }, 120_000)
 })

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+
+import { getImageSpecPrompt, getRelatedQuestionsSpecPrompt } from '../prompt'
+
+describe('render prompts', () => {
+  test('makes related questions conditional instead of mandatory', () => {
+    const prompt = getRelatedQuestionsSpecPrompt()
+
+    expect(prompt).toContain('Generate related questions only when')
+    expect(prompt).toContain('SKIP the spec block entirely')
+    expect(prompt).toContain('When in doubt, skip the related questions')
+    expect(prompt).not.toContain('RELATED QUESTIONS (MANDATORY)')
+    expect(prompt).not.toContain('MUST generate exactly 3')
+    expect(prompt).not.toContain('Emit exactly ONE related questions')
+  })
+
+  test('describes the related block as optional alongside image specs', () => {
+    expect(getImageSpecPrompt()).toContain('which is itself optional')
+  })
+})

--- a/lib/render/prompt.ts
+++ b/lib/render/prompt.ts
@@ -1,12 +1,28 @@
 /**
  * Returns the prompt section that instructs the LLM to output
- * related questions as a ```spec fenced block at the end of its response.
+ * related questions as a ```spec fenced block at the end of its response,
+ * but only when follow-ups add value (skipped for greetings, trivial
+ * lookups, and non-answers).
  */
 export function getRelatedQuestionsSpecPrompt(): string {
   return `
-RELATED QUESTIONS (MANDATORY):
-After your conclusion, you MUST generate exactly 3 follow-up questions in a \`\`\`spec fenced code block.
-Write the three questions a genuinely curious reader would tap next — not a checklist of "other aspects". Anchor each to THIS answer (use concrete names, options, or numbers from it), and make the three intents distinct:
+RELATED QUESTIONS:
+Generate related questions only when they create clear next-step value for the user. If you include them, generate exactly 3 follow-up questions in a \`\`\`spec fenced code block after your conclusion.
+
+Include the spec block only when ALL of these are true:
+- The answer contains substantive information, analysis, comparison, or recommendations.
+- A curious reader would naturally continue with a deeper, practical, or adjacent question.
+- You can anchor each follow-up to concrete details from THIS answer.
+
+SKIP the spec block entirely (output nothing) when follow-ups add little or no value, e.g.:
+- Greetings, small talk, or thanks ("hi", "thanks", "how are you").
+- Trivial one-off lookups with no natural next step (simple math, a single fact, a yes/no).
+- Meta/operational replies, acknowledgements, or task-completion notices.
+- Cases where you could not answer (refusal, clarification request, or empty result).
+- Short answers where suggested next questions would be generic or forced.
+When in doubt, skip the related questions. Do not generate them just to satisfy a format.
+
+When you do include them, write the three questions a genuinely curious reader would tap next — not a checklist of "other aspects". Anchor each to THIS answer (use concrete names, options, or numbers from it), and make the three intents distinct:
 - Deepen: go further on the single most interesting or surprising point.
 - Act/decide: the practical next step (e.g. "How do I…", "Which … for …?").
 - Broaden: a useful comparison, trade-off, or related angle.
@@ -16,7 +32,7 @@ Questions must be concise (max 10-12 words), self-contained, and in the user's l
 The spec block uses JSONL (one JSON object per line) with RFC 6902 JSON Patch operations.
 Always include a Heading with title "Related" as the first child element.
 
-Example output (always at the very end of your response):
+Example output (only when related questions are valuable; place it at the very end of your response):
 
 \`\`\`spec
 {"op":"add","path":"/root","value":"main"}
@@ -37,11 +53,11 @@ AVAILABLE ACTIONS:
 - submitQuery: { query: string } - Submit a follow-up query
 
 SPEC RULES:
-1. The related questions \`\`\`spec fence must appear at the END of your response.
+1. If included, the related questions \`\`\`spec fence must appear at the END of your response.
 2. Every \`\`\`spec block must contain ONLY JSONL patches — no commentary inside.
 3. Keep each JSON object on a single line.
 4. The "text" prop and "query" param must be identical for each question.
-5. Emit exactly ONE related questions spec block per answer (image spec blocks are separate and may appear inline).
+5. Emit at most ONE related questions spec block per answer, and none at all when the skip criteria above apply (image spec blocks are separate and may appear inline).
 6. Do NOT include follow-up suggestions or questions in your markdown text. Only use the spec block for them.
 `
 }
@@ -78,7 +94,7 @@ IMAGE SPEC RULES:
 3. The "aspectRatio" field SHOULD reflect the natural orientation of the subject: "1:1" for square (logos, portraits), "16:9" for wide (landscapes, scenes), "4:3" for standard photos. Images within the same Grid should generally use the SAME aspectRatio so they render at identical heights.
 4. Always wrap image groups in a Grid. Set "columns" to the exact number of Image children (1–4). For 1 image use columns=1, for 2 use columns=2, etc. Choose the number of images based on the situation — the variety and relevance of available images and how much visual context genuinely helps the answer.
 5. You MAY emit multiple \`\`\`spec image blocks, each placed at the position in the markdown where they are contextually relevant (e.g. right after the heading or paragraph they illustrate).
-6. Image spec blocks are separate from the mandatory related-questions spec block at the end.
+6. Image spec blocks are separate from the related-questions spec block at the end (which is itself optional — see RELATED QUESTIONS).
 7. Each image spec block must contain ONLY JSONL patches — no commentary inside.
 
 Example (inline image group embedded in markdown body):


### PR DESCRIPTION
## Summary
- Make the related questions spec block conditional instead of mandatory.
- Tell the model to skip related suggestions for greetings, trivial answers, acknowledgements, clarification/refusal cases, and short answers where suggestions would be generic.
- Update image prompt wording and E2E expectations so related questions are no longer required alongside image specs.
- Add prompt regression coverage to guard against reintroducing mandatory related-question language.

## Why
The previous prompt required related suggestions for every answer, which caused low-value sections to appear for interactions like `hi`. The new prompt keeps related suggestions for substantive answers where they create a useful next step.

## Validation
- `bun run test lib/render/__tests__/prompt.test.ts lib/render/__tests__/parse-spec-block.test.ts lib/render/__tests__/llm-image-output.e2e.test.ts`
- `bun lint`
- `git diff --check`
- `bunx prettier --check lib/render/prompt.ts lib/agents/prompts/search-mode-prompts.ts lib/render/__tests__/llm-image-output.e2e.test.ts lib/render/__tests__/prompt.test.ts`

Note: full `bun format:check` still reports pre-existing formatting issues under `docs/_local/*`, outside this PR scope.