### PR TITLE
fix(streaming): stop recoverable tool errors from failing the research trace

### DIFF
--- a/lib/agents/__tests__/tool-loop-agent-on-error.test.ts
+++ b/lib/agents/__tests__/tool-loop-agent-on-error.test.ts
@@ -1,0 +1,51 @@
+import type { StreamTextOnErrorCallback } from 'ai'
+import { ToolLoopAgent } from 'ai'
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('ToolLoopAgent onError forwarding', () => {
+  it('forwards onError to streamText', async () => {
+    const streamError = new Error('stream failed')
+    const onError = vi.fn()
+    const agent = new ToolLoopAgent({
+      model: new MockLanguageModelV3({
+        doStream: async () => ({
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              { type: 'error', error: streamError },
+              {
+                type: 'finish',
+                usage: {
+                  inputTokens: {
+                    total: 1,
+                    noCache: 1,
+                    cacheRead: 0,
+                    cacheWrite: 0
+                  },
+                  outputTokens: {
+                    total: 0,
+                    text: 0,
+                    reasoning: 0
+                  }
+                },
+                finishReason: { unified: 'error', raw: 'mock-error' }
+              }
+            ]
+          })
+        })
+      })
+    })
+
+    const result = await agent.stream({
+      messages: [{ role: 'user', content: 'hello' }],
+      onError
+    } as Parameters<typeof agent.stream>[0] & {
+      onError: StreamTextOnErrorCallback
+    })
+    await result.consumeStream()
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError).toHaveBeenCalledWith({ error: streamError })
+  })
+})

--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -1,18 +1,144 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const mocks = vi.hoisted(() => ({
+  stream: vi.fn(),
+  span: {
+    traceId: 'trace-id',
+    update: vi.fn(),
+    end: vi.fn()
+  },
+  forceFlush: vi.fn(),
+  finishPromise: Promise.resolve(),
+  serializedError: undefined as string | undefined
+}))
+
+vi.mock('ai', () => ({
+  consumeStream: vi.fn(),
+  convertToModelMessages: vi.fn(async () => []),
+  smoothStream: vi.fn()
+}))
+
+vi.mock('@langfuse/tracing', () => ({
+  propagateAttributes: vi.fn((_attributes: unknown, callback: () => unknown) =>
+    callback()
+  ),
+  startActiveObservation: vi.fn(
+    (_name: string, callback: (span: typeof mocks.span) => unknown) =>
+      callback(mocks.span)
+  )
+}))
+
+vi.mock('@/instrumentation', () => ({
+  langfuseSpanProcessor: {
+    forceFlush: mocks.forceFlush
+  }
+}))
+
+vi.mock('@/lib/agents/researcher', () => ({
+  researcher: vi.fn(() => ({ stream: mocks.stream }))
+}))
+
+vi.mock('@/lib/utils/telemetry', () => ({
+  isTracingEnabled: vi.fn(() => true)
+}))
+
+vi.mock('@/lib/utils/usage-logging', () => ({
+  isUsageLogging: vi.fn(() => false),
+  logUsage: vi.fn()
+}))
+
+import { serializePublicError } from '@/lib/errors/public-error'
 import { createEphemeralChatStreamResponse } from '@/lib/streaming/create-ephemeral-chat-stream-response'
+import { describeStreamError } from '@/lib/streaming/helpers/describe-stream-error'
+
+type StreamOptions = {
+  onError: (event: { error: unknown }) => void
+}
+
+type UIMessageStreamResponseOptions = {
+  onError: (error: unknown) => string
+  onFinish: () => Promise<void>
+}
+
+function createFakeResult(toolError?: unknown) {
+  return {
+    consumeStream: vi.fn(),
+    toUIMessageStreamResponse: vi.fn(
+      (options: UIMessageStreamResponseOptions) => {
+        if (toolError) {
+          mocks.serializedError = options.onError(toolError)
+        }
+        mocks.finishPromise = options.onFinish()
+        return new Response()
+      }
+    )
+  }
+}
+
+function createConfig() {
+  return {
+    messages: [
+      {
+        id: 'message-id',
+        role: 'user' as const,
+        parts: [{ type: 'text' as const, text: 'hello' }]
+      }
+    ],
+    model: { providerId: 'openai', id: 'gpt-4o-mini' } as any,
+    abortSignal: new AbortController().signal,
+    searchMode: 'quick' as const
+  }
+}
 
 describe('createEphemeralChatStreamResponse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.finishPromise = Promise.resolve()
+    mocks.serializedError = undefined
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
   it('returns 400 when messages are missing', async () => {
     const response = await createEphemeralChatStreamResponse({
-      messages: [],
-      model: { providerId: 'openai', id: 'gpt-4o-mini' } as any,
-      abortSignal: new AbortController().signal,
-      searchMode: 'quick'
+      ...createConfig(),
+      messages: []
     })
 
     expect(response.status).toBe(400)
     const text = await response.text()
     expect(text).toBe('messages are required')
+  })
+
+  it('does not mark the span as failed for a tool error', async () => {
+    const toolError = Object.assign(new Error('HTTP 403: Forbidden'), {
+      statusCode: 403
+    })
+    mocks.stream.mockResolvedValue(createFakeResult(toolError))
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.serializedError).toBe(serializePublicError(toolError))
+    expect(mocks.span.update).not.toHaveBeenCalled()
+    expect(mocks.span.end).toHaveBeenCalledOnce()
+    expect(mocks.forceFlush).toHaveBeenCalledOnce()
+  })
+
+  it('marks the span as failed for a stream-level error', async () => {
+    const streamError = new Error('stream failed')
+    mocks.stream.mockImplementation(async (options: StreamOptions) => {
+      options.onError({ error: streamError })
+      return createFakeResult()
+    })
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      level: 'ERROR',
+      statusMessage: describeStreamError(streamError)
+    })
+    expect(mocks.span.end).toHaveBeenCalledOnce()
+    expect(mocks.forceFlush).toHaveBeenCalledOnce()
   })
 })

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -1,5 +1,6 @@
 import type { LangfuseSpan } from '@langfuse/tracing'
 import { propagateAttributes, startActiveObservation } from '@langfuse/tracing'
+import type { StreamTextOnErrorCallback } from 'ai'
 import { consumeStream, convertToModelMessages, smoothStream } from 'ai'
 
 import { researcher } from '@/lib/agents/researcher'
@@ -168,9 +169,15 @@ export async function createChatStreamResponse(
       perfLog(
         `researchAgent.stream - Start: model=${context.modelId}, searchMode=${searchMode}`
       )
+      // AgentStreamParameters omits onError, but it reaches streamText where only
+      // stream errors, not recoverable tool errors, invoke it.
       const result = await researchAgent.stream({
         messages: modelMessages,
         abortSignal,
+        onError: ({ error }) => {
+          hasStreamError = true
+          streamError = error
+        },
         experimental_transform: smoothStream({ chunking: 'word' }),
         ...(isUsageLogging() && {
           onStepFinish: step => {
@@ -181,6 +188,8 @@ export async function createChatStreamResponse(
             )
           }
         })
+      } as Parameters<typeof researchAgent.stream>[0] & {
+        onError: StreamTextOnErrorCallback
       })
       result.consumeStream()
 
@@ -226,8 +235,6 @@ export async function createChatStreamResponse(
           }
         },
         onError: (error: unknown) => {
-          hasStreamError = true
-          streamError = error
           logAPICallErrorDiagnostics(error)
           console.error('Stream response error:', error)
           return serializePublicError(error)

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -1,6 +1,6 @@
 import type { LangfuseSpan } from '@langfuse/tracing'
 import { propagateAttributes, startActiveObservation } from '@langfuse/tracing'
-import type { UIMessage } from 'ai'
+import type { StreamTextOnErrorCallback, UIMessage } from 'ai'
 import { consumeStream, convertToModelMessages, smoothStream } from 'ai'
 
 import { researcher } from '@/lib/agents/researcher'
@@ -88,9 +88,15 @@ export async function createEphemeralChatStreamResponse(
       })
 
       const modelId = `${model.providerId}:${model.id}`
+      // AgentStreamParameters omits onError, but it reaches streamText where only
+      // stream errors, not recoverable tool errors, invoke it.
       const result = await researchAgent.stream({
         messages: modelMessages,
         abortSignal,
+        onError: ({ error }) => {
+          hasStreamError = true
+          streamError = error
+        },
         experimental_transform: smoothStream({ chunking: 'word' }),
         ...(isUsageLogging() && {
           onStepFinish: step => {
@@ -101,6 +107,8 @@ export async function createEphemeralChatStreamResponse(
             )
           }
         })
+      } as Parameters<typeof researchAgent.stream>[0] & {
+        onError: StreamTextOnErrorCallback
       })
       result.consumeStream()
 
@@ -124,8 +132,6 @@ export async function createEphemeralChatStreamResponse(
           await endTracing()
         },
         onError: (error: unknown) => {
-          hasStreamError = true
-          streamError = error
           logAPICallErrorDiagnostics(error)
           console.error('Ephemeral stream response error:', error)
           return serializePublicError(error)


### PR DESCRIPTION
## Problem

The root `research` span is marked `level=ERROR` whenever a single tool call fails, even though the agent loop recovers from it, the answer streams to the user, and the assistant message persists with full content. Observed signatures over a recent 24h window in production tracing: `fetch` raising `HTTP 403: Forbidden`, `HTTP 404: Not Found`, `HTTP 429: Too Many Requests`, `Unsupported content type: ...`, and `search` raising `Search failed`. Every root-span error in that window was one of these, and each corresponding chat has a complete persisted answer.

The failure-rate signal added in #930 is therefore dominated by false positives, and a real streaming failure cannot be told apart from an external site refusing our crawler.

## Root cause

`lib/streaming/create-chat-stream-response.ts` and `lib/streaming/create-ephemeral-chat-stream-response.ts` flip `hasStreamError` inside the `onError` callback given to `result.toUIMessageStreamResponse(...)`.

That callback is invoked for two different chunk types in the AI SDK:

- the `error` chunk, which is a genuine stream failure
- the `tool-error` chunk, which is a per tool call failure the loop recovers from, and whose text is rendered on the tool card

So a recoverable tool failure sets the stream failure flag, and `endTracing()` then stamps the whole trace as failed. It also picks the status message from a whole-app error classifier, which is why an external site answering 403 ends up described as a permission problem.

## Fix

Detect stream failures at the `streamText` level instead. `streamText` has its own `onError` option, which runs only for the `error` chunk, and `ToolLoopAgent.stream()` forwards the option through to it.

- pass `onError` to `researchAgent.stream({ ... })` in both streaming entry points, and set `hasStreamError` / `streamError` there
- the `toUIMessageStreamResponse` callback no longer touches those flags; it keeps calling `logAPICallErrorDiagnostics`, keeps its `console.error`, and keeps returning the serialized public error payload, so nothing changes for the client
- the outer `try/catch`, which covers failures before the stream starts, is unchanged

Known trade-off: errors originating inside the UI message stream conversion itself, rather than in the model stream, no longer mark the span. They are still logged. Everything the model stream emits still passes through `streamText` first, so provider failures remain covered.

`AgentStreamParameters` does not declare `onError`, hence the cast at each call site. A contract test pins the forwarding behavior so an SDK upgrade that drops it fails loudly instead of silently disabling failure tracing.

## Verification

- `lib/agents/__tests__/tool-loop-agent-on-error.test.ts`: builds a real `ToolLoopAgent` over `MockLanguageModelV3`, emits an `error` chunk, and asserts the `onError` passed to `agent.stream()` receives it. No network.
- `lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts`: a tool error routed through the UI stream callback no longer updates the span and still returns the serialized public payload; a stream level error marks the span ERROR with the described message.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (312 passed, 3 skipped), `bun run build` all pass locally.