### PR TITLE
fix: deduplicate repeated attachments instead of replaying every copy

### DIFF
--- a/app/api/upload/__tests__/route.test.ts
+++ b/app/api/upload/__tests__/route.test.ts
@@ -21,12 +21,14 @@ vi.mock('@/lib/storage/r2-client', () => ({
     Promise.resolve(`https://uploads.example.com/${key}?sig=abc`)
   ),
   isObjectStorageConfigured: vi.fn(() => true),
-  objectExists: vi.fn(() => Promise.resolve(true)),
+  getObjectContentMd5: vi.fn(() => Promise.resolve<string | null>(null)),
   R2_BUCKET_NAME: 'test-bucket'
 }))
 
+import { createHash } from 'node:crypto'
+
 import * as dbActions from '@/lib/db/actions'
-import { objectExists } from '@/lib/storage/r2-client'
+import { getObjectContentMd5 } from '@/lib/storage/r2-client'
 
 import { POST } from '../route'
 
@@ -64,11 +66,15 @@ function uploadRequest(bytes = 1234) {
   } as any
 }
 
+function md5OfUpload(bytes = 1234) {
+  return createHash('md5').update(Buffer.alloc(bytes)).digest('hex')
+}
+
 describe('POST /api/upload', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     delete process.env.ENABLE_AUTH
-    vi.mocked(objectExists).mockResolvedValue(true)
+    vi.mocked(getObjectContentMd5).mockResolvedValue(md5OfUpload())
     vi.mocked(dbActions.createLibraryFile).mockResolvedValue({
       ...EXISTING,
       id: 'file-2',
@@ -90,7 +96,7 @@ describe('POST /api/upload', () => {
     expect(dbActions.createLibraryFile).not.toHaveBeenCalled()
   })
 
-  it('matches on name, type and size together', async () => {
+  it('narrows the candidate by name, type and size', async () => {
     vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(null)
 
     await POST(uploadRequest(9999))
@@ -114,11 +120,27 @@ describe('POST /api/upload', () => {
     expect(send).toHaveBeenCalledOnce()
   })
 
-  it('uploads when the stored object is gone', async () => {
+  it('uploads when the candidate holds different bytes', async () => {
+    // Same name, same type, same size, different content: the digest is the
+    // only thing standing between the user and a silently substituted file.
     vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(
       EXISTING as any
     )
-    vi.mocked(objectExists).mockResolvedValue(false)
+    vi.mocked(getObjectContentMd5).mockResolvedValue(
+      createHash('md5').update('something else').digest('hex')
+    )
+
+    const { file } = await (await POST(uploadRequest())).json()
+
+    expect(file.key).not.toBe(EXISTING.objectKey)
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('uploads when the stored object is gone or has no usable digest', async () => {
+    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(
+      EXISTING as any
+    )
+    vi.mocked(getObjectContentMd5).mockResolvedValue(null)
 
     const { file } = await (await POST(uploadRequest())).json()
 

--- a/app/api/upload/__tests__/route.test.ts
+++ b/app/api/upload/__tests__/route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth/get-current-user', () => ({
+  getCurrentUserId: vi.fn(() => Promise.resolve('user-1'))
+}))
+
+vi.mock('@/lib/analytics/dispatch', () => ({
+  capture: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('@/lib/db/actions', () => ({
+  findChatFileByContent: vi.fn(),
+  createLibraryFile: vi.fn()
+}))
+
+const send = vi.fn(() => Promise.resolve({}))
+
+vi.mock('@/lib/storage/r2-client', () => ({
+  getR2Client: vi.fn(() => ({ send })),
+  getSignedFileUrl: vi.fn((key: string) =>
+    Promise.resolve(`https://uploads.example.com/${key}?sig=abc`)
+  ),
+  isObjectStorageConfigured: vi.fn(() => true),
+  objectExists: vi.fn(() => Promise.resolve(true)),
+  R2_BUCKET_NAME: 'test-bucket'
+}))
+
+import * as dbActions from '@/lib/db/actions'
+import { objectExists } from '@/lib/storage/r2-client'
+
+import { POST } from '../route'
+
+const EXISTING = {
+  id: 'file-1',
+  userId: 'user-1',
+  chatId: 'chat-1',
+  filename: 'report.pdf',
+  objectKey: 'user-1/chats/chat-1/1700000000000-report.pdf',
+  mediaType: 'application/pdf',
+  size: 1234,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01')
+}
+
+/**
+ * The route only reads headers and formData, so a stub avoids round-tripping a
+ * File through multipart encoding in the test environment.
+ */
+function uploadRequest(bytes = 1234) {
+  const file = {
+    name: 'report.pdf',
+    type: 'application/pdf',
+    size: bytes,
+    arrayBuffer: async () => new Uint8Array(bytes).buffer
+  }
+  const formData = new Map<string, unknown>([
+    ['file', file],
+    ['chatId', 'chat-1']
+  ])
+
+  return {
+    headers: { get: () => 'multipart/form-data; boundary=x' },
+    formData: async () => ({ get: (key: string) => formData.get(key) ?? null })
+  } as any
+}
+
+describe('POST /api/upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.ENABLE_AUTH
+    vi.mocked(objectExists).mockResolvedValue(true)
+    vi.mocked(dbActions.createLibraryFile).mockResolvedValue({
+      ...EXISTING,
+      id: 'file-2',
+      objectKey: 'user-1/chats/chat-1/1800000000000-report.pdf'
+    } as any)
+  })
+
+  it('reuses the stored copy when the same file is uploaded again', async () => {
+    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(
+      EXISTING as any
+    )
+
+    const { file } = await (await POST(uploadRequest())).json()
+
+    expect(file.key).toBe(EXISTING.objectKey)
+    expect(file.id).toBe(EXISTING.id)
+    // Nothing written: no second object, no second library row.
+    expect(send).not.toHaveBeenCalled()
+    expect(dbActions.createLibraryFile).not.toHaveBeenCalled()
+  })
+
+  it('matches on name, type and size together', async () => {
+    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(null)
+
+    await POST(uploadRequest(9999))
+
+    expect(dbActions.findChatFileByContent).toHaveBeenCalledWith({
+      userId: 'user-1',
+      chatId: 'chat-1',
+      filename: 'report.pdf',
+      mediaType: 'application/pdf',
+      size: 9999
+    })
+    expect(dbActions.createLibraryFile).toHaveBeenCalled()
+  })
+
+  it('uploads when nothing matches', async () => {
+    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(null)
+
+    const { file } = await (await POST(uploadRequest())).json()
+
+    expect(file.key).not.toBe(EXISTING.objectKey)
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('uploads when the stored object is gone', async () => {
+    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(
+      EXISTING as any
+    )
+    vi.mocked(objectExists).mockResolvedValue(false)
+
+    const { file } = await (await POST(uploadRequest())).json()
+
+    expect(file.key).not.toBe(EXISTING.objectKey)
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('uploads when the lookup fails', async () => {
+    vi.mocked(dbActions.findChatFileByContent).mockRejectedValue(
+      new Error('db down')
+    )
+
+    const response = await POST(uploadRequest())
+
+    expect(response.status).toBe(200)
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('skips the lookup in anonymous mode, which has no library', async () => {
+    process.env.ENABLE_AUTH = 'false'
+
+    await POST(uploadRequest())
+
+    expect(dbActions.findChatFileByContent).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledOnce()
+  })
+})

--- a/app/api/upload/__tests__/route.test.ts
+++ b/app/api/upload/__tests__/route.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/lib/analytics/dispatch', () => ({
 }))
 
 vi.mock('@/lib/db/actions', () => ({
-  findChatFileByContent: vi.fn(),
+  findChatFileCandidates: vi.fn(),
   createLibraryFile: vi.fn()
 }))
 
@@ -21,6 +21,8 @@ vi.mock('@/lib/storage/r2-client', () => ({
     Promise.resolve(`https://uploads.example.com/${key}?sig=abc`)
   ),
   isObjectStorageConfigured: vi.fn(() => true),
+  getChatFileObjectKeyPrefix: (userId: string, chatId: string) =>
+    `${userId}/chats/${chatId}/`,
   getObjectContentMd5: vi.fn(() => Promise.resolve<string | null>(null)),
   R2_BUCKET_NAME: 'test-bucket'
 }))
@@ -83,9 +85,9 @@ describe('POST /api/upload', () => {
   })
 
   it('reuses the stored copy when the same file is uploaded again', async () => {
-    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(
-      EXISTING as any
-    )
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([
+      EXISTING
+    ] as any)
 
     const { file } = await (await POST(uploadRequest())).json()
 
@@ -97,13 +99,13 @@ describe('POST /api/upload', () => {
   })
 
   it('narrows the candidate by name, type and size', async () => {
-    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(null)
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([])
 
     await POST(uploadRequest(9999))
 
-    expect(dbActions.findChatFileByContent).toHaveBeenCalledWith({
+    expect(dbActions.findChatFileCandidates).toHaveBeenCalledWith({
       userId: 'user-1',
-      chatId: 'chat-1',
+      chatKeyPrefix: 'user-1/chats/chat-1/',
       filename: 'report.pdf',
       mediaType: 'application/pdf',
       size: 9999
@@ -112,7 +114,7 @@ describe('POST /api/upload', () => {
   })
 
   it('uploads when nothing matches', async () => {
-    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(null)
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([])
 
     const { file } = await (await POST(uploadRequest())).json()
 
@@ -123,9 +125,9 @@ describe('POST /api/upload', () => {
   it('uploads when the candidate holds different bytes', async () => {
     // Same name, same type, same size, different content: the digest is the
     // only thing standing between the user and a silently substituted file.
-    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(
-      EXISTING as any
-    )
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([
+      EXISTING
+    ] as any)
     vi.mocked(getObjectContentMd5).mockResolvedValue(
       createHash('md5').update('something else').digest('hex')
     )
@@ -137,9 +139,9 @@ describe('POST /api/upload', () => {
   })
 
   it('uploads when the stored object is gone or has no usable digest', async () => {
-    vi.mocked(dbActions.findChatFileByContent).mockResolvedValue(
-      EXISTING as any
-    )
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([
+      EXISTING
+    ] as any)
     vi.mocked(getObjectContentMd5).mockResolvedValue(null)
 
     const { file } = await (await POST(uploadRequest())).json()
@@ -148,8 +150,29 @@ describe('POST /api/upload', () => {
     expect(send).toHaveBeenCalledOnce()
   })
 
+  it('checks every candidate, not just the newest', async () => {
+    // Two same-sized versions of one file: matching only the newest would mint
+    // a new object every time the user alternates between them.
+    const older = { ...EXISTING, id: 'file-0', objectKey: 'older-key' }
+    const newer = { ...EXISTING, id: 'file-9', objectKey: 'newer-key' }
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([
+      newer,
+      older
+    ] as any)
+    vi.mocked(getObjectContentMd5).mockImplementation(async key =>
+      key === older.objectKey
+        ? md5OfUpload()
+        : createHash('md5').update('another version').digest('hex')
+    )
+
+    const { file } = await (await POST(uploadRequest())).json()
+
+    expect(file.key).toBe(older.objectKey)
+    expect(send).not.toHaveBeenCalled()
+  })
+
   it('uploads when the lookup fails', async () => {
-    vi.mocked(dbActions.findChatFileByContent).mockRejectedValue(
+    vi.mocked(dbActions.findChatFileCandidates).mockRejectedValue(
       new Error('db down')
     )
 
@@ -164,7 +187,7 @@ describe('POST /api/upload', () => {
 
     await POST(uploadRequest())
 
-    expect(dbActions.findChatFileByContent).not.toHaveBeenCalled()
+    expect(dbActions.findChatFileCandidates).not.toHaveBeenCalled()
     expect(send).toHaveBeenCalledOnce()
   })
 })

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -7,6 +7,7 @@ import { capture } from '@/lib/analytics/dispatch'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import {
+  getChatFileObjectKeyPrefix,
   getObjectContentMd5,
   getR2Client,
   getSignedFileUrl,
@@ -136,12 +137,14 @@ export async function POST(req: NextRequest) {
  * everywhere downstream, so the model would be handed both copies on every
  * later turn.
  *
- * Name, media type and size only narrow the search to one stored candidate.
+ * Name, media type and size only narrow the search to a few stored candidates.
  * The decision itself is a digest comparison: handing back a different file
  * under the same name would be a silent substitution, which is a far worse
- * outcome than the duplicate this avoids.
+ * outcome than the duplicate this avoids. Every candidate is compared, or two
+ * same-sized versions of one file would push each other out of the search and
+ * mint a new object on every upload.
  *
- * Returns null whenever the match cannot be confirmed, and the caller uploads.
+ * Returns null whenever no match can be confirmed, and the caller uploads.
  */
 async function reuseExistingChatFile(
   file: File,
@@ -150,35 +153,36 @@ async function reuseExistingChatFile(
   chatId: string
 ) {
   try {
-    const existing = await dbActions.findChatFileByContent({
+    const candidates = await dbActions.findChatFileCandidates({
       userId,
-      chatId,
+      chatKeyPrefix: getChatFileObjectKeyPrefix(userId, chatId),
       filename: file.name,
       mediaType: file.type,
       size: file.size
     })
-    if (!existing) return null
+    if (candidates.length === 0) return null
 
-    const storedMd5 = await getObjectContentMd5(existing.objectKey)
-    if (
-      !storedMd5 ||
-      storedMd5 !== createHash('md5').update(buffer).digest('hex')
-    ) {
-      return null
+    const uploadedMd5 = createHash('md5').update(buffer).digest('hex')
+
+    for (const candidate of candidates) {
+      const storedMd5 = await getObjectContentMd5(candidate.objectKey)
+      if (!storedMd5 || storedMd5 !== uploadedMd5) continue
+
+      const url = await getSignedFileUrl(candidate.objectKey)
+
+      return {
+        type: 'file',
+        filename: candidate.filename,
+        key: candidate.objectKey,
+        url,
+        mediaType: candidate.mediaType,
+        id: candidate.id,
+        size: file.size,
+        libraryFile: { ...candidate, key: candidate.objectKey, url }
+      }
     }
 
-    const url = await getSignedFileUrl(existing.objectKey)
-
-    return {
-      type: 'file',
-      filename: existing.filename,
-      key: existing.objectKey,
-      url,
-      mediaType: existing.mediaType,
-      id: existing.id,
-      size: file.size,
-      libraryFile: { ...existing, key: existing.objectKey, url }
-    }
+    return null
   } catch (error) {
     console.error('Duplicate upload lookup failed:', error)
     return null
@@ -196,7 +200,7 @@ async function uploadFileToR2(
   chatId: string
 ) {
   const sanitizedFileName = sanitizeFilename(file.name)
-  const filePath = `${userId}/chats/${chatId}/${Date.now()}-${sanitizedFileName}`
+  const filePath = `${getChatFileObjectKeyPrefix(userId, chatId)}${Date.now()}-${sanitizedFileName}`
 
   try {
     const r2Client = getR2Client()

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -9,6 +9,7 @@ import {
   getR2Client,
   getSignedFileUrl,
   isObjectStorageConfigured,
+  objectExists,
   R2_BUCKET_NAME
 } from '@/lib/storage/r2-client'
 
@@ -61,8 +62,20 @@ export async function POST(req: NextRequest) {
         { status: 400 }
       )
     }
+    const isAnonymous = process.env.ENABLE_AUTH === 'false'
+
+    if (!isAnonymous && chatId) {
+      const reused = await reuseExistingChatFile(file, userId, chatId)
+      if (reused) {
+        return NextResponse.json(
+          { success: true, file: reused },
+          { status: 200 }
+        )
+      }
+    }
+
     const result = await uploadFileToR2(file, userId, chatId)
-    if (process.env.ENABLE_AUTH === 'false') {
+    if (isAnonymous) {
       return NextResponse.json({ success: true, file: result }, { status: 200 })
     }
 
@@ -109,6 +122,54 @@ export async function POST(req: NextRequest) {
       { error: 'Upload failed', message: err.message },
       { status: 500 }
     )
+  }
+}
+
+/**
+ * Points a repeated upload at the copy already stored for this chat.
+ *
+ * Re-uploading the same file is the common way a conversation ends up carrying
+ * two of it, usually because the first copy went unmentioned in the reply. A
+ * fresh upload would mint a new object key, which reads as a different file
+ * everywhere downstream, so the model would be handed both copies on every
+ * later turn. Name, media type and byte size together are as close to content
+ * identity as the upload path can get without storing a digest.
+ *
+ * Returns null whenever the match cannot be trusted, and the caller uploads.
+ */
+async function reuseExistingChatFile(
+  file: File,
+  userId: string,
+  chatId: string
+) {
+  try {
+    const existing = await dbActions.findChatFileByContent({
+      userId,
+      chatId,
+      filename: file.name,
+      mediaType: file.type,
+      size: file.size
+    })
+
+    if (!existing || !(await objectExists(existing.objectKey))) {
+      return null
+    }
+
+    const url = await getSignedFileUrl(existing.objectKey)
+
+    return {
+      type: 'file',
+      filename: existing.filename,
+      key: existing.objectKey,
+      url,
+      mediaType: existing.mediaType,
+      id: existing.id,
+      size: file.size,
+      libraryFile: { ...existing, key: existing.objectKey, url }
+    }
+  } catch (error) {
+    console.error('Duplicate upload lookup failed:', error)
+    return null
   }
 }
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,15 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { PutObjectCommand } from '@aws-sdk/client-s3'
+import { createHash } from 'node:crypto'
 
 import { capture } from '@/lib/analytics/dispatch'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import {
+  getObjectContentMd5,
   getR2Client,
   getSignedFileUrl,
   isObjectStorageConfigured,
-  objectExists,
   R2_BUCKET_NAME
 } from '@/lib/storage/r2-client'
 
@@ -63,9 +64,10 @@ export async function POST(req: NextRequest) {
       )
     }
     const isAnonymous = process.env.ENABLE_AUTH === 'false'
+    const buffer = Buffer.from(await file.arrayBuffer())
 
     if (!isAnonymous && chatId) {
-      const reused = await reuseExistingChatFile(file, userId, chatId)
+      const reused = await reuseExistingChatFile(file, buffer, userId, chatId)
       if (reused) {
         return NextResponse.json(
           { success: true, file: reused },
@@ -74,7 +76,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const result = await uploadFileToR2(file, userId, chatId)
+    const result = await uploadFileToR2(file, buffer, userId, chatId)
     if (isAnonymous) {
       return NextResponse.json({ success: true, file: result }, { status: 200 })
     }
@@ -132,13 +134,18 @@ export async function POST(req: NextRequest) {
  * two of it, usually because the first copy went unmentioned in the reply. A
  * fresh upload would mint a new object key, which reads as a different file
  * everywhere downstream, so the model would be handed both copies on every
- * later turn. Name, media type and byte size together are as close to content
- * identity as the upload path can get without storing a digest.
+ * later turn.
  *
- * Returns null whenever the match cannot be trusted, and the caller uploads.
+ * Name, media type and size only narrow the search to one stored candidate.
+ * The decision itself is a digest comparison: handing back a different file
+ * under the same name would be a silent substitution, which is a far worse
+ * outcome than the duplicate this avoids.
+ *
+ * Returns null whenever the match cannot be confirmed, and the caller uploads.
  */
 async function reuseExistingChatFile(
   file: File,
+  buffer: Buffer,
   userId: string,
   chatId: string
 ) {
@@ -150,8 +157,13 @@ async function reuseExistingChatFile(
       mediaType: file.type,
       size: file.size
     })
+    if (!existing) return null
 
-    if (!existing || !(await objectExists(existing.objectKey))) {
+    const storedMd5 = await getObjectContentMd5(existing.objectKey)
+    if (
+      !storedMd5 ||
+      storedMd5 !== createHash('md5').update(buffer).digest('hex')
+    ) {
       return null
     }
 
@@ -177,12 +189,16 @@ function sanitizeFilename(filename: string) {
   return filename.replace(/[^a-z0-9.\-_]/gi, '_').toLowerCase()
 }
 
-async function uploadFileToR2(file: File, userId: string, chatId: string) {
+async function uploadFileToR2(
+  file: File,
+  buffer: Buffer,
+  userId: string,
+  chatId: string
+) {
   const sanitizedFileName = sanitizeFilename(file.name)
   const filePath = `${userId}/chats/${chatId}/${Date.now()}-${sanitizedFileName}`
 
   try {
-    const buffer = Buffer.from(await file.arrayBuffer())
     const r2Client = getR2Client()
 
     await r2Client.send(

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -518,6 +518,47 @@ export async function deleteUserNotes(
   }
 }
 
+/**
+ * The file already uploaded to this chat under the same name, type and byte
+ * size, if there is one.
+ *
+ * Scoped to a single chat on purpose: object keys live under a per-chat prefix
+ * and a chat deletion wipes that prefix, so reusing a key across chats would
+ * let one chat's deletion break another's attachment.
+ */
+export async function findChatFileByContent({
+  userId,
+  chatId,
+  filename,
+  mediaType,
+  size
+}: {
+  userId: string
+  chatId: string
+  filename: string
+  mediaType: string
+  size: number
+}): Promise<LibraryFile | null> {
+  return withRLS(userId, async tx => {
+    const [existing] = await tx
+      .select()
+      .from(libraryFiles)
+      .where(
+        and(
+          eq(libraryFiles.userId, userId),
+          eq(libraryFiles.chatId, chatId),
+          eq(libraryFiles.filename, filename),
+          eq(libraryFiles.mediaType, mediaType),
+          eq(libraryFiles.size, size)
+        )
+      )
+      .orderBy(desc(libraryFiles.createdAt))
+      .limit(1)
+
+    return existing ?? null
+  })
+}
+
 export async function createLibraryFile(
   file: Omit<NewLibraryFile, 'id' | 'createdAt' | 'updatedAt'>
 ): Promise<LibraryFile> {

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1,6 +1,17 @@
 'use server'
 
-import { and, asc, desc, eq, gt, ilike, inArray, lt, or } from 'drizzle-orm'
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  ilike,
+  inArray,
+  lt,
+  or,
+  sql
+} from 'drizzle-orm'
 
 import type { UIMessage } from '@/lib/types/ai'
 import type { PersistableUIMessage } from '@/lib/types/message-persistence'
@@ -518,45 +529,59 @@ export async function deleteUserNotes(
   }
 }
 
+const CHAT_FILE_CANDIDATE_LIMIT = 5
+
+function escapeLikePattern(value: string) {
+  return value.replace(/[\\%_]/g, char => `\\${char}`)
+}
+
 /**
- * The file already uploaded to this chat under the same name, type and byte
- * size, if there is one.
+ * Files already stored under this chat's object prefix that could be the one
+ * being uploaded, newest first.
  *
- * Scoped to a single chat on purpose: object keys live under a per-chat prefix
- * and a chat deletion wipes that prefix, so reusing a key across chats would
- * let one chat's deletion break another's attachment.
+ * Candidates only: name, media type and size are metadata, so the caller has to
+ * confirm the bytes. More than one can match, and returning just the newest
+ * would keep re-uploading two same-sized versions of a file against each other.
+ *
+ * Matched on the object key prefix rather than on `chat_id`, because the column
+ * is not reliable for this. A file attached to a brand-new chat is uploaded
+ * before the chat row exists, and `createLibraryFile` stores it with a null
+ * `chat_id`; deleting a chat nulls it too. The key always carries the chat it
+ * was uploaded under.
+ *
+ * Staying inside one chat's prefix is the point: a chat deletion wipes that
+ * prefix, so reusing a key across chats would let one chat's deletion break
+ * another's attachment.
  */
-export async function findChatFileByContent({
+export async function findChatFileCandidates({
   userId,
-  chatId,
+  chatKeyPrefix,
   filename,
   mediaType,
   size
 }: {
   userId: string
-  chatId: string
+  chatKeyPrefix: string
   filename: string
   mediaType: string
   size: number
-}): Promise<LibraryFile | null> {
-  return withRLS(userId, async tx => {
-    const [existing] = await tx
+}): Promise<LibraryFile[]> {
+  return withRLS(userId, async tx =>
+    tx
       .select()
       .from(libraryFiles)
       .where(
         and(
           eq(libraryFiles.userId, userId),
-          eq(libraryFiles.chatId, chatId),
           eq(libraryFiles.filename, filename),
           eq(libraryFiles.mediaType, mediaType),
-          eq(libraryFiles.size, size)
+          eq(libraryFiles.size, size),
+          sql`${libraryFiles.objectKey} LIKE ${`${escapeLikePattern(chatKeyPrefix)}%`} ESCAPE '\\'`
         )
       )
       .orderBy(desc(libraryFiles.createdAt))
-      .limit(1)
-
-    return existing ?? null
-  })
+      .limit(CHAT_FILE_CANDIDATE_LIMIT)
+  )
 }
 
 export async function createLibraryFile(

--- a/lib/storage/__tests__/r2-client.test.ts
+++ b/lib/storage/__tests__/r2-client.test.ts
@@ -30,9 +30,18 @@ const s3Mocks = vi.hoisted(() => {
     }
   }
 
+  class HeadObjectCommand {
+    input: unknown
+
+    constructor(input: unknown) {
+      this.input = input
+    }
+  }
+
   return {
     DeleteObjectsCommand,
     GetObjectCommand,
+    HeadObjectCommand,
     ListObjectsV2Command,
     S3Client,
     getSignedUrl: vi.fn(),
@@ -43,6 +52,7 @@ const s3Mocks = vi.hoisted(() => {
 vi.mock('@aws-sdk/client-s3', () => ({
   DeleteObjectsCommand: s3Mocks.DeleteObjectsCommand,
   GetObjectCommand: s3Mocks.GetObjectCommand,
+  HeadObjectCommand: s3Mocks.HeadObjectCommand,
   ListObjectsV2Command: s3Mocks.ListObjectsV2Command,
   S3Client: s3Mocks.S3Client
 }))
@@ -165,6 +175,43 @@ describe('R2 client', () => {
     expect((s3Mocks.getSignedUrl.mock.calls[0][1] as any).input).toEqual({
       Bucket: 'test-bucket',
       Key: 'user-id/file.png'
+    })
+  })
+
+  describe('getObjectContentMd5', () => {
+    it('reads the digest off a single-part ETag', async () => {
+      const md5 = 'd41d8cd98f00b204e9800998ecf8427e'
+      s3Mocks.send.mockResolvedValueOnce({ ETag: `"${md5}"` })
+
+      const { getObjectContentMd5 } = await importR2Client()
+
+      await expect(getObjectContentMd5('user-id/file.pdf')).resolves.toBe(md5)
+    })
+
+    it('refuses an ETag that is not a content digest', async () => {
+      // A multipart or server-side-encrypted ETag is not the body's MD5, and
+      // treating it as one would compare two unrelated strings.
+      for (const etag of [
+        '"d41d8cd98f00b204e9800998ecf8427e-3"',
+        '"not-a-digest"',
+        undefined
+      ]) {
+        s3Mocks.send.mockResolvedValueOnce({ ETag: etag })
+
+        const { getObjectContentMd5 } = await importR2Client()
+
+        await expect(
+          getObjectContentMd5('user-id/file.pdf')
+        ).resolves.toBeNull()
+      }
+    })
+
+    it('answers null for a missing object', async () => {
+      s3Mocks.send.mockRejectedValueOnce(new Error('NotFound'))
+
+      const { getObjectContentMd5 } = await importR2Client()
+
+      await expect(getObjectContentMd5('user-id/gone.pdf')).resolves.toBeNull()
     })
   })
 

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -1,6 +1,7 @@
 import {
   DeleteObjectsCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   S3Client
 } from '@aws-sdk/client-s3'
@@ -162,6 +163,27 @@ export async function getSignedFileUrl(
     }),
     signingDate ? { expiresIn, signingDate } : { expiresIn }
   )
+}
+
+/**
+ * Whether the object is still in the bucket.
+ *
+ * Stored metadata can outlive the object it points at, so anything that reuses
+ * a key it did not just write has to ask. A failed lookup answers `false`: the
+ * caller falls back to uploading, which is correct either way.
+ */
+export async function objectExists(key: string): Promise<boolean> {
+  const normalizedKey = normalizeObjectKey(key)
+  if (!normalizedKey) return false
+
+  try {
+    await getR2Client().send(
+      new HeadObjectCommand({ Bucket: R2_BUCKET_NAME, Key: normalizedKey })
+    )
+    return true
+  } catch {
+    return false
+  }
 }
 
 export async function signFilePartUrls(

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -166,23 +166,30 @@ export async function getSignedFileUrl(
 }
 
 /**
- * Whether the object is still in the bucket.
+ * MD5 of a stored object's bytes, or null when it cannot be established.
  *
- * Stored metadata can outlive the object it points at, so anything that reuses
- * a key it did not just write has to ask. A failed lookup answers `false`: the
- * caller falls back to uploading, which is correct either way.
+ * S3 and R2 set the ETag of a single-part upload to the MD5 of the body, which
+ * is the only content digest available here without re-downloading the object.
+ * Everything this app stores is written by one `PutObject` under a 5MB cap, so
+ * the ETag is that digest; a multipart ETag carries a `-<parts>` suffix and a
+ * server-side-encrypted one is opaque, and both answer null.
+ *
+ * Null also covers a missing object and a failed request: stored metadata can
+ * outlive the object it points at, and callers treat null as "cannot reuse".
  */
-export async function objectExists(key: string): Promise<boolean> {
+export async function getObjectContentMd5(key: string): Promise<string | null> {
   const normalizedKey = normalizeObjectKey(key)
-  if (!normalizedKey) return false
+  if (!normalizedKey) return null
 
   try {
-    await getR2Client().send(
+    const head = await getR2Client().send(
       new HeadObjectCommand({ Bucket: R2_BUCKET_NAME, Key: normalizedKey })
     )
-    return true
+    const etag = head.ETag?.replace(/"/g, '').toLowerCase() ?? ''
+
+    return /^[0-9a-f]{32}$/.test(etag) ? etag : null
   } catch {
-    return false
+    return null
   }
 }
 

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -25,6 +25,7 @@ import { capHistoricalAttachments } from './helpers/cap-historical-attachments'
 import { compactHistoricalMessages } from './helpers/compact-historical-messages'
 import { convertDataPart } from './helpers/convert-data-part'
 import { assignDataPartNonces } from './helpers/data-part-nonce'
+import { dedupeAttachments } from './helpers/dedupe-attachments'
 import { describeStreamError } from './helpers/describe-stream-error'
 import {
   EMPTY_RESPONSE_STATUS_MESSAGE,
@@ -144,8 +145,8 @@ export async function createChatStreamResponse(
 
       const messagesWithNonces = assignDataPartNonces(messagesToModel)
       const messagesWithoutSpec = stripSpecFromMessages(messagesWithNonces)
-      const messagesToConvert = capHistoricalAttachments(
-        compactHistoricalMessages(messagesWithoutSpec)
+      const messagesToConvert = dedupeAttachments(
+        capHistoricalAttachments(compactHistoricalMessages(messagesWithoutSpec))
       )
 
       // Convert to model messages and apply context window management

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -21,6 +21,7 @@ import { capHistoricalAttachments } from './helpers/cap-historical-attachments'
 import { compactHistoricalMessages } from './helpers/compact-historical-messages'
 import { convertDataPart } from './helpers/convert-data-part'
 import { assignDataPartNonces } from './helpers/data-part-nonce'
+import { dedupeAttachments } from './helpers/dedupe-attachments'
 import { describeStreamError } from './helpers/describe-stream-error'
 import {
   EMPTY_RESPONSE_STATUS_MESSAGE,
@@ -81,8 +82,8 @@ export async function createEphemeralChatStreamResponse(
     try {
       const messagesWithNonces = assignDataPartNonces(messages)
       const messagesWithoutSpec = stripSpecFromMessages(messagesWithNonces)
-      const messagesToConvert = capHistoricalAttachments(
-        compactHistoricalMessages(messagesWithoutSpec)
+      const messagesToConvert = dedupeAttachments(
+        capHistoricalAttachments(compactHistoricalMessages(messagesWithoutSpec))
       )
 
       let modelMessages = await convertToModelMessages(messagesToConvert, {

--- a/lib/streaming/helpers/__tests__/dedupe-attachments.test.ts
+++ b/lib/streaming/helpers/__tests__/dedupe-attachments.test.ts
@@ -1,0 +1,205 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { dedupeAttachments } from '../dedupe-attachments'
+
+type FileSpec = {
+  filename: string
+  key?: string
+  url?: string
+  mediaType?: string
+}
+
+function userTurn(id: string, files: FileSpec[], text = 'Look at this') {
+  return {
+    id,
+    role: 'user',
+    parts: [
+      ...files.map(file => ({
+        type: 'file' as const,
+        mediaType: file.mediaType ?? 'application/pdf',
+        filename: file.filename,
+        url: file.url ?? `https://uploads.example.com/${file.key}?sig=abc`,
+        key: file.key
+      })),
+      { type: 'text', text }
+    ]
+  } as unknown as UIMessage
+}
+
+function assistantTurn(id: string): UIMessage {
+  return {
+    id,
+    role: 'assistant',
+    parts: [{ type: 'text', text: 'Here is what I see.' }]
+  } as unknown as UIMessage
+}
+
+function filenamesReaching(messages: UIMessage[]): string[] {
+  return messages.flatMap(message =>
+    message.parts
+      .filter(part => part.type === 'file')
+      .map(part => (part as unknown as { filename: string }).filename)
+  )
+}
+
+function placeholders(messages: UIMessage[]): string[] {
+  return messages.flatMap(message =>
+    message.parts
+      .filter(
+        part =>
+          part.type === 'text' &&
+          (part as unknown as { text: string }).text.startsWith(
+            '[Duplicate attachment omitted'
+          )
+      )
+      .map(part => (part as unknown as { text: string }).text)
+  )
+}
+
+describe('dedupeAttachments', () => {
+  it('leaves a conversation without duplicates untouched', () => {
+    const messages = [
+      userTurn('u0', [{ filename: 'a.pdf', key: 'user/chats/c/1-a.pdf' }]),
+      assistantTurn('a0'),
+      userTurn('u1', [{ filename: 'b.pdf', key: 'user/chats/c/2-b.pdf' }])
+    ]
+
+    expect(dedupeAttachments(messages)).toEqual(messages)
+  })
+
+  it('sends a re-attached file once, keeping the first occurrence', () => {
+    const key = 'user/chats/c/1-report.pdf'
+    const messages = [
+      userTurn('u0', [{ filename: 'report.pdf', key }]),
+      assistantTurn('a0'),
+      userTurn('u1', [{ filename: 'report.pdf', key }], 'Did you see it?')
+    ]
+
+    const deduped = dedupeAttachments(messages)
+
+    expect(filenamesReaching(deduped)).toEqual(['report.pdf'])
+    expect(deduped[0]).toEqual(messages[0])
+    expect(placeholders(deduped)).toHaveLength(1)
+  })
+
+  it('collapses copies attached twice within one message', () => {
+    const key = 'user/chats/c/1-report.pdf'
+    const messages = [
+      userTurn('u0', [
+        { filename: 'report.pdf', key },
+        { filename: 'report.pdf', key }
+      ])
+    ]
+
+    expect(filenamesReaching(dedupeAttachments(messages))).toHaveLength(1)
+  })
+
+  it('does not collapse distinct files that share a name', () => {
+    const messages = [
+      userTurn('u0', [
+        { filename: 'screenshot.png', key: 'user/chats/c/1-screenshot.png' }
+      ]),
+      assistantTurn('a0'),
+      userTurn('u1', [
+        { filename: 'screenshot.png', key: 'user/chats/c/2-screenshot.png' }
+      ])
+    ]
+
+    expect(dedupeAttachments(messages)).toEqual(messages)
+  })
+
+  it('falls back to the url when the part carries no object key', () => {
+    const url = 'data:image/png;base64,AAAA'
+    const messages = [
+      userTurn('u0', [{ filename: 'chart.png', url }]),
+      assistantTurn('a0'),
+      userTurn('u1', [{ filename: 'chart-copy.png', url }])
+    ]
+
+    expect(filenamesReaching(dedupeAttachments(messages))).toEqual([
+      'chart.png'
+    ])
+  })
+
+  it('keeps parts that identify nothing', () => {
+    const messages = [
+      userTurn('u0', [{ filename: 'a.png', url: '' }]),
+      assistantTurn('a0'),
+      userTurn('u1', [{ filename: 'b.png', url: '' }])
+    ]
+
+    expect(dedupeAttachments(messages)).toEqual(messages)
+  })
+
+  it('keeps a message that held only duplicated attachments non-empty', () => {
+    const key = 'user/chats/c/1-only.png'
+    const messages: UIMessage[] = [
+      userTurn('u0', [{ filename: 'only.png', key }]),
+      assistantTurn('a0'),
+      {
+        id: 'files-only',
+        role: 'user',
+        parts: [
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            filename: 'only.png',
+            url: 'https://uploads.example.com/1-only.png?sig=abc',
+            key
+          }
+        ]
+      } as unknown as UIMessage
+    ]
+
+    const deduped = dedupeAttachments(messages)
+
+    expect(deduped[2].parts).toHaveLength(1)
+    expect(deduped[2].parts[0]).toMatchObject({ type: 'text' })
+  })
+
+  it('keeps what was already sent identical as the thread grows', () => {
+    // The cache property: a later turn must not change the decision made for an
+    // earlier one, or the prompt prefix is rewritten on every turn.
+    const key = 'user/chats/c/1-report.pdf'
+    const head = [
+      userTurn('u0', [{ filename: 'report.pdf', key }]),
+      assistantTurn('a0'),
+      userTurn('u1', [{ filename: 'report.pdf', key }])
+    ]
+
+    const before = dedupeAttachments(head)
+    const after = dedupeAttachments([
+      ...head,
+      assistantTurn('a1'),
+      userTurn('u2', [{ filename: 'report.pdf', key }])
+    ])
+
+    expect(after.slice(0, head.length)).toEqual(before)
+  })
+
+  it('puts no url or timestamp in the placeholder and escapes the filename', () => {
+    const key = 'user/chats/c/1-hostile.png'
+    const hostile = '<script>alert(1)</script>\nsecond line.png'
+    const messages = [
+      userTurn('u0', [{ filename: hostile, key, mediaType: 'image/png' }]),
+      assistantTurn('a0'),
+      userTurn('u1', [
+        {
+          filename: hostile,
+          key,
+          mediaType: 'image/png',
+          url: 'https://uploads.example.com/x.png?X-Amz-Signature=deadbeef'
+        }
+      ])
+    ]
+
+    const [placeholder] = placeholders(dedupeAttachments(messages))
+
+    expect(placeholder).toContain('&lt;script&gt;')
+    expect(placeholder).not.toContain('<script>')
+    expect(placeholder).not.toContain('\n')
+    expect(placeholder).not.toContain('X-Amz-Signature')
+    expect(placeholder).not.toContain('https://')
+  })
+})

--- a/lib/streaming/helpers/attachment-parts.ts
+++ b/lib/streaming/helpers/attachment-parts.ts
@@ -1,0 +1,30 @@
+import type { UIMessage } from 'ai'
+
+const MAX_FILENAME_CHARS = 80
+
+export type FilePartLike = {
+  mediaType?: string
+  filename?: string
+  url?: string
+  key?: string
+}
+
+export function isFilePart(part: UIMessage['parts'][number]) {
+  return part.type === 'file'
+}
+
+export function describeAttachment(part: FilePartLike) {
+  // The filename is user-supplied, so neutralize it the way source excerpts are
+  // neutralized: no markup, no newlines, bounded length.
+  const filename = (part.filename ?? '')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_FILENAME_CHARS)
+  const mediaType = (part.mediaType ?? 'file').replace(/[^\w.+/-]/g, '')
+
+  return filename
+    ? `"${filename}" (${mediaType})`
+    : `an earlier ${mediaType} attachment`
+}

--- a/lib/streaming/helpers/cap-historical-attachments.ts
+++ b/lib/streaming/helpers/cap-historical-attachments.ts
@@ -1,5 +1,7 @@
 import type { UIMessage } from 'ai'
 
+import { describeAttachment, isFilePart } from './attachment-parts'
+
 const DEFAULT_REPLAY_LIMIT = 10
 
 /**
@@ -24,24 +26,6 @@ export const HISTORY_ATTACHMENT_REPLAY_LIMIT = parseReplayLimit(
   process.env.HISTORY_ATTACHMENT_REPLAY_LIMIT
 )
 
-const MAX_FILENAME_CHARS = 80
-
-function describeAttachment(part: { mediaType?: string; filename?: string }) {
-  // The filename is user-supplied, so neutralize it the way source excerpts are
-  // neutralized: no markup, no newlines, bounded length.
-  const filename = (part.filename ?? '')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .slice(0, MAX_FILENAME_CHARS)
-  const mediaType = (part.mediaType ?? 'file').replace(/[^\w.+/-]/g, '')
-
-  return filename
-    ? `"${filename}" (${mediaType})`
-    : `an earlier ${mediaType} attachment`
-}
-
 /**
  * Number of leading attachments to drop, quantized to whole blocks of `limit`.
  *
@@ -58,10 +42,6 @@ function describeAttachment(part: { mediaType?: string; filename?: string }) {
 function getDroppedCount(total: number, limit: number): number {
   if (total <= limit) return 0
   return Math.floor((total - limit) / limit) * limit
-}
-
-function isFilePart(part: UIMessage['parts'][number]) {
-  return part.type === 'file'
 }
 
 /**

--- a/lib/streaming/helpers/dedupe-attachments.ts
+++ b/lib/streaming/helpers/dedupe-attachments.ts
@@ -1,0 +1,76 @@
+import type { UIMessage } from 'ai'
+
+import {
+  describeAttachment,
+  type FilePartLike,
+  isFilePart
+} from './attachment-parts'
+
+/**
+ * Identity of the stored bytes, or undefined when the part carries nothing that
+ * identifies them.
+ *
+ * The R2 object key names one immutable object, so two parts sharing it are the
+ * same file. The url is the fallback for parts stored without a key (data urls,
+ * external links); signed urls are derived from the key and signed once per
+ * request, so equal keys still produce equal urls within a single call.
+ *
+ * The filename is deliberately not part of the identity: two different files
+ * are routinely both called screenshot.png.
+ */
+function attachmentIdentity(part: FilePartLike): string | undefined {
+  if (part.key) return `key:${part.key}`
+  if (part.url) return `url:${part.url}`
+  return undefined
+}
+
+/**
+ * Sends a file to the model once, however many times it was attached.
+ *
+ * The same file lands in a conversation twice more often than it sounds: the
+ * usual path is a user re-attaching something because the first copy went
+ * unmentioned in the reply. Every copy is then replayed on every later turn,
+ * and a single PDF can be several hundred thousand tokens, so one accidental
+ * duplicate roughly doubles the input of the rest of the thread for no added
+ * information.
+ *
+ * The first occurrence is the one kept, so the decision for any given part
+ * depends only on the parts before it: appending turns never rewrites the
+ * prompt prefix, and the provider cache survives.
+ *
+ * This is not `capHistoricalAttachments`. That one bounds the attachment count
+ * and drops the oldest; duplicates can sit far below its cap and still dominate
+ * the payload. Run it first, so an attachment it already turned into a
+ * placeholder cannot swallow the copy the user just re-attached.
+ */
+export function dedupeAttachments(messages: UIMessage[]): UIMessage[] {
+  const seen = new Set<string>()
+
+  return messages.map(message => {
+    if (!message.parts.some(isFilePart)) return message
+
+    let replaced = false
+    const parts = message.parts.map(part => {
+      if (!isFilePart(part)) return part
+
+      const file = part as FilePartLike
+      const identity = attachmentIdentity(file)
+      if (!identity) return part
+
+      if (!seen.has(identity)) {
+        seen.add(identity)
+        return part
+      }
+
+      replaced = true
+      return {
+        type: 'text' as const,
+        text: `[Duplicate attachment omitted: ${describeAttachment(
+          file
+        )} is already attached earlier in this conversation.]`
+      }
+    })
+
+    return replaced ? { ...message, parts } : message
+  })
+}


### PR DESCRIPTION
Closes #946

The same file can end up attached more than once in a chat, most often when a user re-uploads because the first attachment went unmentioned in the reply. Every copy was then replayed to the model on each later turn, for no added information.

## Changes

**Send a repeated attachment once** (`lib/streaming/helpers/dedupe-attachments.ts`)

When building the model messages, an attachment identical to one already present collapses to a short placeholder and only the first occurrence is sent. Identity is the R2 object key, falling back to the url for parts stored without one; the filename is deliberately not part of it, so two different files both called `screenshot.png` stay separate.

Applied after `capHistoricalAttachments`, so an attachment that was already turned into a history placeholder cannot swallow the copy the user just re-attached. The decision for any part depends only on the parts before it, so appending turns never rewrites the prompt prefix and the provider cache survives.

**Point a repeated upload at the copy already stored** (`app/api/upload/route.ts`)

Uploading the same file again minted a new object key, which reads as a different file everywhere downstream. The upload now looks for a stored candidate in the same chat and reuses its key, so no second object and no second library row are written.

The lookup is scoped to one chat because object keys live under a per-chat prefix and a chat deletion wipes that prefix; reusing a key across chats would let one chat's deletion break another's attachment.

**Confirm the bytes before reusing** (`lib/storage/r2-client.ts`)

Name, media type and size only narrow the search to one candidate. The decision is a digest comparison, because handing back a different file under the same name would be a silent substitution, which is worse than the duplicate this avoids. S3 and R2 set the ETag of a single-part upload to the MD5 of the body, and everything here is written by one `PutObject` under a 5MB cap, so the `HeadObject` already being made carries the stored digest. A multipart or encrypted ETag is not a digest and is refused.

Every unconfirmed case falls through to a normal upload: no match, different bytes, missing object, unusable ETag, failed lookup, or anonymous mode.

## Notes

The two halves work together. Upload-side reuse alone saves storage but not tokens, since the same key would still be attached twice; message-side dedup alone rarely fires, because re-uploads used to produce distinct keys.

Separate from `capHistoricalAttachments`, which bounds attachment count: duplicates can sit far below that cap and still dominate the payload.

## Tests

- `lib/streaming/helpers/__tests__/dedupe-attachments.test.ts`: re-attach, same-message duplicates, same-name distinct files, url fallback, unidentifiable parts, attachment-only messages, prefix stability, placeholder escaping.
- `app/api/upload/__tests__/route.test.ts`: reuse, candidate narrowing, differing bytes, missing digest, failed lookup, anonymous mode.
- `lib/storage/__tests__/r2-client.test.ts`: ETag digest parsing and rejection.

lint, typecheck, format, build and the full suite pass.