### PR TITLE
fix: zod preprocess coercion for include_domains string input

### DIFF
--- a/lib/schema/search.tsx
+++ b/lib/schema/search.tsx
@@ -30,16 +30,24 @@ export const searchSchema = z.object({
       'The depth of the search. Allowed values are "basic" or "advanced"'
     ),
   include_domains: z
-    .array(z.string())
-    .nullish()
-    .transform(val => val ?? [])
+    .preprocess(
+      val => (typeof val === 'string' ? [val] : val),
+      z
+        .array(z.string())
+        .nullish()
+        .transform(val => val ?? [])
+    )
     .describe(
       'A list of domains to specifically include in the search results. Default is None, which includes all domains.'
     ),
   exclude_domains: z
-    .array(z.string())
-    .nullish()
-    .transform(val => val ?? [])
+    .preprocess(
+      val => (typeof val === 'string' ? [val] : val),
+      z
+        .array(z.string())
+        .nullish()
+        .transform(val => val ?? [])
+    )
     .describe(
       "A list of domains to specifically exclude from the search results. Default is None, which doesn't exclude any domains."
     )
@@ -59,16 +67,24 @@ export const strictSearchSchema = z.object({
     .enum(['basic', 'advanced'])
     .describe('The depth of the search'),
   include_domains: z
-    .array(z.string())
-    .nullish()
-    .transform(val => val ?? [])
+    .preprocess(
+      val => (typeof val === 'string' ? [val] : val),
+      z
+        .array(z.string())
+        .nullish()
+        .transform(val => val ?? [])
+    )
     .describe(
       'A list of domains to specifically include in the search results. Default is None, which includes all domains.'
     ),
   exclude_domains: z
-    .array(z.string())
-    .nullish()
-    .transform(val => val ?? [])
+    .preprocess(
+      val => (typeof val === 'string' ? [val] : val),
+      z
+        .array(z.string())
+        .nullish()
+        .transform(val => val ?? [])
+    )
     .describe(
       "A list of domains to specifically exclude from the search results. Default is None, which doesn't exclude any domains."
     )


### PR DESCRIPTION
## Summary

AI models sometimes return `include_domains` / `exclude_domains` as a bare
string (e.g. `"reddit.com"`) instead of `string[]` (`["reddit.com"]`), causing
`TypeError: f.join is not a function` in `search-section.tsx`.

## Root cause

The Vercel AI SDK validates tool call inputs against the Zod schema on the
client side (`parse-tool-call.ts`). When the model sends a bare string where an
array is expected, Zod rejects it → the tool call is marked invalid. However,
the UI renders the tool call's **raw (unvalidated) input** regardless, so
`tool.input?.include_domains` is still the bare string, and `.join()` throws.

This can happen with ANY model — the AI SDK does not use `json_schema`
response format or `json_object` for tool calling (that is only for `generateObject` structured
output). There is no API-level enforcement of tool parameter types.

## Changes

Added `z.preprocess()` to coerce bare strings into single-element arrays for
`include_domains` and `exclude_domains` in both `searchSchema` and
`strictSearchSchema` (`lib/schema/search.tsx`).

```ts
z.preprocess(
  val => (typeof val === 'string' ? [val] : val),
  z.array(z.string()).nullish().transform(val => val ?? [])
)
This ensures Zod validation passes even when the model sends a bare string,
and the search tool actually applies the domain filter correctly.
Suggestion for a more fundamental fix
This issue can affect any array-typed field in any tool. Consider:
1. Enable strict: true on tools for providers that support it (OpenAI's
structured output for function calling). Pass strict: true in tool():
tool({ inputSchema, strict: true, ... })
This makes the API provider reject non-conforming types before the response
reaches the client.
2. Implement repairToolCall in the ToolLoopAgent configuration to
automatically fix type mismatches (e.g. wrap bare strings in arrays) and
retry failed tool calls, rather than silently marking them invalid.
3. Adopt a generic Zod preprocessor for all array-typed tool parameters
across the project, so each tool doesn't need its own ad-hoc coercion.