### PR TITLE
Gate related questions behind related_questions_enabled flag

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -40,6 +40,9 @@ export async function POST(req: Request) {
     const body = await req.json()
     const { message, messages, chatId, trigger, messageId, isNewChat } = body
     const analyticsId: unknown = body.analyticsId
+    // related_questions_enabled flag (evaluated client-side, on by default).
+    // Off only when the client explicitly sends false.
+    const relatedEnabled = body.relatedEnabled !== false
 
     // Normalize the message id up front so persistence and analytics agree on it.
     if (message && !message.id) {
@@ -172,7 +175,8 @@ export async function POST(req: Request) {
           model: selectedModel,
           abortSignal,
           searchMode,
-          chatId
+          chatId,
+          relatedEnabled
         })
       : await createChatStreamResponse({
           message,
@@ -183,7 +187,8 @@ export async function POST(req: Request) {
           messageId,
           abortSignal,
           isNewChat,
-          searchMode
+          searchMode,
+          relatedEnabled
         })
 
     perfTime('createChatStreamResponse resolved', streamStart)
@@ -232,6 +237,7 @@ export async function POST(req: Request) {
           userId: userId ?? undefined,
           providerId: selectedModel.providerId,
           modelId: selectedModel.id,
+          relatedFlag: relatedEnabled,
           queryShape
         })
       } catch (error) {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import { loadChat } from '@/lib/actions/chat'
 import {
   calculateConversationTurn,
   deriveQueryShape,
+  getServerFeatureFlag,
   trackChatEvent
 } from '@/lib/analytics'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
@@ -40,9 +41,6 @@ export async function POST(req: Request) {
     const body = await req.json()
     const { message, messages, chatId, trigger, messageId, isNewChat } = body
     const analyticsId: unknown = body.analyticsId
-    // related_questions_enabled flag (evaluated client-side, on by default).
-    // Off only when the client explicitly sends false.
-    const relatedEnabled = body.relatedEnabled !== false
 
     // Normalize the message id up front so persistence and analytics agree on it.
     if (message && !message.id) {
@@ -164,6 +162,26 @@ export async function POST(req: Request) {
       }
     }
 
+    // Distinct id used for BOTH flag evaluation and analytics attribution, so
+    // the stamped relatedFlag matches the arm the user was actually bucketed to.
+    const analyticsDistinctId =
+      userId ?? (typeof analyticsId === 'string' ? analyticsId : undefined)
+
+    // related_questions_enabled flag. Prefer the client-evaluated value (no
+    // round-trip); fall back to server evaluation against the same distinct id
+    // when the client couldn't resolve flags in time (cold-start / auto-submit),
+    // so first-message sessions aren't misattributed to the on arm. On by default.
+    const clientRelated = body.relatedEnabled
+    const relatedEnabled =
+      typeof clientRelated === 'boolean'
+        ? clientRelated
+        : ((analyticsDistinctId
+            ? await getServerFeatureFlag(
+                'related_questions_enabled',
+                analyticsDistinctId
+              )
+            : undefined) ?? true)
+
     const streamStart = performance.now()
     perfLog(
       `createChatStreamResponse - Start: model=${selectedModel.providerId}:${selectedModel.id}, searchMode=${searchMode}`
@@ -199,8 +217,7 @@ export async function POST(req: Request) {
       try {
         // Attribute to the authenticated user id, or the client-provided
         // PostHog distinct id for guests (so it merges with their client events).
-        const distinctId =
-          userId ?? (typeof analyticsId === 'string' ? analyticsId : undefined)
+        const distinctId = analyticsDistinctId
         if (!distinctId) return
 
         let conversationTurn = 1 // Default for new chats

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -8,7 +8,11 @@ import { DefaultChatTransport } from 'ai'
 import { toast } from 'sonner'
 
 import { summarizeGenui } from '@/lib/analytics/genui-summary'
-import { captureClient, getDistinctId } from '@/lib/analytics/posthog-client'
+import {
+  captureClient,
+  getDistinctId,
+  isRelatedQuestionsEnabled
+} from '@/lib/analytics/posthog-client'
 import { ChatProvider } from '@/lib/contexts/chat-context'
 import { generateId } from '@/lib/db/schema'
 import {
@@ -156,6 +160,7 @@ export function Chat({
             chatId: chatId,
             messageId,
             analyticsId: getDistinctId(),
+            relatedEnabled: isRelatedQuestionsEnabled(),
             ...(isGuest ? { messages } : {}),
             message:
               trigger === 'regenerate-message' &&

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -154,13 +154,17 @@ export function Chat({
             ? messages.find(m => m.id === messageId)
             : undefined
 
+        // Omit when flags aren't loaded yet so the server resolves the flag
+        // against the same distinct id (avoids on-arm bias on cold-start sends).
+        const relatedEnabled = isRelatedQuestionsEnabled()
+
         return {
           body: {
             trigger, // Use AI SDK's default trigger value directly
             chatId: chatId,
             messageId,
             analyticsId: getDistinctId(),
-            relatedEnabled: isRelatedQuestionsEnabled(),
+            ...(relatedEnabled === undefined ? {} : { relatedEnabled }),
             ...(isGuest ? { messages } : {}),
             message:
               trigger === 'regenerate-message' &&

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -19,7 +19,7 @@ function getSourceDirectionGuidance(): string {
 - Fallback: if a domain-restricted search returns too few or no results, run one more search without the restriction before answering.`
 }
 
-export function getQuickModePrompt(): string {
+export function getQuickModePrompt(relatedEnabled = true): string {
   const hasGeneralProvider = isGeneralSearchProviderAvailable()
 
   return `
@@ -156,11 +156,11 @@ End with a synthesizing conclusion that ties the main points together into a cle
 
 ${getImageSpecPrompt()}
 
-${getRelatedQuestionsSpecPrompt()}
+${relatedEnabled ? getRelatedQuestionsSpecPrompt() : ''}
 `
 }
 
-function getApproachStrategy(): string {
+function getApproachStrategy(relatedEnabled = true): string {
   return `APPROACH STRATEGY:
 1. **FIRST STEP - Assess query complexity:**
    - Most queries: Direct search and respond. Do NOT use todoWrite.
@@ -206,7 +206,7 @@ Rule precedence:
 7. Provide comprehensive and detailed responses based on search results, ensuring thorough coverage of the user's question`
 }
 
-export function getAdaptiveModePrompt(): string {
+export function getAdaptiveModePrompt(relatedEnabled = true): string {
   return `
 Instructions:
 
@@ -228,7 +228,7 @@ You are a helpful AI assistant with access to real-time web search, content retr
 Language:
 - ALWAYS respond in the user's language.
 
-${getApproachStrategy()}
+${getApproachStrategy(relatedEnabled)}
 
 TOOL USAGE GUIDELINES:
 
@@ -332,7 +332,7 @@ Conclude with a brief synthesis that ties together the main insights into a clea
 
 ${getImageSpecPrompt()}
 
-${getRelatedQuestionsSpecPrompt()}
+${relatedEnabled ? getRelatedQuestionsSpecPrompt() : ''}
 `
 }
 

--- a/lib/agents/researcher.ts
+++ b/lib/agents/researcher.ts
@@ -13,7 +13,7 @@ import { isTracingEnabled } from '../utils/telemetry'
 
 import {
   getAdaptiveModePrompt,
-  QUICK_MODE_PROMPT
+  getQuickModePrompt
 } from './prompts/search-mode-prompts'
 
 // Enhanced wrapper function with better type safety and streaming support
@@ -71,12 +71,14 @@ export function createResearcher({
   model,
   modelConfig,
   parentTraceId,
-  searchMode = 'adaptive'
+  searchMode = 'adaptive',
+  relatedEnabled = true
 }: {
   model: string
   modelConfig?: Model
   parentTraceId?: string
   searchMode?: SearchMode
+  relatedEnabled?: boolean
 }) {
   try {
     const currentDate = new Date().toLocaleString()
@@ -97,7 +99,7 @@ export function createResearcher({
         console.log(
           '[Researcher] Quick mode: maxSteps=20, tools=[search, fetch]'
         )
-        systemPrompt = QUICK_MODE_PROMPT
+        systemPrompt = getQuickModePrompt(relatedEnabled)
         activeToolsList = ['search', 'fetch']
         maxSteps = 20
         searchTool = wrapSearchToolForQuickMode(originalSearchTool)
@@ -105,7 +107,7 @@ export function createResearcher({
 
       case 'adaptive':
       default:
-        systemPrompt = getAdaptiveModePrompt()
+        systemPrompt = getAdaptiveModePrompt(relatedEnabled)
         activeToolsList = ['search', 'fetch', 'todoWrite']
         console.log(
           `[Researcher] Adaptive mode: maxSteps=50, tools=[${activeToolsList.join(', ')}]`

--- a/lib/analytics/dispatch.ts
+++ b/lib/analytics/dispatch.ts
@@ -1,11 +1,31 @@
 import {
   captureServerEvent,
   deletePerson,
+  getServerFeatureFlag as getServerFeatureFlagProvider,
   type ServerEvent
 } from './providers/posthog-server'
 
 export function isAnalyticsEnabled(): boolean {
   return process.env.MORPHIC_CLOUD_DEPLOYMENT === 'true'
+}
+
+/**
+ * Evaluate a boolean feature flag for a distinct id. Returns undefined when
+ * analytics is disabled or evaluation fails, so callers apply their own
+ * default (never throws).
+ */
+export async function getServerFeatureFlag(
+  key: string,
+  distinctId: string
+): Promise<boolean | undefined> {
+  if (!isAnalyticsEnabled()) return undefined
+
+  try {
+    return await getServerFeatureFlagProvider(key, distinctId)
+  } catch (error) {
+    console.error('Failed to evaluate feature flag:', error)
+    return undefined
+  }
 }
 
 export async function capture(event: ServerEvent): Promise<void> {

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -6,6 +6,7 @@
  * @module analytics
  */
 
+export { getServerFeatureFlag } from './dispatch'
 export { trackAccountDeleted } from './track-account-event'
 export {
   type AdaptiveLimitEventData,

--- a/lib/analytics/posthog-client.ts
+++ b/lib/analytics/posthog-client.ts
@@ -74,6 +74,18 @@ export function isFeatureEnabled(key: string): boolean {
   return posthog.isFeatureEnabled?.(key) === true
 }
 
+/**
+ * Whether related questions are enabled for the current distinct id.
+ * On by default: returns false ONLY when the `related_questions_enabled`
+ * flag explicitly resolves to false, so unloaded flags / disabled analytics
+ * keep the existing behavior (related questions shown).
+ */
+export function isRelatedQuestionsEnabled(): boolean {
+  if (!clientKey()) return true
+  initPostHog()
+  return posthog.getFeatureFlag?.('related_questions_enabled') !== false
+}
+
 /** Subscribe to feature-flag loads/changes. Returns an unsubscribe function. */
 export function subscribeFeatureFlags(callback: () => void): () => void {
   if (!clientKey()) return () => {}

--- a/lib/analytics/posthog-client.ts
+++ b/lib/analytics/posthog-client.ts
@@ -76,14 +76,21 @@ export function isFeatureEnabled(key: string): boolean {
 
 /**
  * Whether related questions are enabled for the current distinct id.
- * On by default: returns false ONLY when the `related_questions_enabled`
- * flag explicitly resolves to false, so unloaded flags / disabled analytics
- * keep the existing behavior (related questions shown).
+ *
+ * Returns:
+ * - `true`  — analytics disabled (keep current behavior), or flag resolved on.
+ * - `false` — flag explicitly resolved to false.
+ * - `undefined` — flags not loaded yet (cold start / immediate auto-submit).
+ *   Callers should treat this as "unknown" and let the server evaluate against
+ *   the same distinct id, instead of defaulting on and misattributing
+ *   first-message sessions to the on arm of the A/B.
  */
-export function isRelatedQuestionsEnabled(): boolean {
+export function isRelatedQuestionsEnabled(): boolean | undefined {
   if (!clientKey()) return true
   initPostHog()
-  return posthog.getFeatureFlag?.('related_questions_enabled') !== false
+  const value = posthog.getFeatureFlag?.('related_questions_enabled')
+  if (value === undefined) return undefined
+  return value !== false
 }
 
 /** Subscribe to feature-flag loads/changes. Returns an unsubscribe function. */

--- a/lib/analytics/providers/posthog-server.ts
+++ b/lib/analytics/providers/posthog-server.ts
@@ -36,6 +36,25 @@ export async function captureServerEvent({
 }
 
 /**
+ * Evaluate a boolean feature flag server-side for a distinct id.
+ * Returns undefined when analytics is unconfigured, the flag is unknown, or
+ * evaluation fails, so callers apply their own default. Does not emit a
+ * $feature_flag_called event (the flag value is stamped on the chat event).
+ */
+export async function getServerFeatureFlag(
+  key: string,
+  distinctId: string
+): Promise<boolean | undefined> {
+  const ph = getClient()
+  if (!ph) return undefined
+
+  const value = await ph.getFeatureFlag(key, distinctId, {
+    sendFeatureFlagEvents: false
+  })
+  return value === undefined ? undefined : value !== false
+}
+
+/**
  * Delete a person and their events via the management API.
  * Requires a dedicated personal API key scoped to person:write.
  * No-op when the key or project id is not configured.

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -43,6 +43,8 @@ export interface ChatEventData {
   providerId: string
   /** Model identifier used for the chat */
   modelId: string
+  /** related_questions_enabled flag value for this request (A/B variant) */
+  relatedFlag?: boolean
   /** Derived query shape (omitted for regenerate, where no new query exists) */
   queryShape?: QueryShape
 }

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -48,7 +48,8 @@ export async function createChatStreamResponse(
     messageId,
     abortSignal,
     isNewChat,
-    searchMode
+    searchMode,
+    relatedEnabled = true
   } = config
 
   // Verify that chatId is provided
@@ -129,7 +130,8 @@ export async function createChatStreamResponse(
       model: context.modelId,
       modelConfig: model,
       parentTraceId,
-      searchMode
+      searchMode,
+      relatedEnabled
     })
 
     // For OpenAI models, strip reasoning parts from UIMessages before conversion

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -29,7 +29,7 @@ import { BaseStreamConfig } from './types'
 
 type EphemeralStreamConfig = Pick<
   BaseStreamConfig,
-  'model' | 'abortSignal' | 'searchMode'
+  'model' | 'abortSignal' | 'searchMode' | 'relatedEnabled'
 > & {
   messages: UIMessage[]
   chatId?: string
@@ -38,7 +38,14 @@ type EphemeralStreamConfig = Pick<
 export async function createEphemeralChatStreamResponse(
   config: EphemeralStreamConfig
 ): Promise<Response> {
-  const { messages, model, abortSignal, searchMode, chatId } = config
+  const {
+    messages,
+    model,
+    abortSignal,
+    searchMode,
+    chatId,
+    relatedEnabled = true
+  } = config
 
   if (!messages || messages.length === 0) {
     return new Response('messages are required', {
@@ -94,7 +101,8 @@ export async function createEphemeralChatStreamResponse(
       model: `${model.providerId}:${model.id}`,
       modelConfig: model,
       parentTraceId,
-      searchMode
+      searchMode,
+      relatedEnabled
     })
 
     const modelId = `${model.providerId}:${model.id}`

--- a/lib/streaming/types.ts
+++ b/lib/streaming/types.ts
@@ -13,4 +13,5 @@ export interface BaseStreamConfig {
   abortSignal?: AbortSignal
   isNewChat?: boolean
   searchMode?: SearchMode
+  relatedEnabled?: boolean
 }


### PR DESCRIPTION
## What

Adds an on/off A/B switch for related questions via the `related_questions_enabled` PostHog boolean flag.

- **Client-side evaluation** (`isRelatedQuestionsEnabled` in `posthog-client.ts`) — uses the already-loaded posthog-js flags, so no per-request `/decide` round-trip. The value is sent in the chat request body as `relatedEnabled`.
- **Server** ([`app/api/chat/route.ts`](app/api/chat/route.ts)) reads `relatedEnabled` (defaults to true) and threads it through both the authed and ephemeral stream paths into `createResearcher`, which omits `getRelatedQuestionsSpecPrompt()` from the system prompt for the off variant.
- **Measurement** — stamps `relatedFlag` onto `chat_message_sent` so depth (`conversationTurn`) and W2 retention can be split per variant (the A/B's primary metrics; CTR is undefined for the off arm).

## Default behavior

On by default — returns related questions whenever the flag is unloaded, unassigned, or analytics is disabled, preserving current behavior. Off only when the flag explicitly resolves to false.

## Why

Observational data can't separate whether related questions *cause* deeper sessions (the conditional gate correlates with conversation state). An on/off A/B on depth + retention settles it.