### PR TITLE
fix(prompts): keep spec fences out of the worked answer example

### DIFF
--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -1,5 +1,4 @@
 import {
-  EXAMPLE_IMAGE_SPEC_BLOCK,
   getImageSpecPrompt,
   getRelatedQuestionsSpecPrompt
 } from '@/lib/render/prompt'
@@ -148,8 +147,6 @@ Example approach:
 ### Core Information
 - **Key Point:** Direct answer with specific data/numbers when available [1](#EXAMPLE_TOOL_CALL_ID_1)
 - **Detail:** Supporting information with concrete examples [2](#EXAMPLE_TOOL_CALL_ID_1)
-
-${EXAMPLE_IMAGE_SPEC_BLOCK}
 
 ### When Comparing (use table format)
 | Feature | Option A | Option B |
@@ -334,8 +331,6 @@ Flexible example:
 ### Primary Information
 - **Core Answer:** Direct response with evidence [1](#EXAMPLE_TOOL_CALL_ID_1)
 - **Context:** Relevant supporting details
-
-${EXAMPLE_IMAGE_SPEC_BLOCK}
 
 Conclude with a brief synthesis that ties together the main insights into a clear overall understanding.
 

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -55,13 +55,23 @@ describe('render prompts', () => {
     expect(getAdaptiveModePrompt()).toContain('result order within each search')
   })
 
-  test.each([getQuickModePrompt, getAdaptiveModePrompt])(
-    'includes the canonical image block in the worked example',
-    getPrompt => {
+  test.each([
+    [getQuickModePrompt, 'Example approach:'],
+    [getAdaptiveModePrompt, 'Flexible example:']
+  ])(
+    'keeps spec fences out of the worked answer example',
+    (getPrompt, marker) => {
       const prompt = getPrompt()
+      const workedExample = prompt.slice(
+        prompt.indexOf(marker),
+        prompt.indexOf('INLINE IMAGE EMBEDDING:')
+      )
 
-      expect(prompt).toContain(EXAMPLE_IMAGE_SPEC_BLOCK)
-      expect(prompt.split(EXAMPLE_IMAGE_SPEC_BLOCK)).toHaveLength(3)
+      // The worked example shows a complete answer body. A spec fence inside
+      // it makes it a finished answer that ends without the related-questions
+      // block, which suppresses that block instead of teaching it.
+      expect(workedExample).not.toContain('```spec')
+      expect(prompt.split(EXAMPLE_IMAGE_SPEC_BLOCK)).toHaveLength(2)
     }
   )
 


### PR DESCRIPTION
## Problem

Since #938 deployed, the related questions ```spec block is emitted far less often, in both quick and adaptive mode. The image spec emission that #938 targeted did not move at all, so the change traded a large regression on one GenUI block for no gain on the other.

The drop is not a population or query-mix effect:

- Restricted to the set of users active both before and after the deploy, adaptive related emission still falls sharply. So it is not turnover in who is using the product.
- Split by script of the answer text, it falls uniformly: Latin, Cyrillic and CJK all drop from comparable pre-deploy levels and converge on a common, much lower post-deploy value. Three populations with different query mixes landing on the same value is the signature of a global prompt change rather than a shift in traffic.
- Hourly on calendar UTC, the post-deploy day is uniformly depressed rather than trending within the day.

## Root cause

Both mode prompts end with a worked answer skeleton (`Example approach:` in quick, `Flexible example:` in adaptive) that shows a complete answer body. #938 inserted `EXAMPLE_IMAGE_SPEC_BLOCK` into both skeletons, reasoning that the skeleton was a negative example for images: image blocks belong inside the body the skeleton fully specifies, while the related block sits after the body and so was never shown as absent.

Inserting the block made that reasoning apply to related questions instead. `getRelatedQuestionsSpecPrompt()` states the related fence must appear at the END of the response. Once the skeleton contains a spec fence and runs through to its concluding sentence, it reads as a finished answer that ends without a related block. The skeleton stopped being neutral about the related block and started demonstrating its absence.

This explains the shape of the data: related down sharply, image flat (the model already had the image instruction, and showing it mid-skeleton adds no pressure), and both modes affected, since both skeletons were changed.

## Fix

Remove `EXAMPLE_IMAGE_SPEC_BLOCK` from both worked answer skeletons. It stays in `getImageSpecPrompt()`, where it illustrates the image instruction without closing out an answer.

Deliberately kept from #938:

- The `EXAMPLE_` placeholder ids. They fixed a real leak, where realistic looking example ids were transcribed into answers and rendered as unresolvable citations.
- The non-web `src` guard in `lib/render/components/image.tsx`.
- The image section's own restructured example.

Keeping those isolates the change to the single element that explains the regression.

## Verification

- `bun lint`, `bun typecheck`, `bun format:check` clean; `bun run test` passes with no failures.
- The existing test asserted the block appeared twice per prompt. It is replaced by one that encodes the invariant this regression violated: the worked example region contains no ```spec fence, and the block occurs exactly once in the prompt. Both assertions fail if the block is put back into a skeleton.
- Local `bun run build` compiles and passes TypeScript; page data collection needs `DATABASE_URL`, which is not set in this sandbox, so the build gate is left to CI.

Expected effect: related emission returns to its pre-#938 level in both modes, image emission unchanged. Both are tracked internally.

Refs #929
