### PR TITLE
fix(feedback): send Langfuse score once per feedback action

### DIFF
--- a/app/api/feedback/__tests__/route.test.ts
+++ b/app/api/feedback/__tests__/route.test.ts
@@ -90,6 +90,7 @@ describe('Feedback API Route', () => {
 
       expect(response.status).toBe(200)
       expect(text).toBe('Feedback recorded successfully')
+      expect(mockScoreCreate).toHaveBeenCalledTimes(1)
       expect(mockScoreCreate).toHaveBeenCalledWith({
         traceId: 'test-trace-id',
         name: 'user_feedback',

--- a/lib/actions/__tests__/feedback.test.ts
+++ b/lib/actions/__tests__/feedback.test.ts
@@ -3,13 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Mock the modules before any imports
 vi.mock('@/lib/db')
 vi.mock('@langfuse/client')
-vi.mock('@/lib/utils/telemetry')
 
 // Import after mocking
 import { LangfuseClient } from '@langfuse/client'
 
 import { db } from '@/lib/db'
-import { isTracingEnabled } from '@/lib/utils/telemetry'
 
 import { getMessageFeedback, updateMessageFeedback } from '../feedback'
 
@@ -39,9 +37,6 @@ describe('Feedback Actions', () => {
       const mockUpdateWhere = vi.fn().mockResolvedValue(undefined)
       const mockSet = vi.fn().mockReturnValue({ where: mockUpdateWhere })
       vi.mocked(db).update = vi.fn().mockReturnValue({ set: mockSet })
-
-      // Mock tracing disabled
-      vi.mocked(isTracingEnabled).mockReturnValue(false)
 
       const result = await updateMessageFeedback(messageId, score)
 
@@ -84,25 +79,10 @@ describe('Feedback Actions', () => {
       expect(result.error).toBe('Database error')
     })
 
-    it('should send feedback to Langfuse when tracing is enabled', async () => {
+    it('should not send a Langfuse score (the API route owns score submission)', async () => {
       const messageId = 'test-message-id'
       const chatId = 'test-chat-id'
       const score = 1
-
-      // Enable tracing
-      vi.mocked(isTracingEnabled).mockReturnValue(true)
-
-      // Mock LangfuseClient
-      const mockScoreCreate = vi.fn()
-      const mockFlush = vi.fn().mockResolvedValue(undefined)
-      vi.mocked(LangfuseClient).mockImplementation(function () {
-        return {
-          score: {
-            create: mockScoreCreate,
-            flush: mockFlush
-          }
-        } as any
-      } as any)
 
       // Mock db.select
       const mockLimit = vi.fn().mockResolvedValue([
@@ -123,14 +103,7 @@ describe('Feedback Actions', () => {
       const result = await updateMessageFeedback(messageId, score)
 
       expect(result).toEqual({ success: true })
-      expect(LangfuseClient).toHaveBeenCalled()
-      expect(mockScoreCreate).toHaveBeenCalledWith({
-        traceId: 'test-trace-id',
-        name: 'user-feedback',
-        value: score,
-        comment: 'Thumbs up'
-      })
-      expect(mockFlush).toHaveBeenCalled()
+      expect(LangfuseClient).not.toHaveBeenCalled()
     })
   })
 

--- a/lib/actions/feedback.ts
+++ b/lib/actions/feedback.ts
@@ -1,13 +1,11 @@
 'use server'
 
-import { LangfuseClient } from '@langfuse/client'
 import { eq } from 'drizzle-orm'
 
 import { db } from '@/lib/db'
 import { messages } from '@/lib/db/schema'
 import { withOptionalRLS } from '@/lib/db/with-rls'
 import type { UIMessageMetadata } from '@/lib/types/ai'
-import { isTracingEnabled } from '@/lib/utils/telemetry'
 
 export async function updateMessageFeedback(
   messageId: string,
@@ -43,28 +41,10 @@ export async function updateMessageFeedback(
         .set({ metadata: updatedMetadata })
         .where(eq(messages.id, messageId))
 
-      return { success: true, metadata: currentMessage.metadata }
+      return { success: true }
     })
 
-    if (!result.success) {
-      return result
-    }
-
-    // Send feedback to Langfuse if trace ID exists and tracing is enabled
-    const traceId = (result.metadata as UIMessageMetadata)?.traceId
-    if (traceId && isTracingEnabled()) {
-      const langfuse = new LangfuseClient()
-      langfuse.score.create({
-        traceId,
-        name: 'user-feedback',
-        value: score,
-        comment: score === 1 ? 'Thumbs up' : 'Thumbs down'
-      })
-      // Flush before the server action returns so the score is not lost
-      await langfuse.score.flush()
-    }
-
-    return { success: true }
+    return result
   } catch (error) {
     console.error('Error updating message feedback:', error)
     return {


### PR DESCRIPTION
## Summary

Message feedback (thumbs up/down) recorded two scores on the same Langfuse trace per action: the feedback API route sent `user_feedback`, then `updateMessageFeedback` sent `user-feedback` to the same traceId.

This PR unifies score submission in one place:

- The API route (`app/api/feedback/route.ts`) remains the single owner of Langfuse score submission, using the name `user_feedback`. It keeps the client-supplied comment and works for requests without `messageId`.
- `updateMessageFeedback` (`lib/actions/feedback.ts`) no longer creates a Langfuse score and is now a pure database update. Unused `LangfuseClient` and `isTracingEnabled` imports removed.

## Tests

- `lib/actions/__tests__/feedback.test.ts`: replaced the "sends to Langfuse when tracing enabled" test with a regression test asserting the action never calls Langfuse.
- `app/api/feedback/__tests__/route.test.ts`: added an assertion that `score.create` is called exactly once.

## Checks

- [x] bun lint
- [x] bun typecheck
- [x] bun format:check
- [x] bun run build
- [x] bun run test (283 passed, 1 skipped)