### PR TITLE
fix(streaming): mark the research span as ERROR when the stream fails

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -22,6 +22,7 @@ import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
 import { compactHistoricalMessages } from './helpers/compact-historical-messages'
 import { convertDataPart } from './helpers/convert-data-part'
+import { describeStreamError } from './helpers/describe-stream-error'
 import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
 import { persistStreamResults } from './helpers/persist-stream-results'
 import { prepareMessages } from './helpers/prepare-messages'
@@ -80,9 +81,17 @@ export async function createChatStreamResponse(
     // Real OTel trace ID, stored in message metadata so feedback scores can
     // be attached to this trace later
     const parentTraceId = rootSpan?.traceId
+    let hasStreamError = false
+    let streamError: unknown
 
     const endTracing = async () => {
       if (rootSpan) {
+        if (hasStreamError) {
+          rootSpan.update({
+            level: 'ERROR',
+            statusMessage: describeStreamError(streamError)
+          })
+        }
         rootSpan.end()
         await langfuseSpanProcessor.forceFlush()
       }
@@ -215,6 +224,8 @@ export async function createChatStreamResponse(
           }
         },
         onError: (error: unknown) => {
+          hasStreamError = true
+          streamError = error
           logAPICallErrorDiagnostics(error)
           console.error('Stream response error:', error)
           return serializePublicError(error)
@@ -222,6 +233,8 @@ export async function createChatStreamResponse(
         consumeSseStream: consumeStream
       })
     } catch (error) {
+      hasStreamError = true
+      streamError = error
       await endTracing()
       logAPICallErrorDiagnostics(error)
       console.error('Stream execution error:', error)

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -19,6 +19,7 @@ import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
 import { compactHistoricalMessages } from './helpers/compact-historical-messages'
 import { convertDataPart } from './helpers/convert-data-part'
+import { describeStreamError } from './helpers/describe-stream-error'
 import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
 import { BaseStreamConfig } from './types'
@@ -49,9 +50,17 @@ export async function createEphemeralChatStreamResponse(
     // Real OTel trace ID, sent to the client in message metadata so feedback
     // scores can be attached to this trace later
     const parentTraceId = rootSpan?.traceId
+    let hasStreamError = false
+    let streamError: unknown
 
     const endTracing = async () => {
       if (rootSpan) {
+        if (hasStreamError) {
+          rootSpan.update({
+            level: 'ERROR',
+            statusMessage: describeStreamError(streamError)
+          })
+        }
         rootSpan.end()
         await langfuseSpanProcessor.forceFlush()
       }
@@ -113,6 +122,8 @@ export async function createEphemeralChatStreamResponse(
           await endTracing()
         },
         onError: (error: unknown) => {
+          hasStreamError = true
+          streamError = error
           logAPICallErrorDiagnostics(error)
           console.error('Ephemeral stream response error:', error)
           return serializePublicError(error)
@@ -120,6 +131,8 @@ export async function createEphemeralChatStreamResponse(
         consumeSseStream: consumeStream
       })
     } catch (error) {
+      hasStreamError = true
+      streamError = error
       await endTracing()
       logAPICallErrorDiagnostics(error)
       console.error('Ephemeral stream execution error:', error)

--- a/lib/streaming/helpers/__tests__/describe-stream-error.test.ts
+++ b/lib/streaming/helpers/__tests__/describe-stream-error.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeStreamError } from '@/lib/streaming/helpers/describe-stream-error'
+
+describe('describeStreamError', () => {
+  it('describes a provider billing failure using the public code', () => {
+    const error = new Error(
+      JSON.stringify({
+        type: 'insufficient_quota',
+        code: 'credit_balance_exhausted',
+        message:
+          'You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.'
+      })
+    )
+
+    expect(describeStreamError(error)).toBe(
+      'provider_billing: The AI service is currently unavailable.'
+    )
+  })
+
+  it('does not expose the raw provider message', () => {
+    const error = new Error(
+      'insufficient_quota: credit_balance_exhausted for account secret-123'
+    )
+    const description = describeStreamError(error)
+
+    expect(description).toBe(
+      'provider_quota: The AI service is currently unavailable.'
+    )
+    expect(description).not.toContain('secret-123')
+  })
+
+  it('does not expose the message of an unclassified error', () => {
+    const description = describeStreamError(
+      new Error('Unexpected failure for user-content-456')
+    )
+
+    expect(description).toBe(
+      'unknown: We could not generate a response. Please try again.'
+    )
+    expect(description).not.toContain('user-content-456')
+  })
+
+  it('does not expose the contents of a non-Error value', () => {
+    const description = describeStreamError({
+      reason: 'provider response body credential-789',
+      requestId: 'private-request-id'
+    })
+
+    expect(description).not.toContain('credential-789')
+    expect(description).not.toContain('private-request-id')
+    expect(description.length).toBeGreaterThan(0)
+  })
+
+  it('caps a public message that is passed through verbatim', () => {
+    const error = JSON.stringify({
+      error: `Daily limit reached. ${'Please try again tomorrow. '.repeat(20)}TAIL-MARKER`,
+      code: 'rate_limit',
+      remaining: 0
+    })
+    const description = describeStreamError(error)
+
+    expect(description).toHaveLength(300)
+    expect(description.startsWith('rate_limit: Daily limit reached.')).toBe(
+      true
+    )
+    expect(description).not.toContain('TAIL-MARKER')
+  })
+})

--- a/lib/streaming/helpers/describe-stream-error.ts
+++ b/lib/streaming/helpers/describe-stream-error.ts
@@ -1,0 +1,11 @@
+import { toPublicErrorPayload } from '@/lib/errors/public-error'
+
+const MAX_STATUS_MESSAGE_LENGTH = 300
+
+// Only the public payload's code and message are used: that payload is already
+// sent to every client, so it carries no user content or credentials.
+export function describeStreamError(error: unknown): string {
+  const { code, error: message } = toPublicErrorPayload(error)
+
+  return `${code}: ${message}`.slice(0, MAX_STATUS_MESSAGE_LENGTH)
+}


### PR DESCRIPTION
## Problem

When the chat stream fails, the failure never reaches the tracing surface. The root `research` observation ends with `level: DEFAULT` and `statusMessage: null` even though the turn produced no answer at all.

This matters because tracing is the only surface that covers guest and ephemeral executions, and it is what gets scanned for error-level observations. A recent provider outage produced a large number of consecutive turns where every observation on the research path was recorded at `DEFAULT` with zero tokens and no output. The failure was only visible because `title-generation` runs through `generateText`, which throws and therefore does get recorded as an error. Had the chat path been the only caller, the outage would have produced no error-level observation whatsoever.

## Root cause

The provider error arrives as an error chunk inside the response stream rather than as a thrown exception, so the surrounding `try/catch` never runs and the request completes with HTTP 200. The `onError` callback passed to `toUIMessageStreamResponse` does fire, and it logs the error and serializes it for the client, but nothing marks the span. `endTracing()` then calls `rootSpan.end()` on an unmodified span.

## Fix

Capture the error in both entry points (`create-chat-stream-response.ts` and `create-ephemeral-chat-stream-response.ts`), from the stream `onError` callback and from the surrounding `catch`, and mark the root span with `level: 'ERROR'` plus a status message before it is ended.

The status message comes from a new `describeStreamError` helper that uses only the `code` and `error` fields of the existing public error payload. That payload is already sent to every client, so the trace cannot pick up user content, a provider response body, or credentials. The result is capped at 300 characters, which matters because some public payloads are passed through verbatim.

This is additive only. Response status codes, the serialized public error payload, and the existing logging are unchanged.

Client aborts are not affected: aborts travel as a distinct `abort` chunk and set `isAborted` on `onFinish`, so they never reach `onError` and will not be marked as errors.

## Verification

- New unit tests cover a provider billing failure, an unclassified `Error`, a non-Error value, and the length cap, asserting the exact resulting message and that raw input text never appears in it.
- `bun run test` 295 passed, `bun typecheck`, `bun lint`, `bun format:check` and `bun run build` all pass.
- The billing case is asserted against the exact error shape observed in production, which resolves to `provider_billing: The AI service is currently unavailable.`