### PR TITLE
fix(upload): reject files whose contents are not a supported format

### DIFF
--- a/app/api/upload/__tests__/route.test.ts
+++ b/app/api/upload/__tests__/route.test.ts
@@ -50,10 +50,14 @@ const EXISTING = {
  * The route only reads headers and formData, so a stub avoids round-tripping a
  * File through multipart encoding in the test environment.
  */
-function uploadRequest(bytes = 1234, contents = pdfUploadBytes(bytes)) {
+function uploadRequest(
+  bytes = 1234,
+  contents = pdfUploadBytes(bytes),
+  declared = { name: 'report.pdf', type: 'application/pdf' }
+) {
   const file = {
-    name: 'report.pdf',
-    type: 'application/pdf',
+    name: declared.name,
+    type: declared.type,
     size: bytes,
     arrayBuffer: async () => contents.buffer
   }
@@ -142,6 +146,36 @@ describe('POST /api/upload', () => {
     expect(dbActions.findChatFileCandidates).not.toHaveBeenCalled()
     expect(send).not.toHaveBeenCalled()
     expect(dbActions.createLibraryFile).not.toHaveBeenCalled()
+  })
+
+  it('stores a mislabelled file under the type its bytes say it is', async () => {
+    // A document renamed to .jpg is reported as an image by the browser, and
+    // handing it to the provider as one fails the turn just like unreadable
+    // content does.
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([])
+    const contents = pdfUploadBytes(1234)
+
+    const { file } = await (
+      await POST(
+        uploadRequest(contents.byteLength, contents, {
+          name: 'report.jpg',
+          type: 'image/jpeg'
+        })
+      )
+    ).json()
+
+    expect(file.mediaType).toBe('application/pdf')
+    expect(dbActions.findChatFileCandidates).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: 'application/pdf' })
+    )
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ ContentType: 'application/pdf' })
+      })
+    )
+    expect(dbActions.createLibraryFile).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: 'application/pdf' })
+    )
   })
 
   it('uploads when the candidate holds different bytes', async () => {

--- a/app/api/upload/__tests__/route.test.ts
+++ b/app/api/upload/__tests__/route.test.ts
@@ -50,12 +50,12 @@ const EXISTING = {
  * The route only reads headers and formData, so a stub avoids round-tripping a
  * File through multipart encoding in the test environment.
  */
-function uploadRequest(bytes = 1234) {
+function uploadRequest(bytes = 1234, contents = pdfUploadBytes(bytes)) {
   const file = {
     name: 'report.pdf',
     type: 'application/pdf',
     size: bytes,
-    arrayBuffer: async () => new Uint8Array(bytes).buffer
+    arrayBuffer: async () => contents.buffer
   }
   const formData = new Map<string, unknown>([
     ['file', file],
@@ -68,8 +68,14 @@ function uploadRequest(bytes = 1234) {
   } as any
 }
 
+function pdfUploadBytes(bytes = 1234) {
+  const contents = new Uint8Array(bytes)
+  contents.set(Buffer.from('%PDF-', 'ascii'))
+  return contents
+}
+
 function md5OfUpload(bytes = 1234) {
-  return createHash('md5').update(Buffer.alloc(bytes)).digest('hex')
+  return createHash('md5').update(pdfUploadBytes(bytes)).digest('hex')
 }
 
 describe('POST /api/upload', () => {
@@ -120,6 +126,22 @@ describe('POST /api/upload', () => {
 
     expect(file.key).not.toBe(EXISTING.objectKey)
     expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('rejects allowed declared types with unsupported content', async () => {
+    const contents = new Uint8Array([
+      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d
+    ])
+
+    const response = await POST(uploadRequest(contents.byteLength, contents))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      error: 'Unsupported file content'
+    })
+    expect(dbActions.findChatFileCandidates).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+    expect(dbActions.createLibraryFile).not.toHaveBeenCalled()
   })
 
   it('uploads when the candidate holds different bytes', async () => {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -8,7 +8,8 @@ import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import {
   detectFileMediaType,
-  isSupportedFileType
+  isSupportedFileType,
+  type SupportedFileType
 } from '@/lib/storage/file-signature'
 import {
   getChatFileObjectKeyPrefix,
@@ -70,12 +71,12 @@ export async function POST(req: NextRequest) {
     const isAnonymous = process.env.ENABLE_AUTH === 'false'
     const buffer = Buffer.from(await file.arrayBuffer())
 
-    // The browser reports file.type from the name, so an unreadable file passes
-    // the check above and only fails later, once the provider rejects the whole
-    // turn. The bytes decide whether the file is readable at all; which of the
-    // supported formats they match is deliberately not used to overwrite the
-    // declared type, because file identity downstream keys off it.
-    if (!detectFileMediaType(buffer)) {
+    // The browser reports file.type from the name, so the check above says
+    // nothing about the contents. Only the bytes do, and from here on they are
+    // what the file is: sending a document to the provider as an image fails
+    // the whole turn just as surely as sending something unreadable.
+    const mediaType = detectFileMediaType(buffer)
+    if (!mediaType) {
       return NextResponse.json(
         {
           error: 'Unsupported file content',
@@ -87,7 +88,13 @@ export async function POST(req: NextRequest) {
     }
 
     if (!isAnonymous && chatId) {
-      const reused = await reuseExistingChatFile(file, buffer, userId, chatId)
+      const reused = await reuseExistingChatFile(
+        file,
+        buffer,
+        mediaType,
+        userId,
+        chatId
+      )
       if (reused) {
         return NextResponse.json(
           { success: true, file: reused },
@@ -96,7 +103,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const result = await uploadFileToR2(file, buffer, userId, chatId)
+    const result = await uploadFileToR2(file, buffer, mediaType, userId, chatId)
     if (isAnonymous) {
       return NextResponse.json({ success: true, file: result }, { status: 200 })
     }
@@ -168,6 +175,7 @@ export async function POST(req: NextRequest) {
 async function reuseExistingChatFile(
   file: File,
   buffer: Buffer,
+  mediaType: SupportedFileType,
   userId: string,
   chatId: string
 ) {
@@ -176,7 +184,7 @@ async function reuseExistingChatFile(
       userId,
       chatKeyPrefix: getChatFileObjectKeyPrefix(userId, chatId),
       filename: file.name,
-      mediaType: file.type,
+      mediaType,
       size: file.size
     })
     if (candidates.length === 0) return null
@@ -215,6 +223,7 @@ function sanitizeFilename(filename: string) {
 async function uploadFileToR2(
   file: File,
   buffer: Buffer,
+  mediaType: SupportedFileType,
   userId: string,
   chatId: string
 ) {
@@ -229,7 +238,7 @@ async function uploadFileToR2(
         Bucket: R2_BUCKET_NAME,
         Key: filePath,
         Body: buffer,
-        ContentType: file.type,
+        ContentType: mediaType,
         CacheControl: 'max-age=3600'
       })
     )
@@ -240,7 +249,7 @@ async function uploadFileToR2(
       filename: file.name,
       key: filePath,
       url: signedUrl,
-      mediaType: file.type,
+      mediaType,
       type: 'file'
     }
   } catch (error: any) {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -7,6 +7,10 @@ import { capture } from '@/lib/analytics/dispatch'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import {
+  detectFileMediaType,
+  isSupportedFileType
+} from '@/lib/storage/file-signature'
+import {
   getChatFileObjectKeyPrefix,
   getObjectContentMd5,
   getR2Client,
@@ -16,7 +20,6 @@ import {
 } from '@/lib/storage/r2-client'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'application/pdf']
 
 export async function POST(req: NextRequest) {
   try {
@@ -58,7 +61,7 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    if (!ALLOWED_TYPES.includes(file.type)) {
+    if (!isSupportedFileType(file.type)) {
       return NextResponse.json(
         { error: 'Unsupported file type' },
         { status: 400 }
@@ -66,6 +69,22 @@ export async function POST(req: NextRequest) {
     }
     const isAnonymous = process.env.ENABLE_AUTH === 'false'
     const buffer = Buffer.from(await file.arrayBuffer())
+
+    // The browser reports file.type from the name, so an unreadable file passes
+    // the check above and only fails later, once the provider rejects the whole
+    // turn. The bytes decide whether the file is readable at all; which of the
+    // supported formats they match is deliberately not used to overwrite the
+    // declared type, because file identity downstream keys off it.
+    if (!detectFileMediaType(buffer)) {
+      return NextResponse.json(
+        {
+          error: 'Unsupported file content',
+          message:
+            'The file contents are not a JPEG, PNG, or PDF even though the file name suggests otherwise.'
+        },
+        { status: 400 }
+      )
+    }
 
     if (!isAnonymous && chatId) {
       const reused = await reuseExistingChatFile(file, buffer, userId, chatId)

--- a/lib/storage/__tests__/file-signature.test.ts
+++ b/lib/storage/__tests__/file-signature.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectFileMediaType } from '../file-signature'
+
+describe('detectFileMediaType', () => {
+  it('detects JPEG content', () => {
+    expect(detectFileMediaType(Buffer.from([0xff, 0xd8, 0xff, 0xe0]))).toBe(
+      'image/jpeg'
+    )
+  })
+
+  it('detects PNG content', () => {
+    expect(
+      detectFileMediaType(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      )
+    ).toBe('image/png')
+  })
+
+  it('detects PDF content', () => {
+    expect(detectFileMediaType(Buffer.from('%PDF-1.7', 'ascii'))).toBe(
+      'application/pdf'
+    )
+  })
+
+  it('detects a PDF header after a preamble', () => {
+    expect(
+      detectFileMediaType(Buffer.from('preamble\n%PDF-1.7', 'ascii'))
+    ).toBe('application/pdf')
+  })
+
+  it('rejects the MP4 content from the production upload', () => {
+    expect(
+      detectFileMediaType(
+        Buffer.from([
+          0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d
+        ])
+      )
+    ).toBeNull()
+  })
+
+  it('rejects empty and short content', () => {
+    expect(detectFileMediaType(Buffer.alloc(0))).toBeNull()
+    expect(detectFileMediaType(Buffer.from([0xff, 0xd8]))).toBeNull()
+  })
+})

--- a/lib/storage/file-signature.ts
+++ b/lib/storage/file-signature.ts
@@ -1,0 +1,30 @@
+export const ALLOWED_FILE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'application/pdf'
+] as const
+
+export type SupportedFileType = (typeof ALLOWED_FILE_TYPES)[number]
+
+const signatures: Record<SupportedFileType, (buffer: Buffer) => boolean> = {
+  'image/jpeg': buffer =>
+    buffer.subarray(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff])),
+  'image/png': buffer =>
+    buffer
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])),
+  'application/pdf': buffer =>
+    buffer.subarray(0, 1024).indexOf(Buffer.from('%PDF-', 'ascii')) !== -1
+}
+
+export function isSupportedFileType(value: string): value is SupportedFileType {
+  return ALLOWED_FILE_TYPES.some(mediaType => mediaType === value)
+}
+
+export function detectFileMediaType(buffer: Buffer): SupportedFileType | null {
+  for (const mediaType of ALLOWED_FILE_TYPES) {
+    if (signatures[mediaType](buffer)) return mediaType
+  }
+
+  return null
+}


### PR DESCRIPTION
## Problem

An upload can pass validation while carrying bytes that are not the format it claims to be. When that happens the file is stored, attached to the chat, and replayed to the model as an image on later turns. The provider rejects the entire request, so the turn produces no answer and the user sees only a generic error with nothing pointing at the attachment.

Observed in production: a file named `image.jpg` was accepted as `image/jpeg`, but its leading bytes were an ISO base media container (`ftypisom`, i.e. MP4/MOV), and the provider answered with an `invalid_request_error` on the image input.

## Root cause

`app/api/upload/route.ts` gated the upload on `ALLOWED_TYPES.includes(file.type)` alone. `file.type` is supplied by the browser, which derives it from the file name extension rather than from the contents, so any file renamed to `.jpg`, `.png`, or `.pdf` is reported as that type and passes. The route then wrote the object with `ContentType: file.type` and persisted the same value as the attachment's media type, so the mismatch was carried all the way to the provider request.

## Fix

- New `lib/storage/file-signature.ts` detects the supported formats from the leading bytes: JPEG (`FF D8 FF`), PNG (`89 50 4E 47 0D 0A 1A 0A`), and PDF (`%PDF-` within the first 1024 bytes, since the spec permits a preamble before the header). The allowed-type list now lives in this module so the declared-type gate and the signature check cannot drift apart.
- The route runs the check right after reading the buffer, before the duplicate lookup and before any object-storage write. Bytes matching none of the supported formats are rejected with a 400 that names the actual problem.
- Past that point the detected type is what the file is. It is threaded through the duplicate lookup, the object's `ContentType`, the library row, and the returned attachment part, so a document renamed to `.jpg` is stored and sent as a document instead of failing the turn as a broken image. For every upload whose bytes match its declared type, which is the normal case, behaviour is unchanged.

Rejecting on a declared/detected mismatch was the alternative, but it would also refuse harmless files: a valid PNG saved as `photo.jpg` is reported as `image/jpeg` by the browser and works end to end today.

Scope notes: this closes the entry point only. Files already stored under a wrong media type are unaffected and will keep failing on the turns that replay them. A file uploaded before this change under a wrong declared type will also not match a re-upload's corrected type, so it mints a new object instead of deduplicating; that costs a duplicate, not a failure.

## Verification

- New unit tests cover each supported signature, a PDF behind a preamble, the container header from the production case, and empty/short buffers.
- New route tests assert that unreadable content returns 400 without reaching the duplicate lookup, object storage, or the library-file write, and that a mislabelled file is stored under its detected type across all four sinks.
- The existing route tests built their upload from an all-zero buffer, which the new check rejects. The shared fixture now carries a valid PDF header, and the digest helper hashes the same bytes so the dedup test still exercises a real match.
- `bun run test`, `bun lint`, `bun typecheck`, `bun format:check`, `bun run build` all pass locally.