### PR TITLE
fix(errors): classify a malformed provider request instead of a generic 400

### DIFF
--- a/lib/errors/__tests__/public-error.test.ts
+++ b/lib/errors/__tests__/public-error.test.ts
@@ -204,6 +204,35 @@ describe('public error mapping', () => {
     expect(payload.code).toBe('bad_request')
   })
 
+  it('survives the serialize and reparse round trip the client performs', () => {
+    const serialized = serializePublicError(
+      Object.assign(new Error('Invalid body: failed to parse JSON value.'), {
+        statusCode: 400
+      })
+    )
+    const payload = toPublicErrorPayload(new Error(serialized))
+
+    expect(payload.code).toBe('malformed_request')
+    expect(payload.error).toBe(
+      'This conversation could not be sent to the model. Please start a new chat.'
+    )
+    expect(payload.details).toBe(
+      'Retrying this message will fail the same way.'
+    )
+    expect(payload.retryable).toBe(false)
+  })
+
+  it('does not honour a malformed_request code carrying foreign copy', () => {
+    const payload = toPublicErrorPayload({
+      error: 'Upstream said something we should not show verbatim.',
+      code: 'malformed_request'
+    })
+
+    expect(payload.error).not.toBe(
+      'Upstream said something we should not show verbatim.'
+    )
+  })
+
   it('keeps upstream "Invalid JSON response" fetch failures on the bad request path', () => {
     const payload = toPublicErrorPayload({
       error: 'Invalid JSON response',

--- a/lib/errors/__tests__/public-error.test.ts
+++ b/lib/errors/__tests__/public-error.test.ts
@@ -159,6 +159,69 @@ describe('public error mapping', () => {
     expect(payload.error).not.toContain('144000')
   })
 
+  it('maps malformed 400 request messages to actionable copy', () => {
+    const error = Object.assign(
+      new Error(
+        'Invalid body: failed to parse JSON value. Please check the value to ensure it is valid JSON. (Common errors include trailing commas, missing closing brackets, missing quotation marks, etc.)'
+      ),
+      { statusCode: 400 }
+    )
+    const payload = toPublicErrorPayload(error)
+
+    expect(payload.code).toBe('malformed_request')
+    expect(payload.error).toBe(
+      'This conversation could not be sent to the model. Please start a new chat.'
+    )
+    expect(payload.details).toBe(
+      'Retrying this message will fail the same way.'
+    )
+    expect(payload.retryable).toBe(false)
+  })
+
+  it('maps malformed 400 provider codes to actionable copy', () => {
+    const error = Object.assign(new Error('Request failed'), {
+      statusCode: 400,
+      code: 'invalid_json'
+    })
+    const payload = toPublicErrorPayload(error)
+
+    expect(payload.code).toBe('malformed_request')
+    expect(payload.error).toBe(
+      'This conversation could not be sent to the model. Please start a new chat.'
+    )
+    expect(payload.details).toBe(
+      'Retrying this message will fail the same way.'
+    )
+    expect(payload.retryable).toBe(false)
+  })
+
+  it('keeps unrelated 400 errors on the bad request path', () => {
+    const error = Object.assign(new Error('Request failed validation'), {
+      statusCode: 400
+    })
+    const payload = toPublicErrorPayload(error)
+
+    expect(payload.code).toBe('bad_request')
+  })
+
+  it('keeps upstream "Invalid JSON response" fetch failures on the bad request path', () => {
+    const payload = toPublicErrorPayload({
+      error: 'Invalid JSON response',
+      status: 400
+    })
+
+    expect(payload.code).toBe('bad_request')
+  })
+
+  it('does not map malformed request messages for non-400 errors', () => {
+    const error = Object.assign(new Error('failed to parse JSON value'), {
+      statusCode: 500
+    })
+    const payload = toPublicErrorPayload(error)
+
+    expect(payload.code).not.toBe('malformed_request')
+  })
+
   it('serializes public payloads for stream error chunks', () => {
     const serialized = serializePublicError(
       new Error('Redis timeout while saving stream results')

--- a/lib/errors/public-error.ts
+++ b/lib/errors/public-error.ts
@@ -7,6 +7,7 @@ export type PublicErrorCode =
   | 'bad_request'
   | 'context_length'
   | 'forbidden'
+  | 'malformed_request'
   | 'model_unavailable'
   | 'provider_auth'
   | 'provider_billing'
@@ -50,6 +51,7 @@ const PUBLIC_ERROR_CODES: ReadonlySet<string> = new Set([
   'bad_request',
   'context_length',
   'forbidden',
+  'malformed_request',
   'model_unavailable',
   'provider_auth',
   'provider_billing',
@@ -112,6 +114,13 @@ const CONTEXT_LENGTH_PATTERNS = [
   /maximum context/i,
   /token limit/i,
   /too many tokens/i
+]
+
+// Matched against the provider's own signature only: the prose form
+// "Invalid JSON response" is an upstream-fetch message, not this failure.
+const MALFORMED_REQUEST_PATTERNS = [
+  /failed to parse JSON/i,
+  /\binvalid_json\b/i
 ]
 
 const MODEL_UNAVAILABLE_PATTERNS = [
@@ -340,6 +349,17 @@ function classifyError(snapshot: ErrorSnapshot, fallbackMessage?: string) {
       code: 'model_unavailable' as const,
       type: 'general' as const,
       error: 'The selected model is unavailable. Please choose another model.',
+      retryable: false
+    }
+  }
+
+  if (status === 400 && matchesAny(combined, MALFORMED_REQUEST_PATTERNS)) {
+    return {
+      code: 'malformed_request' as const,
+      type: 'general' as const,
+      error:
+        'This conversation could not be sent to the model. Please start a new chat.',
+      details: 'Retrying this message will fail the same way.',
       retryable: false
     }
   }

--- a/lib/errors/public-error.ts
+++ b/lib/errors/public-error.ts
@@ -46,6 +46,12 @@ type ErrorSnapshot = {
 const DEFAULT_PUBLIC_ERROR_MESSAGE =
   'We could not generate a response. Please try again.'
 
+const MALFORMED_REQUEST_MESSAGE =
+  'This conversation could not be sent to the model. Please start a new chat.'
+
+const MALFORMED_REQUEST_DETAILS =
+  'Retrying this message will fail the same way.'
+
 const PUBLIC_ERROR_CODES: ReadonlySet<string> = new Set([
   'auth_required',
   'bad_request',
@@ -357,9 +363,8 @@ function classifyError(snapshot: ErrorSnapshot, fallbackMessage?: string) {
     return {
       code: 'malformed_request' as const,
       type: 'general' as const,
-      error:
-        'This conversation could not be sent to the model. Please start a new chat.',
-      details: 'Retrying this message will fail the same way.',
+      error: MALFORMED_REQUEST_MESSAGE,
+      details: MALFORMED_REQUEST_DETAILS,
       retryable: false
     }
   }
@@ -405,6 +410,20 @@ function isToolFailurePayload(message: string, code: PublicErrorCode): boolean {
   return code === 'tool_failed' && isToolFailureMessage(message)
 }
 
+/**
+ * The client re-parses the serialized payload, and that second pass carries
+ * neither the provider status nor its signature, so the copy would fall back to
+ * the generic retry message while the details still said retrying is futile.
+ * Only this module's own copy is honoured, for the same provenance reason as
+ * `isToolFailurePayload`.
+ */
+function isMalformedRequestPayload(
+  message: string,
+  code: PublicErrorCode
+): boolean {
+  return code === 'malformed_request' && message === MALFORMED_REQUEST_MESSAGE
+}
+
 function isIntentionalPublicPayload(
   value: Record<string, unknown>,
   code: PublicErrorCode
@@ -438,7 +457,8 @@ function fromParsedPayload(
   const type = asPublicErrorType(value.type) ?? typeForCode(code)
   const preserveMessage =
     isIntentionalPublicPayload(value, code) ||
-    isToolFailurePayload(message, code)
+    isToolFailurePayload(message, code) ||
+    isMalformedRequestPayload(message, code)
 
   return {
     error: preserveMessage ? message : classification.error,


### PR DESCRIPTION
## Problem

When the provider rejects a streaming request with HTTP 400 and its own `invalid_json` error code, the user is told only "The request could not be processed."

That copy is a dead end. This particular failure is deterministic for the affected thread: the identical request is rejected the same way on retry, and in each occurrence observed so far the thread never produced another successful answer. The generic wording invites the one action that cannot work (retrying the same message) and offers no way forward, so a thread that is permanently stuck looks to the user like a transient glitch.

The underlying 400 is not root caused, and this PR does not attempt to fix it. That work stays in #927. This is only about naming the failure and telling the user something true and actionable.

## Root cause

`classifyError` in `lib/errors/public-error.ts` has no branch matching this signature. The message does not match `CONTEXT_LENGTH_PATTERNS` or any other specific pattern list, so it falls through to the catch all `status === 400` branch, which emits `bad_request` with the generic message.

`describeStreamError` derives the Langfuse span `statusMessage` from the same payload, so the failure is also indistinguishable from every other 400 in traces.

## Fix

Add a `malformed_request` classification, placed immediately before the generic `status === 400` branch so every existing, more specific classification keeps priority and no other error changes behaviour. It is gated on both a 400 status and the provider's own signature (`failed to parse JSON` in the message, or the `invalid_json` code).

Copy follows the existing `context_length` branch, which is the closest analogue:

- error: "This conversation could not be sent to the model. Please start a new chat."
- details: "Retrying this message will fail the same way."
- `retryable: false`

The pattern deliberately matches the provider's snake_case code only, not the prose form "Invalid JSON response", which is an unrelated upstream fetch message produced in `app/api/advanced-search/route.ts`. A regression test pins that distinction.

The copy also has to survive the client round trip. `serializePublicError` sends this payload to the browser, and `components/chat.tsx` passes the resulting `Error` back through `toPublicErrorPayload`; that second pass has neither the provider status nor its signature, so the message was being replaced by the generic retry copy while `details` still said retrying is futile. `isMalformedRequestPayload` preserves it, using the same provenance rule as `tool_failed`: the code alone is not enough, the message must also be byte-identical to this module's own copy, so an upstream error that happens to serialize as JSON carrying our code cannot get its text in front of a user.

As a side effect, these failures now carry a distinct code in the span status message, so future occurrences are separable from ordinary 400s when reading traces.

## Verification

`bun run test`, `bun lint`, `bun typecheck`, `bun format:check`, `bun run build` all pass locally.

New tests in `lib/errors/__tests__/public-error.test.ts`:

- the real provider message at 400 classifies as `malformed_request`, not retryable, with the new copy
- the provider code arriving via the error `code` field classifies the same way
- an unrelated 400 still classifies as `bad_request`
- the upstream "Invalid JSON response" message at 400 still classifies as `bad_request`
- a matching message at a non-400 status does not classify as `malformed_request`
- the payload survives the serialize and reparse round trip the client performs
- a `malformed_request` code carrying foreign copy does not have that copy preserved

Refs #927
