### PR TITLE
feat: add Render Blueprint for Exa search deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,14 @@ Visit http://localhost:3000.
 
 ## Deploy
 
-### Vercel
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmiurla%2Fmorphic&env=OPENAI_API_KEY,TAVILY_API_KEY,ENABLE_AUTH)
+<p>
+  <a href="https://render.com/deploy?repo=https://github.com/miurla/morphic">
+    <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="32" />
+  </a>
+  <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmiurla%2Fmorphic&env=OPENAI_API_KEY,TAVILY_API_KEY,ENABLE_AUTH">
+    <img src="https://vercel.com/button" alt="Deploy with Vercel" height="32" />
+  </a>
+</p>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,13 @@ Visit http://localhost:3000.
 
 ## Deploy
 
-<p>
-  <a href="https://render.com/deploy?repo=https://github.com/miurla/morphic">
-    <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="32" />
-  </a>
-  <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmiurla%2Fmorphic&env=OPENAI_API_KEY,TAVILY_API_KEY,ENABLE_AUTH">
-    <img src="https://vercel.com/button" alt="Deploy with Vercel" height="32" />
-  </a>
-</p>
+### Render
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/miurla/morphic)
+
+### Vercel
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmiurla%2Fmorphic&env=OPENAI_API_KEY,TAVILY_API_KEY,ENABLE_AUTH)
 
 ## Contributing
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+#
+# Morphic on Render — Exa search variant
+# Dashboard → New → Blueprint → connect this repo → Apply.
+#
+# Builds from ./Dockerfile. Migrations run on container start (docker-entrypoint.sh).
+#
+# Set at Apply or in the Dashboard after deploy:
+#   EXA_API_KEY — https://dashboard.exa.ai/
+#   One LLM key: ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_GENERATIVE_AI_API_KEY
+#
+# NODE_TLS_REJECT_UNAUTHORIZED: required for Render Postgres with current lib/db TLS
+# settings. Render's internal Postgres URL uses a platform CA that Node rejects without this.
+
+previews:
+  generation: off
+
+envVarGroups:
+  - name: morphic-render
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: ENABLE_AUTH
+        value: "false"
+      - key: ANONYMOUS_USER_ID
+        value: anonymous-user
+      - key: SEARCH_API
+        value: exa
+      - key: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
+
+projects:
+  - name: morphic
+    environments:
+      - name: production
+        services:
+          - type: web
+            name: morphic
+            runtime: docker
+            plan: standard
+            region: oregon
+            dockerfilePath: ./Dockerfile
+            dockerContext: .
+            healthCheckPath: /
+            maxShutdownDelaySeconds: 120
+            envVars:
+              - fromGroup: morphic-render
+              - key: DATABASE_URL
+                fromDatabase:
+                  name: morphic-db
+                  property: connectionString
+              - key: DATABASE_RESTRICTED_URL
+                fromDatabase:
+                  name: morphic-db
+                  property: connectionString
+              - key: EXA_API_KEY
+                sync: false
+
+        databases:
+          - name: morphic-db
+            plan: basic-256mb
+            region: oregon
+            databaseName: morphic
+            postgresMajorVersion: "17"
+            ipAllowList: []


### PR DESCRIPTION
## Summary

- Adds `render.yaml` for Render Blueprint deploy (Docker build, Postgres, Exa search).
- Adds Render deploy button beside the existing Vercel button in the README.

Gallery template docs (screenshots, troubleshooting) are on the `render-templates` branch for render.com/templates submission, not in this PR.

## Test plan

- [x] `render blueprints validate render.yaml` passes
- [x] Blueprint deploy from fork on Render
- [x] Search query completes with Exa + LLM key