### PR TITLE
fix(streaming): mark the research span when the answer is empty

### DIFF
--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -50,6 +50,7 @@ vi.mock('@/lib/utils/usage-logging', () => ({
 import { serializePublicError } from '@/lib/errors/public-error'
 import { createEphemeralChatStreamResponse } from '@/lib/streaming/create-ephemeral-chat-stream-response'
 import { describeStreamError } from '@/lib/streaming/helpers/describe-stream-error'
+import { EMPTY_RESPONSE_STATUS_MESSAGE } from '@/lib/streaming/helpers/is-empty-response'
 
 type StreamOptions = {
   onError: (event: { error: unknown }) => void
@@ -57,10 +58,25 @@ type StreamOptions = {
 
 type UIMessageStreamResponseOptions = {
   onError: (error: unknown) => string
-  onFinish: () => Promise<void>
+  onFinish: (event: {
+    responseMessage: {
+      id: string
+      role: 'assistant'
+      parts: Array<{ type: string; text?: string }>
+    }
+    isAborted: boolean
+  }) => Promise<void>
 }
 
-function createFakeResult(toolError?: unknown) {
+function createFakeResult({
+  toolError,
+  parts = [{ type: 'text', text: 'Answer' }],
+  isAborted = false
+}: {
+  toolError?: unknown
+  parts?: Array<{ type: string; text?: string }>
+  isAborted?: boolean
+} = {}) {
   return {
     consumeStream: vi.fn(),
     toUIMessageStreamResponse: vi.fn(
@@ -68,7 +84,14 @@ function createFakeResult(toolError?: unknown) {
         if (toolError) {
           mocks.serializedError = options.onError(toolError)
         }
-        mocks.finishPromise = options.onFinish()
+        mocks.finishPromise = options.onFinish({
+          responseMessage: {
+            id: 'response-id',
+            role: 'assistant',
+            parts
+          },
+          isAborted
+        })
         return new Response()
       }
     )
@@ -113,7 +136,7 @@ describe('createEphemeralChatStreamResponse', () => {
     const toolError = Object.assign(new Error('HTTP 403: Forbidden'), {
       statusCode: 403
     })
-    mocks.stream.mockResolvedValue(createFakeResult(toolError))
+    mocks.stream.mockResolvedValue(createFakeResult({ toolError }))
 
     await createEphemeralChatStreamResponse(createConfig())
     await mocks.finishPromise
@@ -140,5 +163,54 @@ describe('createEphemeralChatStreamResponse', () => {
     })
     expect(mocks.span.end).toHaveBeenCalledOnce()
     expect(mocks.forceFlush).toHaveBeenCalledOnce()
+  })
+
+  it('marks the span as failed for an empty response', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult({ parts: [] }))
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      level: 'ERROR',
+      statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
+    })
+  })
+
+  it('does not update the span for a response with text', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).not.toHaveBeenCalled()
+  })
+
+  it('does not update the span for an aborted turn', async () => {
+    mocks.stream.mockResolvedValue(
+      createFakeResult({ parts: [], isAborted: true })
+    )
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).not.toHaveBeenCalled()
+  })
+
+  it('preserves the stream error when the response is empty', async () => {
+    const streamError = new Error('stream failed')
+    mocks.stream.mockImplementation(async (options: StreamOptions) => {
+      options.onError({ error: streamError })
+      return createFakeResult({ parts: [] })
+    })
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledOnce()
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      level: 'ERROR',
+      statusMessage: describeStreamError(streamError)
+    })
   })
 })

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -25,6 +25,10 @@ import { compactHistoricalMessages } from './helpers/compact-historical-messages
 import { convertDataPart } from './helpers/convert-data-part'
 import { assignDataPartNonces } from './helpers/data-part-nonce'
 import { describeStreamError } from './helpers/describe-stream-error'
+import {
+  EMPTY_RESPONSE_STATUS_MESSAGE,
+  isEmptyResponse
+} from './helpers/is-empty-response'
 import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
 import { persistStreamResults } from './helpers/persist-stream-results'
 import { prepareMessages } from './helpers/prepare-messages'
@@ -84,6 +88,7 @@ export async function createChatStreamResponse(
     // be attached to this trace later
     const parentTraceId = rootSpan?.traceId
     let hasStreamError = false
+    let hasEmptyResponse = false
     let streamError: unknown
 
     const endTracing = async () => {
@@ -92,6 +97,11 @@ export async function createChatStreamResponse(
           rootSpan.update({
             level: 'ERROR',
             statusMessage: describeStreamError(streamError)
+          })
+        } else if (hasEmptyResponse) {
+          rootSpan.update({
+            level: 'ERROR',
+            statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
           })
         }
         rootSpan.end()
@@ -217,6 +227,8 @@ export async function createChatStreamResponse(
           try {
             perfTime('researchAgent.stream completed', llmStart)
             if (isAborted || !responseMessage) return
+
+            hasEmptyResponse = isEmptyResponse(responseMessage)
 
             // Persist stream results to database
             await persistStreamResults(

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -21,6 +21,10 @@ import { compactHistoricalMessages } from './helpers/compact-historical-messages
 import { convertDataPart } from './helpers/convert-data-part'
 import { assignDataPartNonces } from './helpers/data-part-nonce'
 import { describeStreamError } from './helpers/describe-stream-error'
+import {
+  EMPTY_RESPONSE_STATUS_MESSAGE,
+  isEmptyResponse
+} from './helpers/is-empty-response'
 import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
 import { BaseStreamConfig } from './types'
@@ -52,6 +56,7 @@ export async function createEphemeralChatStreamResponse(
     // scores can be attached to this trace later
     const parentTraceId = rootSpan?.traceId
     let hasStreamError = false
+    let hasEmptyResponse = false
     let streamError: unknown
 
     const endTracing = async () => {
@@ -60,6 +65,11 @@ export async function createEphemeralChatStreamResponse(
           rootSpan.update({
             level: 'ERROR',
             statusMessage: describeStreamError(streamError)
+          })
+        } else if (hasEmptyResponse) {
+          rootSpan.update({
+            level: 'ERROR',
+            statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
           })
         }
         rootSpan.end()
@@ -128,7 +138,10 @@ export async function createEphemeralChatStreamResponse(
             }
           }
         },
-        onFinish: async () => {
+        onFinish: async ({ responseMessage, isAborted }) => {
+          if (!isAborted && responseMessage) {
+            hasEmptyResponse = isEmptyResponse(responseMessage)
+          }
           await endTracing()
         },
         onError: (error: unknown) => {

--- a/lib/streaming/helpers/__tests__/is-empty-response.test.ts
+++ b/lib/streaming/helpers/__tests__/is-empty-response.test.ts
@@ -1,0 +1,55 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { isEmptyResponse } from '@/lib/streaming/helpers/is-empty-response'
+
+function createResponseMessage(parts: UIMessage['parts']): UIMessage {
+  return {
+    id: 'response-id',
+    role: 'assistant',
+    parts
+  }
+}
+
+describe('isEmptyResponse', () => {
+  it('returns false for a text part with content', () => {
+    expect(
+      isEmptyResponse(createResponseMessage([{ type: 'text', text: 'Answer' }]))
+    ).toBe(false)
+  })
+
+  it('returns true when there are no parts', () => {
+    expect(isEmptyResponse(createResponseMessage([]))).toBe(true)
+  })
+
+  it('returns true for tool-only parts', () => {
+    expect(
+      isEmptyResponse(
+        createResponseMessage([
+          {
+            type: 'dynamic-tool',
+            toolName: 'search',
+            toolCallId: 'tool-call-id',
+            state: 'output-available',
+            input: {},
+            output: {}
+          }
+        ])
+      )
+    ).toBe(true)
+  })
+
+  it('returns true for reasoning-only parts', () => {
+    expect(
+      isEmptyResponse(
+        createResponseMessage([{ type: 'reasoning', text: 'Thinking' }])
+      )
+    ).toBe(true)
+  })
+
+  it('returns true for whitespace-only text', () => {
+    expect(
+      isEmptyResponse(createResponseMessage([{ type: 'text', text: ' \n\t ' }]))
+    ).toBe(true)
+  })
+})

--- a/lib/streaming/helpers/is-empty-response.ts
+++ b/lib/streaming/helpers/is-empty-response.ts
@@ -1,0 +1,10 @@
+import type { UIMessage } from 'ai'
+
+export const EMPTY_RESPONSE_STATUS_MESSAGE =
+  'empty_response: The model returned no answer text.'
+
+export function isEmptyResponse(responseMessage: UIMessage): boolean {
+  return !responseMessage.parts.some(
+    part => part.type === 'text' && part.text.trim().length > 0
+  )
+}


### PR DESCRIPTION
Refs #936

## Problem

A chat turn that streams successfully but produces no answer text ends the root `research` span at `DEFAULT` level with no error, so nothing in tracing separates "the model answered" from "the model answered with nothing".

This is the failure shape that hurts most during an incident. When a provider stops serving, streams still complete and the traces look structurally normal, and the emptiness is only recoverable afterwards by counting persisted assistant messages that carry no text part. Guest turns are not persisted at all, so for them the signal does not exist anywhere.

#930 marked the span when the stream fails, and #934 narrowed that marker to mean exactly that. An empty but successful stream was the remaining hole.

## Root cause

`lib/streaming/create-chat-stream-response.ts` and `lib/streaming/create-ephemeral-chat-stream-response.ts` only ever update the span level from the stream error path. The `onFinish` callback of `toUIMessageStreamResponse` receives the finished `responseMessage` and passes it straight to persistence without inspecting whether it holds any answer text. The ephemeral path did not even destructure it.

## Fix

- new helper `lib/streaming/helpers/is-empty-response.ts`: a response is empty when no part of type `text` has non-whitespace content, so tool-only and reasoning-only responses count as empty. It also owns the span status string, formatted like `describeStreamError` output (`empty_response: ...`).
- both streaming entry points track the empty case in `onFinish` and mark the span `ERROR` with that status in `endTracing`.
- a real stream error keeps precedence: its own status message is what lands on the span.
- aborted turns are not marked.
- the ephemeral `onFinish` now takes the same `{ responseMessage, isAborted }` shape as the authenticated one.

Tracing only. Persistence, the error callbacks, the tools and the UI are untouched.

## Verification

- `lib/streaming/helpers/__tests__/is-empty-response.test.ts`: text with content is not empty; no parts, tool-only, reasoning-only and whitespace-only text are empty.
- `lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts`: an empty response marks the span with the empty-response status; a response with text does not update the span; an aborted turn does not update the span; a stream error still wins when the response is also empty.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (321 passed, 3 skipped), `bun run build` all pass locally.

Note for review: the open choices listed in #936 were resolved as zero text parts (rather than a length threshold), aborted turns excluded, and `ERROR` level rather than a warning, so that the daily error scan picks it up. Any of the three is easy to change.