### PR TITLE
fix(db): correct 0016 journal timestamp and fix format CI break

### DIFF
--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -123,9 +123,7 @@
           "name": "users_manage_own_chats",
           "as": "PERMISSIVE",
           "for": "ALL",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "user_id = current_setting('app.current_user_id', true)",
           "withCheck": "user_id = current_setting('app.current_user_id', true)"
         },
@@ -133,9 +131,7 @@
           "name": "public_chats_readable",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "visibility = 'public'"
         }
       },
@@ -230,27 +226,21 @@
           "name": "feedback_select_policy",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "true"
         },
         "anyone_can_insert_feedback": {
           "name": "anyone_can_insert_feedback",
           "as": "PERMISSIVE",
           "for": "INSERT",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "withCheck": "true"
         },
         "users_anonymize_own_feedback": {
           "name": "users_anonymize_own_feedback",
           "as": "PERMISSIVE",
           "for": "UPDATE",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "user_id = current_setting('app.current_user_id', true)",
           "withCheck": "user_id IS NULL"
         }
@@ -342,13 +332,9 @@
         "messages_chat_id_chats_id_fk": {
           "name": "messages_chat_id_chats_id_fk",
           "tableFrom": "messages",
-          "columnsFrom": [
-            "chat_id"
-          ],
+          "columnsFrom": ["chat_id"],
           "tableTo": "chats",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -360,9 +346,7 @@
           "name": "users_manage_chat_messages",
           "as": "PERMISSIVE",
           "for": "ALL",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "EXISTS (\n        SELECT 1 FROM \"chats\"\n        WHERE \"chats\".id = chat_id\n        AND \"chats\".user_id = current_setting('app.current_user_id', true)\n      )",
           "withCheck": "EXISTS (\n        SELECT 1 FROM \"chats\"\n        WHERE \"chats\".id = chat_id\n        AND \"chats\".user_id = current_setting('app.current_user_id', true)\n      )"
         },
@@ -370,9 +354,7 @@
           "name": "public_chat_messages_readable",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "EXISTS (\n        SELECT 1 FROM \"chats\"\n        WHERE \"chats\".id = chat_id\n        AND \"chats\".visibility = 'public'\n      )"
         }
       },
@@ -667,13 +649,9 @@
         "parts_message_id_messages_id_fk": {
           "name": "parts_message_id_messages_id_fk",
           "tableFrom": "parts",
-          "columnsFrom": [
-            "message_id"
-          ],
+          "columnsFrom": ["message_id"],
           "tableTo": "messages",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -685,9 +663,7 @@
           "name": "users_manage_message_parts",
           "as": "PERMISSIVE",
           "for": "ALL",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "EXISTS (\n        SELECT 1 FROM \"messages\"\n        INNER JOIN \"chats\" ON \"chats\".id = \"messages\".chat_id\n        WHERE \"messages\".id = message_id\n        AND \"chats\".user_id = current_setting('app.current_user_id', true)\n      )",
           "withCheck": "EXISTS (\n        SELECT 1 FROM \"messages\"\n        INNER JOIN \"chats\" ON \"chats\".id = \"messages\".chat_id\n        WHERE \"messages\".id = message_id\n        AND \"chats\".user_id = current_setting('app.current_user_id', true)\n      )"
         },
@@ -695,9 +671,7 @@
           "name": "public_chat_parts_readable",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "public"
-          ],
+          "to": ["public"],
           "using": "EXISTS (\n        SELECT 1 FROM \"messages\"\n        INNER JOIN \"chats\" ON \"chats\".id = \"messages\".chat_id\n        WHERE \"messages\".id = message_id\n        AND \"chats\".visibility = 'public'\n      )"
         }
       },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -117,7 +117,7 @@
     {
       "idx": 16,
       "version": "7",
-      "when": 1782591772987,
+      "when": 1782604800001,
       "tag": "0016_wrap_rls_current_setting",
       "breakpoints": true
     }


### PR DESCRIPTION
## What

Follow-up to #902. Two fixes to the `0016_wrap_rls_current_setting` migration metadata:

1. **Journal timestamp** — bump `0016`'s `when` in `drizzle/meta/_journal.json` from `1782591772987` to `1782604800001`.
2. **Trailing newlines** — `_journal.json` and `0016_snapshot.json` were committed without a trailing newline, which fails `prettier --check`.

## Why

**Timestamp:** drizzle-orm's postgres migrator applies a journal entry only when its `when` is greater than the latest already-applied migration's `created_at`. `0016`'s `when` (`1782591772987`) was *earlier* than the already-applied `0015` (`1782604800000`), so `bun migrate` treated `0016` as already applied and **silently skipped** the four `ALTER POLICY` statements on any database that already had `0015` (i.e. production). Bumping it just past `0015` makes the migrator apply it.

**Formatting:** the `format` job in CI has been red on `main` since #902 merged ([failed run](https://github.com/miurla/morphic/actions/runs/28305686871)) because the two drizzle meta files lack trailing newlines. Adding them turns CI green.

## Verification

Production policies are now wrapped and `0016` is recorded in `__drizzle_migrations` (applied via `bun migrate` after the local timestamp fix). `bunx prettier --check` passes on both files.