### PR TITLE
fix(storage): treat a blank signing window as unset, not as disabled

### DIFF
--- a/lib/storage/__tests__/r2-client.test.ts
+++ b/lib/storage/__tests__/r2-client.test.ts
@@ -221,6 +221,19 @@ describe('R2 client', () => {
       expect(signingDateOf(0)).toEqual(new Date('2026-08-05T14:24:30.000Z'))
     })
 
+    it('keeps the default when the window is defined but blank', async () => {
+      // Number('') is 0, which would silently turn the window off while looking
+      // configured. Templated environments define variables as '' routinely.
+      process.env.R2_SIGNED_URL_STABILITY_WINDOW_SECONDS = '   '
+
+      const { getSignedFileUrl } = await importR2Client()
+
+      vi.setSystemTime(new Date('2026-08-05T14:24:33.000Z'))
+      await getSignedFileUrl('user-id/file.png')
+
+      expect(signingDateOf(0)).toEqual(new Date('2026-08-05T14:15:00.000Z'))
+    })
+
     it('signs with the current time when the window is disabled', async () => {
       process.env.R2_SIGNED_URL_STABILITY_WINDOW_SECONDS = '0'
 
@@ -303,5 +316,29 @@ describe('R2 client', () => {
         url: 'https://signed.example.com/file'
       }
     ])
+  })
+})
+
+describe('parseSignedUrlStabilityWindowSeconds', () => {
+  it('falls back to the default for anything unusable', async () => {
+    const { parseSignedUrlStabilityWindowSeconds } = await importR2Client()
+
+    for (const raw of [undefined, '', '   ', 'fifteen', '-1', 'NaN']) {
+      expect(parseSignedUrlStabilityWindowSeconds(raw)).toBe(900)
+    }
+  })
+
+  it('turns the window off only on an explicit zero', async () => {
+    const { parseSignedUrlStabilityWindowSeconds } = await importR2Client()
+
+    expect(parseSignedUrlStabilityWindowSeconds('0')).toBe(0)
+    expect(parseSignedUrlStabilityWindowSeconds(' 0 ')).toBe(0)
+  })
+
+  it('keeps a positive value from rounding down into the off switch', async () => {
+    const { parseSignedUrlStabilityWindowSeconds } = await importR2Client()
+
+    expect(parseSignedUrlStabilityWindowSeconds('0.5')).toBe(1)
+    expect(parseSignedUrlStabilityWindowSeconds('300.9')).toBe(300)
   })
 })

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -19,15 +19,32 @@ export const R2_SIGNED_URL_EXPIRES_SECONDS =
     : DEFAULT_SIGNED_URL_EXPIRES_SECONDS
 
 const DEFAULT_SIGNED_URL_STABILITY_WINDOW_SECONDS = 15 * 60
-const configuredSignedUrlStabilityWindowSeconds = Number(
-  process.env.R2_SIGNED_URL_STABILITY_WINDOW_SECONDS
-)
-// Set to 0 to go back to signing every request with the current time.
+
+/**
+ * Only an explicit `0` goes back to signing every request with the current time.
+ *
+ * Templated environments routinely define a variable as an empty string, and
+ * `Number('')` is `0` — which would silently turn the window off while looking
+ * configured. Anything unusable falls back to the default instead.
+ */
+export function parseSignedUrlStabilityWindowSeconds(
+  raw: string | undefined
+): number {
+  const value = raw?.trim()
+  if (!value) return DEFAULT_SIGNED_URL_STABILITY_WINDOW_SECONDS
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SIGNED_URL_STABILITY_WINDOW_SECONDS
+  }
+
+  return parsed === 0 ? 0 : Math.max(1, Math.floor(parsed))
+}
+
 export const R2_SIGNED_URL_STABILITY_WINDOW_SECONDS =
-  Number.isFinite(configuredSignedUrlStabilityWindowSeconds) &&
-  configuredSignedUrlStabilityWindowSeconds >= 0
-    ? configuredSignedUrlStabilityWindowSeconds
-    : DEFAULT_SIGNED_URL_STABILITY_WINDOW_SECONDS
+  parseSignedUrlStabilityWindowSeconds(
+    process.env.R2_SIGNED_URL_STABILITY_WINDOW_SECONDS
+  )
 
 let _r2Client: S3Client | null = null
 


### PR DESCRIPTION
## Problem

`Number('')` is `0`, and `0` is the documented way to turn the stable signing window from #941 off. So an environment that defines `R2_SIGNED_URL_STABILITY_WINDOW_SECONDS` as an empty string went back to signing every request with the current time, while looking configured.

Templated environments define variables as empty strings routinely, and the symptom here would not have been an error — it would have been an unexplained loss of prompt-cache hits on replayed attachments, which is exactly what #941 set out to fix.

Found by review on #942, which had the same shape in `HISTORY_ATTACHMENT_REPLAY_LIMIT` and fixed it there. This is the sibling.

## Change

Parse the value explicitly:

- blank, whitespace-only, non-numeric, or negative → the default (900s)
- an explicit `0` → window disabled, as documented
- a positive value → floored, but never below `1`, so it cannot round down into the off switch

`R2_SIGNED_URL_EXPIRES_SECONDS` is unaffected: it validates with `> 0`, so a blank value already falls back to its default.

## Tests

Direct coverage of the parser, plus a case asserting that a blank environment value still produces a quantized signing date.

## Checks

`bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (659 passed), `bun run build` all pass.