### PR TITLE
fix(streaming): record provider API call diagnostics on the failing trace

### DIFF
--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -30,7 +30,10 @@ import {
   EMPTY_RESPONSE_STATUS_MESSAGE,
   isEmptyResponse
 } from './helpers/is-empty-response'
-import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
+import {
+  buildAPICallErrorDiagnostics,
+  logAPICallErrorDiagnostics
+} from './helpers/log-api-call-error'
 import { persistStreamResults } from './helpers/persist-stream-results'
 import { prepareMessages } from './helpers/prepare-messages'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
@@ -95,9 +98,11 @@ export async function createChatStreamResponse(
     const endTracing = async () => {
       if (rootSpan) {
         if (hasStreamError) {
+          const apiCallDiagnostics = buildAPICallErrorDiagnostics(streamError)
           rootSpan.update({
             level: 'ERROR',
-            statusMessage: describeStreamError(streamError)
+            statusMessage: describeStreamError(streamError),
+            ...(apiCallDiagnostics && { metadata: { apiCallDiagnostics } })
           })
         } else if (hasEmptyResponse) {
           rootSpan.update({

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -26,7 +26,10 @@ import {
   EMPTY_RESPONSE_STATUS_MESSAGE,
   isEmptyResponse
 } from './helpers/is-empty-response'
-import { logAPICallErrorDiagnostics } from './helpers/log-api-call-error'
+import {
+  buildAPICallErrorDiagnostics,
+  logAPICallErrorDiagnostics
+} from './helpers/log-api-call-error'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
 import { BaseStreamConfig } from './types'
 
@@ -63,9 +66,11 @@ export async function createEphemeralChatStreamResponse(
     const endTracing = async () => {
       if (rootSpan) {
         if (hasStreamError) {
+          const apiCallDiagnostics = buildAPICallErrorDiagnostics(streamError)
           rootSpan.update({
             level: 'ERROR',
-            statusMessage: describeStreamError(streamError)
+            statusMessage: describeStreamError(streamError),
+            ...(apiCallDiagnostics && { metadata: { apiCallDiagnostics } })
           })
         } else if (hasEmptyResponse) {
           rootSpan.update({

--- a/lib/streaming/helpers/__tests__/log-api-call-error.test.ts
+++ b/lib/streaming/helpers/__tests__/log-api-call-error.test.ts
@@ -1,7 +1,10 @@
 import { APICallError } from 'ai'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { logAPICallErrorDiagnostics } from '../log-api-call-error'
+import {
+  buildAPICallErrorDiagnostics,
+  logAPICallErrorDiagnostics
+} from '../log-api-call-error'
 
 function createAPICallError(
   requestBodyValues: unknown,
@@ -49,6 +52,10 @@ describe('logAPICallErrorDiagnostics', () => {
 
     logAPICallErrorDiagnostics(error)
 
+    expect(consoleError).toHaveBeenCalledWith(
+      'Provider API call diagnostics:',
+      '{"statusCode":400,"url":"https://provider.example/v1/messages","requestBody":{"topLevelKeys":["model","messages"],"totalSerializedSize":156,"turnsKey":"messages","turnCount":1,"turns":[{"role":"user","content":[{"type":"text","length":45},{"type":"file","length":42}]}]},"responseBody":{"length":12}}'
+    )
     const output = consoleError.mock.calls.flat().join(' ')
     expect(output).toContain('"statusCode":400')
     expect(output).toContain('https://provider.example/v1/messages')
@@ -154,5 +161,54 @@ describe('logAPICallErrorDiagnostics', () => {
     const diagnostics = consoleError.mock.calls[0][1]
     expect(diagnostics).toHaveLength(4000)
     expect(diagnostics.endsWith('...[truncated]')).toBe(true)
+  })
+})
+
+describe('buildAPICallErrorDiagnostics', () => {
+  it.each([new Error('failure'), null, undefined, 'failure'])(
+    'returns null for a non-API call error',
+    value => {
+      expect(buildAPICallErrorDiagnostics(value)).toBeNull()
+    }
+  )
+
+  it('returns structural API call diagnostics without private content', () => {
+    const sentinel = 'SENTINEL_PRIVATE_MESSAGE_20260807'
+    const error = createAPICallError({
+      model: 'provider-model',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: sentinel },
+            { type: 'file', data: 'private file data' }
+          ]
+        }
+      ]
+    })
+
+    const diagnostics = buildAPICallErrorDiagnostics(error)
+
+    expect(diagnostics).toEqual({
+      statusCode: 400,
+      url: 'https://provider.example/v1/messages',
+      requestBody: {
+        topLevelKeys: ['model', 'messages'],
+        totalSerializedSize: 169,
+        turnsKey: 'messages',
+        turnCount: 1,
+        turns: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', length: 58 },
+              { type: 'file', length: 42 }
+            ]
+          }
+        ]
+      },
+      responseBody: { length: 12 }
+    })
+    expect(JSON.stringify(diagnostics)).not.toContain(sentinel)
   })
 })

--- a/lib/streaming/helpers/log-api-call-error.ts
+++ b/lib/streaming/helpers/log-api-call-error.ts
@@ -127,16 +127,30 @@ function summarizeResponseBody(responseBody: unknown) {
 }
 
 export function logAPICallErrorDiagnostics(error: unknown): void {
-  try {
-    if (!APICallError.isInstance(error)) return
+  const diagnostics = buildAPICallErrorDiagnostics(error)
+  if (!diagnostics) return
 
-    const diagnostics = JSON.stringify({
+  try {
+    console.error(
+      'Provider API call diagnostics:',
+      truncate(JSON.stringify(diagnostics))
+    )
+  } catch {}
+}
+
+export function buildAPICallErrorDiagnostics(
+  error: unknown
+): Record<string, unknown> | null {
+  try {
+    if (!APICallError.isInstance(error)) return null
+
+    return {
       statusCode: error.statusCode,
       url: error.url,
       requestBody: summarizeRequestBody(error.requestBodyValues),
       responseBody: summarizeResponseBody(error.responseBody)
-    })
-
-    console.error('Provider API call diagnostics:', truncate(diagnostics))
-  } catch {}
+    }
+  } catch {
+    return null
+  }
 }


### PR DESCRIPTION
Refs #927

## Problem

Chat turns occasionally fail with a provider 400 whose only description is that the request body could not be parsed. #928 added `logAPICallErrorDiagnostics`, which builds a structural summary of the rejected request so the next occurrence would be diagnosable.

That summary is written with `console.error`, which lands in the platform's runtime logs. Their retention is minutes in practice, measured at roughly a 25 minute window. These failures are found by reading traces, typically hours after the fact, so by the time anyone looks the diagnostics are gone. A recurrence was investigated about 14 hours after it happened and nothing remained.

Meanwhile the failure itself is recorded in Langfuse and retained for days, but the root span carries only a generic `statusMessage` such as `bad_request: The request could not be processed.`, which is the same for every failure class and identifies nothing.

## Root cause

Not the 400 itself, which is still unexplained and stays open in #927. The defect fixed here is that the diagnostics built for it are written to a sink that cannot outlive the investigation window, so every occurrence is unusable by the time it is seen.

## Fix

- Extract the diagnostics construction from `logAPICallErrorDiagnostics` into an exported `buildAPICallErrorDiagnostics`, which returns the summary object or `null` when the error is not an `APICallError` or the summary cannot be built.
- In both stream paths, when the root span is already being marked `ERROR` for a stream failure, attach that summary as span metadata. `level` and `statusMessage` are unchanged.
- `logAPICallErrorDiagnostics` keeps its exact previous output, including the 4000 character truncation, and its existing call sites are untouched.

What gets recorded is unchanged from what #928 already computed: key names, serialized sizes, message roles, content part types and lengths, plus enumerated provider error fields. No request or response content. This adds no new exposure, since full model input and output already go to the same destination for every trace.

## Verification

- `bun run test`, `bun lint`, `bun typecheck`, `bun format:check`, `bun run build` all pass.
- New tests cover: `buildAPICallErrorDiagnostics` returning `null` for a plain `Error`, `null`, `undefined` and a string; the full structural summary for a realistic `APICallError`, asserted against concrete expected values rather than by recomputing the production logic; and a privacy guard that places a sentinel string inside a message part and asserts it does not appear anywhere in the serialized diagnostics.
- Existing coverage that `logAPICallErrorDiagnostics` still emits the identical console output is kept and tightened to an exact-string assertion.

The effect is not visible in any product metric. The concrete expectation is that the next occurrence of a provider `APICallError` on the chat stream produces a root `research` span whose metadata carries the rejected request's structure, making it diagnosable from traces alone.
