### PR TITLE
fix(analytics): deliver rate-limit events via after()

### DIFF
--- a/lib/rate-limit/__tests__/adaptive-limit.test.ts
+++ b/lib/rate-limit/__tests__/adaptive-limit.test.ts
@@ -5,6 +5,14 @@ import { checkAndEnforceAdaptiveLimit } from '@/lib/rate-limit/adaptive-limit'
 const mockRedisIncr = vi.fn()
 const mockRedisExpire = vi.fn()
 const mockTrack = vi.fn()
+const mockAfter = vi.fn()
+
+// `after` throws outside a request scope, so stand in for the runtime and
+// run the task inline. Keeping it a spy also lets us assert that delivery
+// is handed to it rather than left floating.
+vi.mock('next/server', () => ({
+  after: (task: Promise<unknown>) => mockAfter(task)
+}))
 
 vi.mock('@upstash/redis', () => ({
   Redis: vi.fn().mockImplementation(function () {
@@ -25,6 +33,7 @@ describe('checkAndEnforceAdaptiveLimit', () => {
     mockRedisExpire.mockReset()
     mockTrack.mockReset()
     mockTrack.mockResolvedValue(undefined)
+    mockAfter.mockReset()
     process.env.MORPHIC_CLOUD_DEPLOYMENT = 'true'
     process.env.UPSTASH_REDIS_REST_URL = 'https://example.com'
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token'
@@ -136,6 +145,17 @@ describe('checkAndEnforceAdaptiveLimit', () => {
         limit: 30
       }
     })
+  })
+
+  it('hands blocked-event delivery to after so the 429 cannot cut it short', async () => {
+    mockRedisIncr.mockResolvedValue(31)
+    mockRedisExpire.mockResolvedValue(1)
+
+    const response = await checkAndEnforceAdaptiveLimit('user-9')
+
+    expect(response?.status).toBe(429)
+    expect(mockAfter).toHaveBeenCalledTimes(1)
+    expect(mockAfter.mock.calls[0][0]).toBeInstanceOf(Promise)
   })
 
   it('does not emit analytics when redis is unavailable (no enforcement)', async () => {

--- a/lib/rate-limit/adaptive-limit.ts
+++ b/lib/rate-limit/adaptive-limit.ts
@@ -1,3 +1,5 @@
+import { after } from 'next/server'
+
 import { Redis } from '@upstash/redis'
 
 import { trackAdaptiveLimitEvent } from '@/lib/analytics'
@@ -122,13 +124,21 @@ export async function checkAndEnforceAdaptiveLimit(
   // Only emit analytics for real (Redis-backed) checks. Local dev / cloud
   // without Upstash returns enforced=false and we skip tracking to avoid
   // polluting the dashboard with no-op events.
+  //
+  // Hand the capture to `after` rather than letting it float: the blocked
+  // path returns a 429 immediately, so an un-awaited PostHog flush can be
+  // cut short when the serverless runtime freezes. Allowed requests go on
+  // to a long-lived stream and would survive, which would bias the block
+  // rate downward exactly where it matters.
   if (result.enforced) {
-    void trackAdaptiveLimitEvent({
-      outcome: result.allowed ? 'allowed' : 'blocked',
-      userId,
-      used: result.used,
-      limit: result.limit
-    })
+    after(
+      trackAdaptiveLimitEvent({
+        outcome: result.allowed ? 'allowed' : 'blocked',
+        userId,
+        used: result.used,
+        limit: result.limit
+      })
+    )
   }
 
   if (!result.allowed) {

--- a/lib/rate-limit/chat-limits.ts
+++ b/lib/rate-limit/chat-limits.ts
@@ -1,3 +1,5 @@
+import { after } from 'next/server'
+
 import { Redis } from '@upstash/redis'
 
 import { trackChatLimitEvent } from '@/lib/analytics'
@@ -130,13 +132,21 @@ export async function checkAndEnforceOverallChatLimit(
   // Only emit analytics for real (Redis-backed) checks. Local dev / cloud
   // without Upstash returns enforced=false and we skip tracking to avoid
   // polluting the dashboard with no-op events.
+  //
+  // Hand the capture to `after` rather than letting it float: the blocked
+  // path returns a 429 immediately, so an un-awaited PostHog flush can be
+  // cut short when the serverless runtime freezes. Allowed requests go on
+  // to a long-lived stream and would survive, which would bias the block
+  // rate downward exactly where it matters.
   if (result.enforced) {
-    void trackChatLimitEvent({
-      outcome: result.allowed ? 'allowed' : 'blocked',
-      userId,
-      used: result.used,
-      limit: result.limit
-    })
+    after(
+      trackChatLimitEvent({
+        outcome: result.allowed ? 'allowed' : 'blocked',
+        userId,
+        used: result.used,
+        limit: result.limit
+      })
+    )
   }
 
   if (!result.allowed) {


### PR DESCRIPTION
## Summary

Both rate-limit checks captured their PostHog event with a floating promise and then returned a 429 straight away on the blocked path:

```ts
if (result.enforced) {
  void trackAdaptiveLimitEvent({ ... })
}

if (!result.allowed) {
  return new Response(/* 429 */)
}
```

`captureServerEvent` awaits a real network flush (the client is configured `flushAt: 1`, `flushInterval: 0`), so on a serverless runtime that flush can be cut short once the response is returned and the function freezes.

Allowed requests are not affected in the same way: they continue into the long-lived chat stream, which gives the flush time to land. **The loss is therefore concentrated on blocked events, biasing the block rate downward exactly where the metric is meant to be read.**

Reported by Codex review on #920.

## Changes

- Hand the capture to `after` from `next/server` in `checkAndEnforceOverallChatLimit` and `checkAndEnforceAdaptiveLimit`, so delivery is tied to the request lifetime without adding latency to the 429
- Mock `next/server` in the adaptive limit tests (`after` throws outside a request scope) and add a regression test asserting the blocked path hands delivery to `after`

## Scope

`chat_limit_check` shipped in #920, but `adaptive_limit_check` has carried the same pattern since it shipped, so both are fixed here. Adaptive block rates recorded before this change should be read as a lower bound rather than compared directly with later numbers.

## Testing

`bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test` (274 passed, 1 skipped) all pass.