### PR TITLE
feat(streaming): bound replayed attachments by weight, not only by count

### DIFF
--- a/lib/db/__tests__/attachment-sizes.test.ts
+++ b/lib/db/__tests__/attachment-sizes.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { withRLS } from '@/lib/db/with-rls'
+
+import { getAttachmentSizesByObjectKey } from '../actions'
+
+vi.mock('@/lib/db/with-rls', () => ({
+  withOptionalRLS: vi.fn(),
+  withRLS: vi.fn()
+}))
+
+describe('getAttachmentSizesByObjectKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not query for an empty key list', async () => {
+    const result = await getAttachmentSizesByObjectKey({
+      userId: 'user-1',
+      objectKeys: []
+    })
+
+    expect(result).toEqual(new Map())
+    expect(withRLS).not.toHaveBeenCalled()
+  })
+
+  it('maps results by object key and skips null sizes', async () => {
+    const where = vi.fn().mockResolvedValue([
+      { objectKey: 'files/a.pdf', size: 1234 },
+      { objectKey: 'files/missing.pdf', size: null },
+      { objectKey: 'files/b.pdf', size: 5678 }
+    ])
+    const from = vi.fn().mockReturnValue({ where })
+    const select = vi.fn().mockReturnValue({ from })
+
+    vi.mocked(withRLS).mockImplementation(async (_userId, callback) =>
+      callback({ select } as never)
+    )
+
+    const result = await getAttachmentSizesByObjectKey({
+      userId: 'user-1',
+      objectKeys: ['files/a.pdf', 'files/missing.pdf', 'files/b.pdf']
+    })
+
+    expect(result).toEqual(
+      new Map([
+        ['files/a.pdf', 1234],
+        ['files/b.pdf', 5678]
+      ])
+    )
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(from).toHaveBeenCalledTimes(1)
+    expect(where).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -530,6 +530,7 @@ export async function deleteUserNotes(
 }
 
 const CHAT_FILE_CANDIDATE_LIMIT = 5
+const ATTACHMENT_SIZE_LOOKUP_LIMIT = 100
 
 function escapeLikePattern(value: string) {
   return value.replace(/[\\%_]/g, char => `\\${char}`)
@@ -581,6 +582,38 @@ export async function findChatFileCandidates({
       )
       .orderBy(desc(libraryFiles.createdAt))
       .limit(CHAT_FILE_CANDIDATE_LIMIT)
+  )
+}
+
+export async function getAttachmentSizesByObjectKey({
+  userId,
+  objectKeys
+}: {
+  userId: string
+  objectKeys: string[]
+}): Promise<Map<string, number>> {
+  if (objectKeys.length === 0) return new Map()
+
+  const boundedKeys = objectKeys.slice(0, ATTACHMENT_SIZE_LOOKUP_LIMIT)
+  const rows = await withRLS(userId, async tx =>
+    tx
+      .select({
+        objectKey: libraryFiles.objectKey,
+        size: libraryFiles.size
+      })
+      .from(libraryFiles)
+      .where(
+        and(
+          eq(libraryFiles.userId, userId),
+          inArray(libraryFiles.objectKey, boundedKeys)
+        )
+      )
+  )
+
+  return new Map(
+    rows.flatMap(row =>
+      row.size === null ? [] : [[row.objectKey, row.size] as const]
+    )
   )
 }
 

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -25,6 +25,7 @@ import { getTextFromParts } from '../utils/message-utils'
 import { perfLog, perfTime } from '../utils/perf-logging'
 import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
+import { resolveAttachmentSizes } from './helpers/attachment-sizes'
 import { capHistoricalAttachments } from './helpers/cap-historical-attachments'
 import { compactHistoricalMessages } from './helpers/compact-historical-messages'
 import { convertDataPart } from './helpers/convert-data-part'
@@ -154,8 +155,14 @@ export async function createChatStreamResponse(
 
       const messagesWithNonces = assignDataPartNonces(messagesToModel)
       const messagesWithoutSpec = stripSpecFromMessages(messagesWithNonces)
+      const messagesWithAttachmentSizes = await resolveAttachmentSizes(
+        messagesWithoutSpec,
+        userId
+      )
       const messagesToConvert = dedupeAttachments(
-        capHistoricalAttachments(compactHistoricalMessages(messagesWithoutSpec))
+        capHistoricalAttachments(
+          compactHistoricalMessages(messagesWithAttachmentSizes)
+        )
       )
 
       // Convert to model messages and apply context window management

--- a/lib/streaming/helpers/__tests__/attachment-sizes.test.ts
+++ b/lib/streaming/helpers/__tests__/attachment-sizes.test.ts
@@ -1,0 +1,86 @@
+import type { UIMessage } from 'ai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getAttachmentSizesByObjectKey } from '@/lib/db/actions'
+
+import { resolveAttachmentSizes } from '../attachment-sizes'
+
+vi.mock('@/lib/db/actions', () => ({
+  getAttachmentSizesByObjectKey: vi.fn()
+}))
+
+function messages(): UIMessage[] {
+  return [
+    {
+      id: 'u1',
+      role: 'user',
+      parts: [
+        { type: 'text', text: 'Review these' },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          filename: 'a.pdf',
+          url: 'https://example.com/a',
+          key: 'files/a.pdf'
+        },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          filename: 'b.pdf',
+          url: 'https://example.com/b',
+          key: 'files/b.pdf'
+        },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          filename: 'no-key.png',
+          url: 'data:image/png;base64,AAAA'
+        }
+      ]
+    } as unknown as UIMessage
+  ]
+}
+
+describe('resolveAttachmentSizes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('annotates only file parts with matching object keys', async () => {
+    vi.mocked(getAttachmentSizesByObjectKey).mockResolvedValue(
+      new Map([['files/a.pdf', 1234]])
+    )
+    const input = messages()
+
+    const result = await resolveAttachmentSizes(input, 'user-1')
+
+    expect(result).not.toBe(input)
+    expect(result[0].parts[0]).toBe(input[0].parts[0])
+    expect(result[0].parts[1]).toEqual({ ...input[0].parts[1], size: 1234 })
+    expect(result[0].parts[2]).toBe(input[0].parts[2])
+    expect(result[0].parts[3]).toBe(input[0].parts[3])
+    expect(getAttachmentSizesByObjectKey).toHaveBeenCalledWith({
+      userId: 'user-1',
+      objectKeys: ['files/a.pdf', 'files/b.pdf']
+    })
+  })
+
+  it('returns the input unchanged when no size matches', async () => {
+    vi.mocked(getAttachmentSizesByObjectKey).mockResolvedValue(new Map())
+    const input = messages()
+
+    expect(await resolveAttachmentSizes(input, 'user-1')).toBe(input)
+  })
+
+  it('continues with unknown sizes when lookup fails', async () => {
+    const error = new Error('database unavailable')
+    vi.mocked(getAttachmentSizesByObjectKey).mockRejectedValue(error)
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const input = messages()
+
+    expect(await resolveAttachmentSizes(input, 'user-1')).toBe(input)
+    expect(log).toHaveBeenCalledWith('Attachment size lookup failed:', error)
+
+    log.mockRestore()
+  })
+})

--- a/lib/streaming/helpers/__tests__/cap-historical-attachments.test.ts
+++ b/lib/streaming/helpers/__tests__/cap-historical-attachments.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   capHistoricalAttachments,
+  parseAttachmentTokenBudget,
   parseReplayLimit
 } from '../cap-historical-attachments'
 
@@ -198,7 +199,7 @@ describe('capHistoricalAttachments', () => {
   it('replays everything when the limit is disabled', () => {
     const messages = thread(70, 1).concat(userTurn('current', 0))
 
-    expect(capHistoricalAttachments(messages, 0)).toEqual(messages)
+    expect(capHistoricalAttachments(messages, 0, 0)).toEqual(messages)
   })
 
   it('counts attachments across turns, not per message', () => {
@@ -210,6 +211,62 @@ describe('capHistoricalAttachments', () => {
 
     expect(placeholders(capped)).toHaveLength(LIMIT)
     expect(filenamesReaching(capped)).toHaveLength(11)
+  })
+
+  it('bounds heavy attachments below the count limit by weight', () => {
+    const heavy = [
+      userTurn('old', 0),
+      assistantTurn('a0'),
+      userTurn('recent', 0),
+      assistantTurn('a1'),
+      userTurn('current', 0)
+    ]
+    heavy[0].parts.unshift({
+      type: 'file',
+      mediaType: 'application/pdf',
+      filename: 'old.pdf',
+      url: 'https://example.com/old.pdf',
+      size: 500_000
+    } as never)
+    heavy[2].parts.unshift({
+      type: 'file',
+      mediaType: 'application/pdf',
+      filename: 'recent.pdf',
+      url: 'https://example.com/recent.pdf',
+      size: 500_000
+    } as never)
+
+    const capped = capHistoricalAttachments(heavy, LIMIT, 200_000)
+
+    expect(filenamesReaching(capped)).toEqual(['recent.pdf'])
+    expect(placeholders(capped)).toHaveLength(1)
+  })
+
+  it('leaves a thread within the weight budget untouched', () => {
+    const messages = thread(5, 1).concat(userTurn('current', 0))
+
+    expect(capHistoricalAttachments(messages, LIMIT, 200_000)).toBe(messages)
+  })
+
+  it('never applies the weight bound to the newest user message', () => {
+    const messages = thread(1, 0).concat(userTurn('current', 0))
+    messages.at(-1)?.parts.unshift({
+      type: 'file',
+      mediaType: 'application/pdf',
+      filename: 'current.pdf',
+      url: 'https://example.com/current.pdf',
+      size: 5_000_000
+    } as never)
+
+    expect(capHistoricalAttachments(messages, LIMIT, 1).at(-1)).toEqual(
+      messages.at(-1)
+    )
+  })
+
+  it('disables the weight bound with an explicit zero', () => {
+    const messages = thread(25, 1).concat(userTurn('current', 0))
+
+    expect(capHistoricalAttachments(messages, 100, 0)).toBe(messages)
   })
 })
 
@@ -232,5 +289,23 @@ describe('parseReplayLimit', () => {
     expect(parseReplayLimit('0.5')).toBe(1)
     expect(parseReplayLimit('4')).toBe(4)
     expect(parseReplayLimit('12.9')).toBe(12)
+  })
+})
+
+describe('parseAttachmentTokenBudget', () => {
+  it('falls back to the default for unusable values', () => {
+    for (const raw of [undefined, '', '   ', 'many', '-1', 'NaN', 'Infinity']) {
+      expect(parseAttachmentTokenBudget(raw)).toBe(200_000)
+    }
+  })
+
+  it('disables the budget only on an explicit zero', () => {
+    expect(parseAttachmentTokenBudget('0')).toBe(0)
+    expect(parseAttachmentTokenBudget(' 0 ')).toBe(0)
+  })
+
+  it('keeps at least one token for positive values', () => {
+    expect(parseAttachmentTokenBudget('0.5')).toBe(1)
+    expect(parseAttachmentTokenBudget('1200.9')).toBe(1200)
   })
 })

--- a/lib/streaming/helpers/__tests__/dedupe-attachments.test.ts
+++ b/lib/streaming/helpers/__tests__/dedupe-attachments.test.ts
@@ -8,6 +8,7 @@ type FileSpec = {
   key?: string
   url?: string
   mediaType?: string
+  size?: number
 }
 
 function userTurn(id: string, files: FileSpec[], text = 'Look at this') {
@@ -20,7 +21,8 @@ function userTurn(id: string, files: FileSpec[], text = 'Look at this') {
         mediaType: file.mediaType ?? 'application/pdf',
         filename: file.filename,
         url: file.url ?? `https://uploads.example.com/${file.key}?sig=abc`,
-        key: file.key
+        key: file.key,
+        size: file.size
       })),
       { type: 'text', text }
     ]
@@ -104,6 +106,50 @@ describe('dedupeAttachments', () => {
       userTurn('u1', [
         { filename: 'screenshot.png', key: 'user/chats/c/2-screenshot.png' }
       ])
+    ]
+
+    expect(dedupeAttachments(messages)).toEqual(messages)
+  })
+
+  it('collapses byte-identical copies stored under different keys', () => {
+    const messages = [
+      userTurn('u0', [
+        {
+          filename: 'report.pdf',
+          key: 'user/chats/c/1-report.pdf',
+          size: 4096
+        }
+      ]),
+      assistantTurn('a0'),
+      userTurn('u1', [
+        {
+          filename: 'report.pdf',
+          key: 'user/chats/c/2-report.pdf',
+          size: 4096
+        }
+      ])
+    ]
+
+    expect(filenamesReaching(dedupeAttachments(messages))).toEqual([
+      'report.pdf'
+    ])
+  })
+
+  it('keeps same-named files with different sizes separate', () => {
+    const messages = [
+      userTurn('u0', [
+        { filename: 'report.pdf', key: 'files/one', size: 4096 }
+      ]),
+      userTurn('u1', [{ filename: 'report.pdf', key: 'files/two', size: 4097 }])
+    ]
+
+    expect(dedupeAttachments(messages)).toEqual(messages)
+  })
+
+  it('keeps key-based behavior when size is unknown', () => {
+    const messages = [
+      userTurn('u0', [{ filename: 'report.pdf', key: 'files/one' }]),
+      userTurn('u1', [{ filename: 'report.pdf', key: 'files/two' }])
     ]
 
     expect(dedupeAttachments(messages)).toEqual(messages)

--- a/lib/streaming/helpers/__tests__/dedupe-attachments.test.ts
+++ b/lib/streaming/helpers/__tests__/dedupe-attachments.test.ts
@@ -111,7 +111,7 @@ describe('dedupeAttachments', () => {
     expect(dedupeAttachments(messages)).toEqual(messages)
   })
 
-  it('collapses byte-identical copies stored under different keys', () => {
+  it('collapses historical copies stored under different keys', () => {
     const messages = [
       userTurn('u0', [
         {
@@ -127,7 +127,38 @@ describe('dedupeAttachments', () => {
           key: 'user/chats/c/2-report.pdf',
           size: 4096
         }
-      ])
+      ]),
+      assistantTurn('a1'),
+      userTurn('u2', [], 'And what about the second half?')
+    ]
+
+    expect(filenamesReaching(dedupeAttachments(messages))).toEqual([
+      'report.pdf'
+    ])
+  })
+
+  it('never collapses the current turn on metadata alone', () => {
+    const messages = [
+      userTurn('u0', [
+        { filename: 'report.pdf', key: 'files/one', size: 4096 }
+      ]),
+      assistantTurn('a0'),
+      userTurn('u1', [{ filename: 'report.pdf', key: 'files/two', size: 4096 }])
+    ]
+
+    expect(filenamesReaching(dedupeAttachments(messages))).toEqual([
+      'report.pdf',
+      'report.pdf'
+    ])
+  })
+
+  it('still collapses the current turn when the key is the same', () => {
+    const messages = [
+      userTurn('u0', [
+        { filename: 'report.pdf', key: 'files/one', size: 4096 }
+      ]),
+      assistantTurn('a0'),
+      userTurn('u1', [{ filename: 'report.pdf', key: 'files/one', size: 4096 }])
     ]
 
     expect(filenamesReaching(dedupeAttachments(messages))).toEqual([
@@ -140,7 +171,10 @@ describe('dedupeAttachments', () => {
       userTurn('u0', [
         { filename: 'report.pdf', key: 'files/one', size: 4096 }
       ]),
-      userTurn('u1', [{ filename: 'report.pdf', key: 'files/two', size: 4097 }])
+      userTurn('u1', [
+        { filename: 'report.pdf', key: 'files/two', size: 4097 }
+      ]),
+      userTurn('u2', [], 'And the appendix?')
     ]
 
     expect(dedupeAttachments(messages)).toEqual(messages)

--- a/lib/streaming/helpers/attachment-parts.ts
+++ b/lib/streaming/helpers/attachment-parts.ts
@@ -7,6 +7,7 @@ export type FilePartLike = {
   filename?: string
   url?: string
   key?: string
+  size?: number
 }
 
 export function isFilePart(part: UIMessage['parts'][number]) {

--- a/lib/streaming/helpers/attachment-sizes.ts
+++ b/lib/streaming/helpers/attachment-sizes.ts
@@ -1,0 +1,52 @@
+import type { UIMessage } from 'ai'
+
+import { getAttachmentSizesByObjectKey } from '@/lib/db/actions'
+
+import { isFilePart } from './attachment-parts'
+
+export async function resolveAttachmentSizes(
+  messages: UIMessage[],
+  userId: string
+): Promise<UIMessage[]> {
+  const objectKeys = [
+    ...new Set(
+      messages.flatMap(message =>
+        message.parts.flatMap(part => {
+          if (!isFilePart(part)) return []
+          const key = (part as { key?: string }).key
+          return key ? [key] : []
+        })
+      )
+    )
+  ]
+
+  if (objectKeys.length === 0) return messages
+
+  try {
+    const sizes = await getAttachmentSizesByObjectKey({ userId, objectKeys })
+    if (sizes.size === 0) return messages
+
+    let changed = false
+    const resolved = messages.map(message => {
+      let messageChanged = false
+      const parts = message.parts.map(part => {
+        if (!isFilePart(part)) return part
+
+        const key = (part as { key?: string }).key
+        const size = key ? sizes.get(key) : undefined
+        if (size === undefined) return part
+
+        changed = true
+        messageChanged = true
+        return { ...part, size }
+      })
+
+      return messageChanged ? { ...message, parts } : message
+    })
+
+    return changed ? resolved : messages
+  } catch (error) {
+    console.error('Attachment size lookup failed:', error)
+    return messages
+  }
+}

--- a/lib/streaming/helpers/attachment-sizes.ts
+++ b/lib/streaming/helpers/attachment-sizes.ts
@@ -4,11 +4,19 @@ import { getAttachmentSizesByObjectKey } from '@/lib/db/actions'
 
 import { isFilePart } from './attachment-parts'
 
+/**
+ * Keys are collected oldest first, but the cap drops the oldest attachments,
+ * so a thread with more keys than one lookup can carry is bounded from the
+ * newest end. Resolving the ones about to be dropped would leave every
+ * surviving file on the unknown estimate.
+ */
+const MAX_RESOLVED_KEYS = 100
+
 export async function resolveAttachmentSizes(
   messages: UIMessage[],
   userId: string
 ): Promise<UIMessage[]> {
-  const objectKeys = [
+  const allKeys = [
     ...new Set(
       messages.flatMap(message =>
         message.parts.flatMap(part => {
@@ -19,6 +27,7 @@ export async function resolveAttachmentSizes(
       )
     )
   ]
+  const objectKeys = allKeys.slice(-MAX_RESOLVED_KEYS)
 
   if (objectKeys.length === 0) return messages
 

--- a/lib/streaming/helpers/cap-historical-attachments.ts
+++ b/lib/streaming/helpers/cap-historical-attachments.ts
@@ -1,11 +1,15 @@
 import type { UIMessage } from 'ai'
 
+import { estimateAttachmentTokens } from '@/lib/utils/attachment-tokens'
+
 import { describeAttachment, isFilePart } from './attachment-parts'
 
 const DEFAULT_REPLAY_LIMIT = 10
+const DEFAULT_ATTACHMENT_TOKEN_BUDGET = 200_000
 
 /**
- * Only an explicit `0` disables the cap.
+ * Only an explicit `0` disables the count cap. The weight budget below is a
+ * separate knob and keeps applying.
  *
  * Templated environments routinely define a variable as an empty string, and
  * `Number('')` is `0` — which would silently replay every attachment while
@@ -24,6 +28,22 @@ export function parseReplayLimit(raw: string | undefined): number {
 
 export const HISTORY_ATTACHMENT_REPLAY_LIMIT = parseReplayLimit(
   process.env.HISTORY_ATTACHMENT_REPLAY_LIMIT
+)
+
+export function parseAttachmentTokenBudget(raw: string | undefined): number {
+  const value = raw?.trim()
+  if (!value) return DEFAULT_ATTACHMENT_TOKEN_BUDGET
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_ATTACHMENT_TOKEN_BUDGET
+  }
+
+  return parsed === 0 ? 0 : Math.max(1, Math.floor(parsed))
+}
+
+export const HISTORY_ATTACHMENT_TOKEN_BUDGET = parseAttachmentTokenBudget(
+  process.env.HISTORY_ATTACHMENT_TOKEN_BUDGET
 )
 
 /**
@@ -59,9 +79,10 @@ function getDroppedCount(total: number, limit: number): number {
  */
 export function capHistoricalAttachments(
   messages: UIMessage[],
-  limit: number = HISTORY_ATTACHMENT_REPLAY_LIMIT
+  limit: number = HISTORY_ATTACHMENT_REPLAY_LIMIT,
+  tokenBudget: number = HISTORY_ATTACHMENT_TOKEN_BUDGET
 ): UIMessage[] {
-  if (limit <= 0) return messages
+  if (limit <= 0 && tokenBudget <= 0) return messages
 
   const currentTurnIndex = messages.findLastIndex(
     message => message.role === 'user'
@@ -74,7 +95,56 @@ export function capHistoricalAttachments(
     total += messages[i].parts.filter(isFilePart).length
   }
 
-  const dropCount = getDroppedCount(total, limit)
+  const countDropCount = limit > 0 ? getDroppedCount(total, limit) : 0
+  let survivingTokens = 0
+  let survivingCount = 0
+  let seenForBudget = 0
+
+  for (let i = 0; i < historyEnd; i++) {
+    for (const part of messages[i].parts) {
+      if (!isFilePart(part)) continue
+
+      seenForBudget += 1
+      if (seenForBudget <= countDropCount) continue
+
+      const file = part as {
+        mediaType?: string
+        size?: number
+      }
+      survivingTokens += estimateAttachmentTokens(file)
+      survivingCount += 1
+    }
+  }
+
+  // The weight pass drops just enough of the oldest survivors to fit, without
+  // the block quantization the count cap uses. It does not need it: history
+  // only grows, so this boundary only ever moves forward, and each crossing
+  // rewrites the prefix once instead of on every turn.
+  let weightDropCount = 0
+  if (tokenBudget > 0 && survivingTokens > tokenBudget) {
+    seenForBudget = 0
+    for (let i = 0; i < historyEnd; i++) {
+      for (const part of messages[i].parts) {
+        if (!isFilePart(part)) continue
+
+        seenForBudget += 1
+        if (seenForBudget <= countDropCount) continue
+        if (survivingTokens <= tokenBudget || survivingCount <= 1) break
+
+        const file = part as {
+          mediaType?: string
+          size?: number
+        }
+        survivingTokens -= estimateAttachmentTokens(file)
+        survivingCount -= 1
+        weightDropCount += 1
+      }
+
+      if (survivingTokens <= tokenBudget || survivingCount <= 1) break
+    }
+  }
+
+  const dropCount = countDropCount + weightDropCount
   if (dropCount === 0) return messages
 
   let seen = 0

--- a/lib/streaming/helpers/dedupe-attachments.ts
+++ b/lib/streaming/helpers/dedupe-attachments.ts
@@ -7,22 +7,34 @@ import {
 } from './attachment-parts'
 
 /**
- * Identity of the stored bytes, or undefined when the part carries nothing that
- * identifies them.
+ * Every identity a part answers to, strongest first.
  *
- * Name, media type and size together identify byte-identical uploads even when
- * they were stored under different keys. This is safe where filename alone was
- * not: equal keys already imply equal content identity, so this only merges
- * more copies with the same name, type and byte length. The object key and url
- * remain fallbacks when size metadata is unavailable.
+ * The R2 object key names one immutable object, so two parts sharing it are
+ * certainly the same file. The url is the fallback for parts stored without a
+ * key (data urls, external links).
+ *
+ * Name, media type and size together are a weaker claim: they are what the
+ * upload path uses to narrow candidates before it settles the question with a
+ * digest, so equal metadata is evidence of identical bytes rather than proof.
+ *
+ * A kept part registers all of them, and a later part is only matched against
+ * the ones it is allowed to be judged on, so restricting the evidence for one
+ * position never costs a match the stronger identities would have made.
  */
-function attachmentIdentity(part: FilePartLike): string | undefined {
-  if (part.filename && part.mediaType && part.size !== undefined) {
-    return `content:${part.filename}|${part.mediaType}|${part.size}`
-  }
-  if (part.key) return `key:${part.key}`
-  if (part.url) return `url:${part.url}`
-  return undefined
+function attachmentIdentities(part: FilePartLike): {
+  storage: string[]
+  metadata: string[]
+} {
+  const storage: string[] = []
+  if (part.key) storage.push(`key:${part.key}`)
+  if (part.url) storage.push(`url:${part.url}`)
+
+  const metadata =
+    part.filename && part.mediaType && part.size !== undefined
+      ? [`content:${part.filename}|${part.mediaType}|${part.size}`]
+      : []
+
+  return { storage, metadata }
 }
 
 /**
@@ -43,23 +55,35 @@ function attachmentIdentity(part: FilePartLike): string | undefined {
  * and drops the oldest; duplicates can sit far below its cap and still dominate
  * the payload. Run it first, so an attachment it already turned into a
  * placeholder cannot swallow the copy the user just re-attached.
+ *
+ * The newest user message is matched on storage identity only. Two different
+ * files can share a name, a type and a byte length, and collapsing the request
+ * being answered on that evidence would drop the very attachment the user is
+ * asking about. A wrong guess about history costs one replay of something
+ * already answered; a wrong guess about the current turn costs the answer.
  */
 export function dedupeAttachments(messages: UIMessage[]): UIMessage[] {
   const seen = new Set<string>()
+  const currentTurnIndex = messages.findLastIndex(
+    message => message.role === 'user'
+  )
 
-  return messages.map(message => {
+  return messages.map((message, index) => {
     if (!message.parts.some(isFilePart)) return message
 
+    const allowMetadata = index !== currentTurnIndex
     let replaced = false
     const parts = message.parts.map(part => {
       if (!isFilePart(part)) return part
 
       const file = part as FilePartLike
-      const identity = attachmentIdentity(file)
-      if (!identity) return part
+      const { storage, metadata } = attachmentIdentities(file)
+      const all = [...storage, ...metadata]
+      if (all.length === 0) return part
 
-      if (!seen.has(identity)) {
-        seen.add(identity)
+      const judgedOn = allowMetadata ? all : storage
+      if (!judgedOn.some(identity => seen.has(identity))) {
+        all.forEach(identity => seen.add(identity))
         return part
       }
 

--- a/lib/streaming/helpers/dedupe-attachments.ts
+++ b/lib/streaming/helpers/dedupe-attachments.ts
@@ -10,15 +10,16 @@ import {
  * Identity of the stored bytes, or undefined when the part carries nothing that
  * identifies them.
  *
- * The R2 object key names one immutable object, so two parts sharing it are the
- * same file. The url is the fallback for parts stored without a key (data urls,
- * external links); signed urls are derived from the key and signed once per
- * request, so equal keys still produce equal urls within a single call.
- *
- * The filename is deliberately not part of the identity: two different files
- * are routinely both called screenshot.png.
+ * Name, media type and size together identify byte-identical uploads even when
+ * they were stored under different keys. This is safe where filename alone was
+ * not: equal keys already imply equal content identity, so this only merges
+ * more copies with the same name, type and byte length. The object key and url
+ * remain fallbacks when size metadata is unavailable.
  */
 function attachmentIdentity(part: FilePartLike): string | undefined {
+  if (part.filename && part.mediaType && part.size !== undefined) {
+    return `content:${part.filename}|${part.mediaType}|${part.size}`
+  }
   if (part.key) return `key:${part.key}`
   if (part.url) return `url:${part.url}`
   return undefined

--- a/lib/utils/__tests__/attachment-tokens.test.ts
+++ b/lib/utils/__tests__/attachment-tokens.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BYTES_PER_TOKEN,
+  estimateAttachmentTokens,
+  IMAGE_ATTACHMENT_TOKENS,
+  UNKNOWN_ATTACHMENT_TOKENS
+} from '../attachment-tokens'
+
+describe('estimateAttachmentTokens', () => {
+  it('uses a fixed estimate for images', () => {
+    expect(
+      estimateAttachmentTokens({ mediaType: 'image/png', size: 20_000_000 })
+    ).toBe(IMAGE_ATTACHMENT_TOKENS)
+  })
+
+  it('estimates known PDF sizes from their byte length', () => {
+    expect(
+      estimateAttachmentTokens({ mediaType: 'application/pdf', size: 3_901 })
+    ).toBe(Math.ceil(3_901 / BYTES_PER_TOKEN))
+  })
+
+  it('uses the unknown estimate when size is unavailable', () => {
+    expect(estimateAttachmentTokens({ mediaType: 'application/pdf' })).toBe(
+      UNKNOWN_ATTACHMENT_TOKENS
+    )
+    expect(
+      estimateAttachmentTokens({ mediaType: 'application/pdf', size: null })
+    ).toBe(UNKNOWN_ATTACHMENT_TOKENS)
+  })
+
+  it('estimates an unrecognized media type from its byte length', () => {
+    expect(
+      estimateAttachmentTokens({
+        mediaType: 'application/octet-stream',
+        size: 3_901
+      })
+    ).toBe(Math.ceil(3_901 / BYTES_PER_TOKEN))
+  })
+
+  it('uses the unknown estimate when neither type nor size says anything', () => {
+    expect(estimateAttachmentTokens({})).toBe(UNKNOWN_ATTACHMENT_TOKENS)
+  })
+})

--- a/lib/utils/__tests__/context-window.test.ts
+++ b/lib/utils/__tests__/context-window.test.ts
@@ -90,6 +90,24 @@ describe('context-window', () => {
       expect(shouldTruncateMessages(messages, mockModel)).toBe(true)
     })
 
+    test('counts file parts toward the context window', () => {
+      const unknownModel: Model = { ...mockModel, id: 'unknown-model' }
+      const messages: ModelMessage[] = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'application/pdf',
+              data: 'https://example.com/report.pdf'
+            }
+          ]
+        }
+      ]
+
+      expect(shouldTruncateMessages(messages, unknownModel)).toBe(true)
+    })
+
     test('handles null/undefined messages gracefully', () => {
       expect(shouldTruncateMessages(null as any, mockModel)).toBe(false)
       expect(shouldTruncateMessages(undefined as any, mockModel)).toBe(false)

--- a/lib/utils/attachment-tokens.ts
+++ b/lib/utils/attachment-tokens.ts
@@ -1,0 +1,21 @@
+export const IMAGE_ATTACHMENT_TOKENS = 10_000
+export const BYTES_PER_TOKEN = 3.9
+export const UNKNOWN_ATTACHMENT_TOKENS = 50_000
+
+export function estimateAttachmentTokens({
+  mediaType,
+  size
+}: {
+  mediaType?: string
+  size?: number | null
+}): number {
+  // An image is tiled by the provider, so its cost does not follow its byte
+  // length. Every other document is charged for what its bytes expand into.
+  if (mediaType?.startsWith('image/')) return IMAGE_ATTACHMENT_TOKENS
+
+  if (typeof size === 'number' && Number.isFinite(size) && size >= 0) {
+    return Math.ceil(size / BYTES_PER_TOKEN)
+  }
+
+  return UNKNOWN_ATTACHMENT_TOKENS
+}

--- a/lib/utils/context-window.ts
+++ b/lib/utils/context-window.ts
@@ -3,6 +3,8 @@ import { getEncoding, type TiktokenEncoding } from 'js-tiktoken'
 
 import { Model } from '../types/models'
 
+import { estimateAttachmentTokens } from './attachment-tokens'
+
 interface ModelContextInfo {
   contextWindow: number
   outputTokens: number
@@ -159,7 +161,22 @@ function estimateTokenCount(
   modelId?: string
 ): number {
   const text = extractTextContent(content)
-  if (!text) return 0
+  const attachmentTokens = Array.isArray(content)
+    ? content.reduce((total, part) => {
+        if (part.type !== 'file') return total
+
+        return (
+          total +
+          estimateAttachmentTokens({
+            mediaType: part.mediaType,
+            size:
+              part.data instanceof Uint8Array ? part.data.byteLength : undefined
+          })
+        )
+      }, 0)
+    : 0
+
+  if (!text) return attachmentTokens
 
   // Try to use tiktoken for accurate counting
   if (modelId) {
@@ -169,7 +186,7 @@ function estimateTokenCount(
         const tokens = encoder.encode(text)
         const tokenCount = tokens.length
         const overhead = 4 // Message formatting tokens
-        return tokenCount + overhead
+        return tokenCount + overhead + attachmentTokens
       } catch (error) {
         if (process.env.NODE_ENV === 'development') {
           console.warn(
@@ -186,7 +203,7 @@ function estimateTokenCount(
   const baseCount = Math.ceil(text.length / 4)
   const overhead = 4 // Message formatting tokens
 
-  return baseCount + overhead
+  return baseCount + overhead + attachmentTokens
 }
 
 /**


### PR DESCRIPTION
Closes #950

## Problem

Attachments are replayed to the model on every turn, and none of the three bounds in the pipeline bounds what one actually costs. A thread carrying a large file keeps paying for it on every later turn, and a thread carrying two byte-identical copies stored as two separate objects pays twice for the life of the thread.

## Root cause

Three gaps that compose:

- `capHistoricalAttachments` bounds the **count** of replayed attachments. Two large PDFs sit far below the limit while dominating the payload.
- `dedupeAttachments` keys identity on the **R2 object key**, falling back to the url. Two byte-identical files stored under two keys read as two different attachments, which is the state of every copy uploaded before the upload-side key reuse in #947. That reuse only applies to new uploads, so those histories stay duplicated.
- `extractTextContent` in `lib/utils/context-window.ts` returns `''` for any part without a `text` field, so file and image parts contributed **zero** to `estimateTokenCount`. A history dominated by attachments was invisible to `shouldTruncateMessages` no matter where the threshold sat.

The blocker for fixing any of it: a file part carries no size. `FileUIPart` is `{type, mediaType, filename, url, key}` and `message_parts` has no size column. Size lives only in the `files` table, written on every non-anonymous upload.

## Fix

**Resolve size at request time, without a schema change** (`lib/streaming/helpers/attachment-sizes.ts`, `lib/db/actions.ts`)

`resolveAttachmentSizes` collects the object keys in the history, makes one RLS-scoped lookup against the file library, and annotates the matching parts. The annotation is request-local: nothing is persisted and no other part is touched. A failed lookup logs and continues with sizes unknown. Guests have no library rows, so the ephemeral path does no lookup at all and simply runs with sizes unknown.

Doing it this way rather than adding a column is what makes the fix reach **existing** conversations: the rows for already-uploaded duplicates are already there.

**Estimate weight, biased high** (`lib/utils/attachment-tokens.ts`)

Underestimating reproduces the bug being fixed (the bound never fires), while overestimating only drops history slightly early, so the estimate leans high on purpose. An image is a fixed constant, because a provider tiles it and its cost does not follow its byte length; treating a large photo by its bytes would evict every image. Anything else with a known size is estimated from its bytes, and an attachment whose size or type says nothing falls back to a deliberately large constant.

**Recognise copies stored under different keys** (`lib/streaming/helpers/dedupe-attachments.ts`)

Identity now prefers filename plus media type plus size when all three are known, falling back to the key and then the url exactly as before. This is safe where filename alone was not: equal keys already imply an equal content identity, so it only ever merges more copies that match in name, type and byte length. First occurrence still wins, which is what keeps the prompt prefix stable.

**Enforce a token budget** (`lib/streaming/helpers/cap-historical-attachments.ts`)

The existing count cap and its block quantization are unchanged. After it, the survivors are walked oldest first and turned into the same placeholder until the estimated total fits `HISTORY_ATTACHMENT_TOKEN_BUDGET`. The weight pass is deliberately not quantized: history only grows, so its boundary only moves forward and each crossing rewrites the prefix once rather than every turn. The newest user message is never capped.

**Stop counting files as free** (`lib/utils/context-window.ts`)

`estimateTokenCount` adds attachment weight to its total. After `convertToModelMessages` a file part carries no size, so the estimate uses the media type and a byte length only where one is directly available.

## Notes

The two halves address different failure modes. Content identity retires duplicates that are already in a history; the token budget covers the case a single large attachment creates on its own, which no identity check can help with.

## Verification

- `dedupe-attachments`: two different object keys with identical filename, media type and size collapse to one; same name with a different size stays separate; behaviour with size unknown is unchanged, and the pre-existing cases still pass.
- `cap-historical-attachments`: a pair of heavy attachments under the count limit is bounded by weight, a thread within budget is untouched, the newest user message is never capped, and an explicit `0` disables the budget.
- `attachment-tokens`: the image constant, the byte-based path, unknown size, and an attachment that says nothing at all.
- `attachment-sizes` and the lookup: empty input issues no query, results map by object key, null sizes are skipped, only matching parts are annotated, and a failing lookup leaves the messages alone.
- `context-window`: a history of file parts is no longer estimated at zero.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test` all pass locally.