### PR TITLE
Reduce title generation overhead

### DIFF
--- a/lib/agents/__tests__/title-generator.test.ts
+++ b/lib/agents/__tests__/title-generator.test.ts
@@ -23,7 +23,7 @@ describe('generateChatTitle', () => {
     } as never)
   })
 
-  it('disables reasoning and limits output for GPT-5.6 Luna', async () => {
+  it('disables reasoning without limiting output for GPT-5.6 Luna', async () => {
     await expect(
       generateChatTitle({
         userMessageContent: 'Explain the latest model changes',
@@ -33,13 +33,15 @@ describe('generateChatTitle', () => {
 
     expect(generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        maxOutputTokens: 32,
         providerOptions: {
           openai: {
             reasoningEffort: 'none'
           }
         }
       })
+    )
+    expect(vi.mocked(generateText).mock.calls[0][0]).not.toHaveProperty(
+      'maxOutputTokens'
     )
   })
 
@@ -51,9 +53,11 @@ describe('generateChatTitle', () => {
 
     expect(generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        maxOutputTokens: 32,
         providerOptions: undefined
       })
+    )
+    expect(vi.mocked(generateText).mock.calls[0][0]).not.toHaveProperty(
+      'maxOutputTokens'
     )
   })
 })

--- a/lib/agents/__tests__/title-generator.test.ts
+++ b/lib/agents/__tests__/title-generator.test.ts
@@ -1,0 +1,59 @@
+import { generateText } from 'ai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getModel } from '../../utils/registry'
+import { generateChatTitle } from '../title-generator'
+
+vi.mock('ai', () => ({
+  generateText: vi.fn()
+}))
+vi.mock('../../utils/registry', () => ({
+  getModel: vi.fn()
+}))
+vi.mock('../../utils/telemetry', () => ({
+  isTracingEnabled: vi.fn(() => false)
+}))
+
+describe('generateChatTitle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getModel).mockReturnValue({} as never)
+    vi.mocked(generateText).mockResolvedValue({
+      text: 'Concise title'
+    } as never)
+  })
+
+  it('disables reasoning and limits output for GPT-5.6 Luna', async () => {
+    await expect(
+      generateChatTitle({
+        userMessageContent: 'Explain the latest model changes',
+        modelId: 'openai:gpt-5.6-luna'
+      })
+    ).resolves.toBe('Concise title')
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 32,
+        providerOptions: {
+          openai: {
+            reasoningEffort: 'none'
+          }
+        }
+      })
+    )
+  })
+
+  it('does not send OpenAI options to other providers', async () => {
+    await generateChatTitle({
+      userMessageContent: 'Explain the latest model changes',
+      modelId: 'google:gemini-3.1-flash-lite'
+    })
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 32,
+        providerOptions: undefined
+      })
+    )
+  })
+})

--- a/lib/agents/title-generator.ts
+++ b/lib/agents/title-generator.ts
@@ -9,8 +9,6 @@ interface GenerateChatTitleParams {
   abortSignal?: AbortSignal
 }
 
-const TITLE_MAX_OUTPUT_TOKENS = 32
-
 function getTitleProviderOptions(modelId: string) {
   if (modelId === 'openai:gpt-5.6-luna') {
     return {
@@ -45,7 +43,6 @@ export async function generateChatTitle({
       system: systemPrompt,
       prompt: userMessageContent,
       abortSignal,
-      maxOutputTokens: TITLE_MAX_OUTPUT_TOKENS,
       providerOptions: getTitleProviderOptions(modelId),
       // Spans join the parent Langfuse trace via OTel context propagation
       experimental_telemetry: {

--- a/lib/agents/title-generator.ts
+++ b/lib/agents/title-generator.ts
@@ -9,6 +9,20 @@ interface GenerateChatTitleParams {
   abortSignal?: AbortSignal
 }
 
+const TITLE_MAX_OUTPUT_TOKENS = 32
+
+function getTitleProviderOptions(modelId: string) {
+  if (modelId === 'openai:gpt-5.6-luna') {
+    return {
+      openai: {
+        reasoningEffort: 'none' as const
+      }
+    }
+  }
+
+  return undefined
+}
+
 /**
  * Generates a concise chat title using an LLM.
  * @param userMessageContent The content of the user's first message.
@@ -31,6 +45,8 @@ export async function generateChatTitle({
       system: systemPrompt,
       prompt: userMessageContent,
       abortSignal,
+      maxOutputTokens: TITLE_MAX_OUTPUT_TOKENS,
+      providerOptions: getTitleProviderOptions(modelId),
       // Spans join the parent Langfuse trace via OTel context propagation
       experimental_telemetry: {
         isEnabled: isTracingEnabled(),


### PR DESCRIPTION
## Summary

- disable reasoning for GPT-5.6 Luna title generation
- cap title generation at 32 output tokens
- keep provider-specific options isolated from other models

## Validation

- lint, typecheck, and format checks
- production build
- 283 tests passed, 1 skipped
