### PR TITLE
fix: handle bare string for include_domains/exclude_domains in Zod schema search tools

### DIFF
--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -63,7 +63,7 @@ export function SearchSection({
   const query = tool.input?.query || output?.query || ''
   const includeDomains = tool.input?.include_domains
   const includeDomainsString =
-    includeDomains && includeDomains.length > 0
+    Array.isArray(includeDomains) && includeDomains.length > 0
       ? ` [${includeDomains.join(', ')}]`
       : ''
 

--- a/lib/schema/search.tsx
+++ b/lib/schema/search.tsx
@@ -30,16 +30,22 @@ export const searchSchema = z.object({
       'The depth of the search. Allowed values are "basic" or "advanced"'
     ),
   include_domains: z
-    .array(z.string())
+    .union([z.string(), z.array(z.string())])
     .nullish()
-    .transform(val => val ?? [])
+    .transform(val => {
+      if (val == null) return []
+      return typeof val === 'string' ? [val] : val
+    })
     .describe(
       'A list of domains to specifically include in the search results. Default is None, which includes all domains.'
     ),
   exclude_domains: z
-    .array(z.string())
+    .union([z.string(), z.array(z.string())])
     .nullish()
-    .transform(val => val ?? [])
+    .transform(val => {
+      if (val == null) return []
+      return typeof val === 'string' ? [val] : val
+    })
     .describe(
       "A list of domains to specifically exclude from the search results. Default is None, which doesn't exclude any domains."
     )
@@ -59,16 +65,22 @@ export const strictSearchSchema = z.object({
     .enum(['basic', 'advanced'])
     .describe('The depth of the search'),
   include_domains: z
-    .array(z.string())
+    .union([z.string(), z.array(z.string())])
     .nullish()
-    .transform(val => val ?? [])
+    .transform(val => {
+      if (val == null) return []
+      return typeof val === 'string' ? [val] : val
+    })
     .describe(
       'A list of domains to specifically include in the search results. Default is None, which includes all domains.'
     ),
   exclude_domains: z
-    .array(z.string())
+    .union([z.string(), z.array(z.string())])
     .nullish()
-    .transform(val => val ?? [])
+    .transform(val => {
+      if (val == null) return []
+      return typeof val === 'string' ? [val] : val
+    })
     .describe(
       "A list of domains to specifically exclude from the search results. Default is None, which doesn't exclude any domains."
     )


### PR DESCRIPTION
## Summary

AI models sometimes return `include_domains` / `exclude_domains` as a bare
string (`"reddit.com"`) instead of `string[]` (`["reddit.com"]`), causing
`TypeError: f.join is not a function` in `search-section.tsx`.

This was observed with the Xiaomi MIMO v2.5 model (OpenAI-compatible
endpoint), which does not enforce `strict: true` on function definitions.
The model can therefore produce type-invalid tool call arguments, which
Zod rejects at validation time — but the AI SDK still renders the raw
(unvalidated) input in the UI.

## Changes

1. **`lib/schema/search.tsx`** — Replaced `z.array(z.string())` with
   `z.union([z.string(), z.array(z.string())])` + `.transform()` so that
   bare strings are coerced into single-element arrays at Zod validation
   time, preventing the tool call from being rejected. Applied to both
   `searchSchema` and `strictSearchSchema` for `include_domains` and
   `exclude_domains`.

2. **`components/search-section.tsx`** — Added `Array.isArray` guard
   before `.join()` as defense-in-depth.

## Suggestion

This type of mismatch can affect any array-typed tool parameter. Consider
enabling `strict: true` on tools for providers that support it, or
implementing `repairToolCall` in `ToolLoopAgent` to automatically fix and
retry failed tool calls.