### PR TITLE
feat(analytics): track overall chat limit checks

### DIFF
--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -12,6 +12,10 @@ export {
   trackAdaptiveLimitEvent
 } from './track-adaptive-limit-event'
 export { trackChatEvent } from './track-chat-event'
+export {
+  type ChatLimitEventData,
+  trackChatLimitEvent
+} from './track-chat-limit-event'
 export type {
   ChatEventData,
   QueryLang,

--- a/lib/analytics/track-chat-limit-event.ts
+++ b/lib/analytics/track-chat-limit-event.ts
@@ -1,0 +1,33 @@
+import { capture } from './dispatch'
+
+export interface ChatLimitEventData {
+  /** Outcome of the overall chat rate-limit check */
+  outcome: 'allowed' | 'blocked'
+  /** Authenticated Supabase user ID */
+  userId: string
+  /** Current daily usage count after the check (incl. this attempt) */
+  used: number
+  /** Effective daily limit at the time of the check */
+  limit: number
+}
+
+/**
+ * Track the overall (all-modes) per-user daily chat limit events.
+ *
+ * Fires on every authenticated request:
+ * - `outcome: "allowed"` while under the cap (with running counter), so we
+ *   can plot daily usage distribution and percentiles.
+ * - `outcome: "blocked"` when the request is denied, so we can monitor the
+ *   429 hit-rate over time and decide whether to relax / tighten the cap.
+ */
+export async function trackChatLimitEvent(
+  data: ChatLimitEventData
+): Promise<void> {
+  const { userId, outcome, used, limit } = data
+
+  await capture({
+    event: 'chat_limit_check',
+    distinctId: userId,
+    properties: { outcome, userId, used, limit }
+  })
+}

--- a/lib/rate-limit/chat-limits.ts
+++ b/lib/rate-limit/chat-limits.ts
@@ -1,5 +1,6 @@
 import { Redis } from '@upstash/redis'
 
+import { trackChatLimitEvent } from '@/lib/analytics'
 import { perfLog } from '@/lib/utils/perf-logging'
 
 const DEFAULT_DAILY_CHAT_LIMIT = 100
@@ -38,12 +39,23 @@ async function checkOverallChatLimit(userId: string): Promise<{
   remaining: number
   resetAt: number
   limit: number
+  /** Current daily usage count after the check (incl. this attempt) */
+  used: number
+  /** True when the check ran against Redis (i.e. enforced) */
+  enforced: boolean
 }> {
   const limit = getDailyChatLimit()
 
   // If not in cloud deployment mode, allow unlimited requests
   if (process.env.MORPHIC_CLOUD_DEPLOYMENT !== 'true') {
-    return { allowed: true, remaining: Infinity, resetAt: 0, limit }
+    return {
+      allowed: true,
+      remaining: Infinity,
+      resetAt: 0,
+      limit,
+      used: 0,
+      enforced: false
+    }
   }
 
   // If Upstash is not configured, allow unlimited requests
@@ -51,7 +63,14 @@ async function checkOverallChatLimit(userId: string): Promise<{
     !process.env.UPSTASH_REDIS_REST_URL ||
     !process.env.UPSTASH_REDIS_REST_TOKEN
   ) {
-    return { allowed: true, remaining: Infinity, resetAt: 0, limit }
+    return {
+      allowed: true,
+      remaining: Infinity,
+      resetAt: 0,
+      limit,
+      used: 0,
+      enforced: false
+    }
   }
 
   try {
@@ -82,11 +101,20 @@ async function checkOverallChatLimit(userId: string): Promise<{
       allowed: count <= limit,
       remaining,
       resetAt,
-      limit
+      limit,
+      used: count,
+      enforced: true
     }
   } catch (error) {
     console.error('Rate limit check failed:', error)
-    return { allowed: true, remaining: Infinity, resetAt: 0, limit }
+    return {
+      allowed: true,
+      remaining: Infinity,
+      resetAt: 0,
+      limit,
+      used: 0,
+      enforced: false
+    }
   }
 }
 
@@ -98,6 +126,18 @@ export async function checkAndEnforceOverallChatLimit(
   userId: string
 ): Promise<Response | null> {
   const result = await checkOverallChatLimit(userId)
+
+  // Only emit analytics for real (Redis-backed) checks. Local dev / cloud
+  // without Upstash returns enforced=false and we skip tracking to avoid
+  // polluting the dashboard with no-op events.
+  if (result.enforced) {
+    void trackChatLimitEvent({
+      outcome: result.allowed ? 'allowed' : 'blocked',
+      userId,
+      used: result.used,
+      limit: result.limit
+    })
+  }
 
   if (!result.allowed) {
     return new Response(


### PR DESCRIPTION
## Summary

The overall per-user daily chat limit is now configurable via env (#919), but its block rate is not observable anywhere. Unlike the adaptive limit, it emits no analytics event, so there is no way to tell whether a given cap is biting.

This adds a `chat_limit_check` event mirroring the existing `adaptive_limit_check`.

## Changes

- Add `lib/analytics/track-chat-limit-event.ts` (`chat_limit_check`, properties `outcome` / `userId` / `used` / `limit`), following the shape of `track-adaptive-limit-event.ts`
- Export it from `lib/analytics`
- Carry `used` and `enforced` on the overall limit check result and fire the event from `checkAndEnforceOverallChatLimit`

## Behavior

Fires on every authenticated request:

- `outcome: "allowed"` while under the cap, carrying the running counter, so daily usage distribution and percentiles are plottable
- `outcome: "blocked"` when the request is denied, so the 429 hit-rate can be monitored over time

Emitting the allowed arm as well is what makes the block rate a *rate*: without the denominator, a raw count of blocked requests is not interpretable.

Tracking is gated on `enforced`, i.e. the check actually ran against Redis. Self-hosted and local runs (no `MORPHIC_CLOUD_DEPLOYMENT=true`, or no Upstash) emit nothing, matching the adaptive limit.

## Testing

`bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test` (273 passed, 1 skipped) all pass.