### PR TITLE
fix(streaming): log structural diagnostics for provider API errors

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -22,6 +22,7 @@ import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
 import { compactHistoricalMessages } from './helpers/compact-historical-messages'
 import { convertDataPart } from './helpers/convert-data-part'
+import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
 import { persistStreamResults } from './helpers/persist-stream-results'
 import { prepareMessages } from './helpers/prepare-messages'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
@@ -214,6 +215,7 @@ export async function createChatStreamResponse(
           }
         },
         onError: (error: unknown) => {
+          logAPICallErrorDiagnostics(error)
           console.error('Stream response error:', error)
           return serializePublicError(error)
         },
@@ -221,6 +223,7 @@ export async function createChatStreamResponse(
       })
     } catch (error) {
       await endTracing()
+      logAPICallErrorDiagnostics(error)
       console.error('Stream execution error:', error)
       return createPublicErrorResponse(error, {
         status: 500,

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -19,6 +19,7 @@ import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
 import { compactHistoricalMessages } from './helpers/compact-historical-messages'
 import { convertDataPart } from './helpers/convert-data-part'
+import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
 import { BaseStreamConfig } from './types'
 
@@ -112,6 +113,7 @@ export async function createEphemeralChatStreamResponse(
           await endTracing()
         },
         onError: (error: unknown) => {
+          logAPICallErrorDiagnostics(error)
           console.error('Ephemeral stream response error:', error)
           return serializePublicError(error)
         },
@@ -119,6 +121,7 @@ export async function createEphemeralChatStreamResponse(
       })
     } catch (error) {
       await endTracing()
+      logAPICallErrorDiagnostics(error)
       console.error('Ephemeral stream execution error:', error)
       return createPublicErrorResponse(error, {
         status: 500,

--- a/lib/streaming/helpers/__tests__/log-api-call-error.test.ts
+++ b/lib/streaming/helpers/__tests__/log-api-call-error.test.ts
@@ -52,9 +52,9 @@ describe('logAPICallErrorDiagnostics', () => {
     const output = consoleError.mock.calls.flat().join(' ')
     expect(output).toContain('"statusCode":400')
     expect(output).toContain('https://provider.example/v1/messages')
-    expect(output).toContain('"responseBody":"Invalid body"')
     expect(output).toContain('"topLevelKeys":["model","messages"]')
     expect(output).toContain('"totalSerializedSize":')
+    expect(output).toContain('"turnsKey":"messages"')
     expect(output).toContain('"role":"user"')
     expect(output).toContain('"type":"text"')
     expect(output).toContain('"type":"file"')
@@ -76,6 +76,66 @@ describe('logAPICallErrorDiagnostics', () => {
     const output = consoleError.mock.calls.flat().join(' ')
     expect(output).toContain('"topLevelKeys":["model","messages"]')
     expect(output).toContain('"role":"user"')
+  })
+
+  it('summarizes the response body without echoing its content', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const error = createAPICallError(
+      { messages: [{ role: 'user', content: 'hi' }] },
+      JSON.stringify({
+        error: {
+          type: 'invalid_request_error',
+          code: 'invalid_body',
+          message: 'Invalid body near "leaked secret fragment"'
+        }
+      })
+    )
+
+    logAPICallErrorDiagnostics(error)
+
+    const output = consoleError.mock.calls.flat().join(' ')
+    expect(output).toContain('"type":"invalid_request_error"')
+    expect(output).toContain('"code":"invalid_body"')
+    expect(output).toContain('"length":')
+    expect(output).not.toContain('leaked secret fragment')
+  })
+
+  it('summarizes turns for providers that do not use a messages key', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const error = createAPICallError({
+      model: 'provider-model',
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'private' }] }
+      ]
+    })
+
+    logAPICallErrorDiagnostics(error)
+
+    const output = consoleError.mock.calls.flat().join(' ')
+    expect(output).toContain('"turnsKey":"input"')
+    expect(output).toContain('"turnCount":1')
+    expect(output).toContain('"type":"input_text"')
+    expect(output).not.toContain('private')
+  })
+
+  it('summarizes google style contents with parts', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const error = createAPICallError({
+      contents: [{ role: 'user', parts: [{ text: 'private' }] }]
+    })
+
+    logAPICallErrorDiagnostics(error)
+
+    const output = consoleError.mock.calls.flat().join(' ')
+    expect(output).toContain('"turnsKey":"contents"')
+    expect(output).toContain('"turnCount":1')
+    expect(output).not.toContain('private')
   })
 
   it('truncates oversized diagnostics', () => {

--- a/lib/streaming/helpers/__tests__/log-api-call-error.test.ts
+++ b/lib/streaming/helpers/__tests__/log-api-call-error.test.ts
@@ -1,0 +1,98 @@
+import { APICallError } from 'ai'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { logAPICallErrorDiagnostics } from '../log-api-call-error'
+
+function createAPICallError(
+  requestBodyValues: unknown,
+  responseBody = 'Invalid body'
+) {
+  return new APICallError({
+    message: 'Invalid request',
+    url: 'https://provider.example/v1/messages',
+    requestBodyValues,
+    statusCode: 400,
+    responseBody
+  })
+}
+
+describe('logAPICallErrorDiagnostics', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('ignores non-API call errors without throwing', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    expect(() => logAPICallErrorDiagnostics(new Error('failure'))).not.toThrow()
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('logs API call details and a structural request summary', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const error = createAPICallError({
+      model: 'provider-model',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'private user message' },
+            { type: 'file', data: 'private file data' }
+          ]
+        }
+      ]
+    })
+
+    logAPICallErrorDiagnostics(error)
+
+    const output = consoleError.mock.calls.flat().join(' ')
+    expect(output).toContain('"statusCode":400')
+    expect(output).toContain('https://provider.example/v1/messages')
+    expect(output).toContain('"responseBody":"Invalid body"')
+    expect(output).toContain('"topLevelKeys":["model","messages"]')
+    expect(output).toContain('"totalSerializedSize":')
+    expect(output).toContain('"role":"user"')
+    expect(output).toContain('"type":"text"')
+    expect(output).toContain('"type":"file"')
+    expect(output).not.toContain('private user message')
+    expect(output).not.toContain('private file data')
+  })
+
+  it('keeps the request summary when the response body is long', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const error = createAPICallError(
+      { model: 'provider-model', messages: [{ role: 'user', content: 'hi' }] },
+      'x'.repeat(20_000)
+    )
+
+    logAPICallErrorDiagnostics(error)
+
+    const output = consoleError.mock.calls.flat().join(' ')
+    expect(output).toContain('"topLevelKeys":["model","messages"]')
+    expect(output).toContain('"role":"user"')
+  })
+
+  it('truncates oversized diagnostics', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const error = createAPICallError({
+      messages: Array.from({ length: 500 }, () => ({
+        role: 'user',
+        content: [{ type: 'text', text: 'content' }]
+      }))
+    })
+
+    logAPICallErrorDiagnostics(error)
+
+    const diagnostics = consoleError.mock.calls[0][1]
+    expect(diagnostics).toHaveLength(4000)
+    expect(diagnostics.endsWith('...[truncated]')).toBe(true)
+  })
+})

--- a/lib/streaming/helpers/log-api-call-error.ts
+++ b/lib/streaming/helpers/log-api-call-error.ts
@@ -1,7 +1,14 @@
 import { APICallError } from 'ai'
 
 const MAX_DIAGNOSTIC_LENGTH = 4000
-const MAX_RESPONSE_BODY_LENGTH = 1000
+
+// Providers name the turn array differently: chat completions use `messages`,
+// the OpenAI Responses API uses `input`, Google uses `contents`.
+const TURNS_KEYS = ['messages', 'input', 'contents']
+
+// Enumerated provider error fields only. The response body itself can echo
+// request fragments, so it is never logged here.
+const ERROR_FIELDS = ['type', 'code', 'param', 'status']
 
 function getSerializedSize(value: unknown): number | null {
   try {
@@ -59,21 +66,31 @@ function summarizeRequestBody(requestBodyValues: unknown) {
   }
 
   const topLevelKeys = Object.keys(requestBodyValues)
-  const messages = Reflect.get(requestBodyValues, 'messages')
+  const turnsKey = TURNS_KEYS.find(key =>
+    Array.isArray(Reflect.get(requestBodyValues, key))
+  )
+  const turns = turnsKey
+    ? (Reflect.get(requestBodyValues, turnsKey) as unknown[])
+    : undefined
 
   return {
     topLevelKeys,
     totalSerializedSize,
-    ...(Array.isArray(messages) && {
-      messageCount: messages.length,
-      messages: messages.map(message => {
-        if (message === null || typeof message !== 'object') {
-          return { role: 'unknown', content: summarizeContent(message) }
+    ...(turns && {
+      turnsKey,
+      turnCount: turns.length,
+      turns: turns.map(turn => {
+        if (turn === null || typeof turn !== 'object') {
+          return { role: 'unknown', content: summarizeContent(turn) }
         }
 
+        const content = Reflect.get(turn, 'content')
+
         return {
-          role: summarizeRole(Reflect.get(message, 'role')),
-          content: summarizeContent(Reflect.get(message, 'content'))
+          role: summarizeRole(Reflect.get(turn, 'role')),
+          content: summarizeContent(
+            content === undefined ? Reflect.get(turn, 'parts') : content
+          )
         }
       })
     })
@@ -85,6 +102,30 @@ function truncate(value: string, max = MAX_DIAGNOSTIC_LENGTH): string {
   return `${value.slice(0, max - 14)}...[truncated]`
 }
 
+function summarizeResponseBody(responseBody: unknown) {
+  if (typeof responseBody !== 'string') return { present: false }
+
+  const summary: Record<string, unknown> = { length: responseBody.length }
+
+  try {
+    const parsed = JSON.parse(responseBody)
+    const errorValue = Reflect.get(parsed, 'error')
+    const source =
+      errorValue !== null && typeof errorValue === 'object'
+        ? errorValue
+        : parsed
+
+    for (const field of ERROR_FIELDS) {
+      const value = Reflect.get(source, field)
+      if (typeof value === 'string' || typeof value === 'number') {
+        summary[field] = value
+      }
+    }
+  } catch {}
+
+  return summary
+}
+
 export function logAPICallErrorDiagnostics(error: unknown): void {
   try {
     if (!APICallError.isInstance(error)) return
@@ -93,10 +134,7 @@ export function logAPICallErrorDiagnostics(error: unknown): void {
       statusCode: error.statusCode,
       url: error.url,
       requestBody: summarizeRequestBody(error.requestBodyValues),
-      responseBody:
-        typeof error.responseBody === 'string'
-          ? truncate(error.responseBody, MAX_RESPONSE_BODY_LENGTH)
-          : error.responseBody
+      responseBody: summarizeResponseBody(error.responseBody)
     })
 
     console.error('Provider API call diagnostics:', truncate(diagnostics))

--- a/lib/streaming/helpers/log-api-call-error.ts
+++ b/lib/streaming/helpers/log-api-call-error.ts
@@ -1,0 +1,104 @@
+import { APICallError } from 'ai'
+
+const MAX_DIAGNOSTIC_LENGTH = 4000
+const MAX_RESPONSE_BODY_LENGTH = 1000
+
+function getSerializedSize(value: unknown): number | null {
+  try {
+    return JSON.stringify(value)?.length ?? 0
+  } catch {
+    return null
+  }
+}
+
+function getPartType(part: unknown): string {
+  if (typeof part === 'string') return 'text'
+  if (part === null || typeof part !== 'object') return typeof part
+
+  const type = Reflect.get(part, 'type')
+  return typeof type === 'string' ? type.slice(0, 64) : 'object'
+}
+
+function summarizeContent(content: unknown) {
+  const parts = Array.isArray(content) ? content : [content]
+
+  return parts.map(part => ({
+    type: getPartType(part),
+    length:
+      typeof part === 'string'
+        ? part.length
+        : (getSerializedSize(part) ?? 'unknown')
+  }))
+}
+
+function summarizeRole(role: unknown): string {
+  return role === 'system' ||
+    role === 'user' ||
+    role === 'assistant' ||
+    role === 'tool'
+    ? role
+    : 'unknown'
+}
+
+function summarizeRequestBody(requestBodyValues: unknown) {
+  const totalSerializedSize = getSerializedSize(requestBodyValues)
+
+  if (
+    requestBodyValues === null ||
+    typeof requestBodyValues !== 'object' ||
+    Array.isArray(requestBodyValues)
+  ) {
+    return {
+      type: Array.isArray(requestBodyValues)
+        ? 'array'
+        : requestBodyValues === null
+          ? 'null'
+          : typeof requestBodyValues,
+      totalSerializedSize
+    }
+  }
+
+  const topLevelKeys = Object.keys(requestBodyValues)
+  const messages = Reflect.get(requestBodyValues, 'messages')
+
+  return {
+    topLevelKeys,
+    totalSerializedSize,
+    ...(Array.isArray(messages) && {
+      messageCount: messages.length,
+      messages: messages.map(message => {
+        if (message === null || typeof message !== 'object') {
+          return { role: 'unknown', content: summarizeContent(message) }
+        }
+
+        return {
+          role: summarizeRole(Reflect.get(message, 'role')),
+          content: summarizeContent(Reflect.get(message, 'content'))
+        }
+      })
+    })
+  }
+}
+
+function truncate(value: string, max = MAX_DIAGNOSTIC_LENGTH): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max - 14)}...[truncated]`
+}
+
+export function logAPICallErrorDiagnostics(error: unknown): void {
+  try {
+    if (!APICallError.isInstance(error)) return
+
+    const diagnostics = JSON.stringify({
+      statusCode: error.statusCode,
+      url: error.url,
+      requestBody: summarizeRequestBody(error.requestBodyValues),
+      responseBody:
+        typeof error.responseBody === 'string'
+          ? truncate(error.responseBody, MAX_RESPONSE_BODY_LENGTH)
+          : error.responseBody
+    })
+
+    console.error('Provider API call diagnostics:', truncate(diagnostics))
+  } catch {}
+}


### PR DESCRIPTION
## Problem

Some chat turns fail at the first generation step: the provider rejects the streaming request with `Invalid body: failed to parse JSON value`. The turn produces no answer and is not retried. The rejected request body is never logged, so there is nothing to inspect and the failure cannot be diagnosed from traces alone.

## Root cause

Not yet identified, and that is exactly the problem this PR addresses. The AI SDK attaches the offending payload to `APICallError` as `requestBodyValues`, but both stream error paths only pass the error to `console.error`, which prints the provider message without the payload.

## Fix

Add `logAPICallErrorDiagnostics`, a helper that recognises an `APICallError` and logs:

- `statusCode` and `url`
- the provider `responseBody`, truncated
- a **structural** summary of `requestBodyValues`: top level keys, total serialized size, message count, and per message the role plus the type and size of each content part

The summary deliberately carries no message text. Roles, part types and sizes are enough to spot a malformed entry, and keeping content out means the logs cannot leak user input. The whole helper is wrapped so it never throws and never changes control flow, and the output is capped so a large payload cannot flood the logs. The request summary is serialized before the response body so a long provider response cannot truncate away the part that matters.

It is wired into both stream error paths in `create-chat-stream-response.ts` and `create-ephemeral-chat-stream-response.ts`, alongside the existing `console.error` calls. Return values and behaviour are unchanged; this is additive logging only.

This does not fix the underlying serialization failure. It makes the next occurrence diagnosable.

## Verification

- New unit tests cover: a non-`APICallError` logs nothing and does not throw; an `APICallError` logs status, url and a structural summary; raw message text from `requestBodyValues` does **not** appear in the output; an oversized payload is truncated; a long response body does not displace the request summary.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test` all pass (287 tests passed, 3 skipped).

Refs #927
