### PR TITLE
fix(fetch): reject a tool argument that is not a URL before requesting it

### DIFF
--- a/lib/errors/__tests__/tool-error.test.ts
+++ b/lib/errors/__tests__/tool-error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   getToolFailureMessage,
+  INVALID_URL_SENTINEL,
   isToolFailureError,
   isToolFailureMessage,
   serializeToolFailure,
@@ -9,6 +10,19 @@ import {
 } from '@/lib/errors/tool-error'
 
 describe('tool error mapping', () => {
+  it('maps an invalid fetch URL to non-retryable scoped copy', () => {
+    const expected = 'The link is not a valid web address.'
+    const error = new ToolFailureError('fetch', INVALID_URL_SENTINEL)
+
+    expect(getToolFailureMessage(error)).toBe(expected)
+    // Membership is what lets the copy survive the client's re-parse.
+    expect(isToolFailureMessage(expected)).toBe(true)
+    expect(JSON.parse(serializeToolFailure(error))).toMatchObject({
+      error: expected,
+      retryable: false
+    })
+  })
+
   it.each([
     ['HTTP 403: Forbidden', 'The page refused the request.'],
     ['Forbidden by upstream', 'The page refused the request.'],

--- a/lib/errors/tool-error.ts
+++ b/lib/errors/tool-error.ts
@@ -2,6 +2,14 @@ import type { PublicErrorPayload } from './public-error'
 
 export type ToolName = 'fetch' | 'search'
 
+/**
+ * Raised by the fetch tool when its argument is not an address at all, so the
+ * classifier can tell that case apart from a page that really did fail. The
+ * platform's own text embeds the rejected value, which would otherwise put a
+ * model-authored string into the trace and into the copy shown to the user.
+ */
+export const INVALID_URL_SENTINEL = 'Invalid fetch URL.'
+
 // What the failure happened to. The whole point of this module is that it is
 // never the user and never the AI service.
 const SUBJECT: Record<ToolName, string> = {
@@ -62,6 +70,7 @@ const RATE_LIMITED = (subject: string) =>
 const UNAVAILABLE = (subject: string) =>
   `${subject} is temporarily unavailable. Please try again shortly.`
 const TOO_SLOW = (subject: string) => `${subject} took too long to respond.`
+const INVALID_URL = 'The link is not a valid web address.'
 const UNREADABLE_TYPE = 'The page is not in a readable text format.'
 const NO_CONTENT = 'The page did not return any readable content.'
 const FETCH_FALLBACK = 'The page could not be read.'
@@ -83,6 +92,7 @@ export const TOOL_FAILURE_MESSAGES: ReadonlySet<string> = new Set([
     UNAVAILABLE(subject),
     TOO_SLOW(subject)
   ]),
+  INVALID_URL,
   UNREADABLE_TYPE,
   NO_CONTENT,
   FETCH_FALLBACK,
@@ -100,6 +110,10 @@ function classifyToolFailure(error: ToolFailureError): {
   const message = error.originalMessage
   const status = error.status
   const subject = SUBJECT[error.toolName]
+
+  if (error.toolName === 'fetch' && message === INVALID_URL_SENTINEL) {
+    return { message: INVALID_URL, retryable: false }
+  }
 
   if (status === 403 || /\b403\b|\bforbidden\b/i.test(message)) {
     return { message: REFUSED(subject), retryable: false }

--- a/lib/schema/fetch.tsx
+++ b/lib/schema/fetch.tsx
@@ -2,7 +2,9 @@ import { DeepPartial } from 'ai'
 import { z } from 'zod'
 
 export const fetchSchema = z.object({
-  url: z.string().describe('The URL to retrieve content from'),
+  url: z
+    .string()
+    .describe('An absolute http:// or https:// URL to retrieve content from'),
   type: z
     .enum(['regular', 'api'])
     .default('regular')

--- a/lib/tools/__tests__/fetch-error.test.ts
+++ b/lib/tools/__tests__/fetch-error.test.ts
@@ -38,4 +38,62 @@ describe('fetch tool errors', () => {
       }
     }
   })
+
+  it.each([
+    'URL To Web design Template Features',
+    'example.com/page',
+    'file:///etc/passwd'
+  ])('rejects invalid URL %s without a network call', async url => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = fetchTool.execute?.(
+      { url, type: 'regular' },
+      { toolCallId: 'fetch', messages: [] }
+    )
+    expect(result).toBeDefined()
+
+    const iterator = (result as AsyncIterable<unknown>)[Symbol.asyncIterator]()
+
+    try {
+      await iterator.next()
+      throw new Error('Expected fetch tool to throw')
+    } catch (error) {
+      expect(isToolFailureError(error)).toBe(true)
+      if (isToolFailureError(error)) {
+        expect(error.toolName).toBe('fetch')
+        expect(error.originalMessage).toBe('Invalid fetch URL.')
+        expect(isToolFailureError(error.cause)).toBe(false)
+      }
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('passes a valid HTTPS URL to the network unchanged', async () => {
+    const url = 'https://example.com/path?query=value'
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          '<html><title>Example</title><body>Content</body></html>',
+          {
+            headers: { 'content-type': 'text/html' }
+          }
+        )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = fetchTool.execute?.(
+      { url, type: 'regular' },
+      { toolCallId: 'fetch', messages: [] }
+    )
+    expect(result).toBeDefined()
+
+    const iterator = (result as AsyncIterable<unknown>)[Symbol.asyncIterator]()
+    await iterator.next()
+    await iterator.next()
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(fetchMock).toHaveBeenCalledWith(url, expect.any(Object))
+  })
 })

--- a/lib/tools/__tests__/fetch-error.test.ts
+++ b/lib/tools/__tests__/fetch-error.test.ts
@@ -42,7 +42,10 @@ describe('fetch tool errors', () => {
   it.each([
     'URL To Web design Template Features',
     'example.com/page',
-    'file:///etc/passwd'
+    'file:///etc/passwd',
+    // `new URL` reads this as the host `url-to-web-design-template-features`.
+    'https:URL-To-Web-design-Template-Features',
+    'https://'
   ])('rejects invalid URL %s without a network call', async url => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -1,12 +1,27 @@
 import { tool, UIToolInvocation } from 'ai'
 
-import { ToolFailureError } from '@/lib/errors/tool-error'
+import { INVALID_URL_SENTINEL, ToolFailureError } from '@/lib/errors/tool-error'
 import { fetchSchema } from '@/lib/schema/fetch'
 import { SearchResults as SearchResultsType } from '@/lib/types'
 import { logToolPayload } from '@/lib/utils/usage-logging'
 
 const CONTENT_CHARACTER_LIMIT = 50000
 const TITLE_CHARACTER_LIMIT = 100
+
+// The model sometimes fills this argument with a description of what it wants
+// rather than an address, so nothing downstream can assume it is one.
+function assertFetchableUrl(url: string): void {
+  let protocol: string | undefined
+  try {
+    protocol = new URL(url).protocol
+  } catch {
+    // Unparseable is rejected the same way a wrong protocol is.
+  }
+
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throw new ToolFailureError('fetch', INVALID_URL_SENTINEL)
+  }
+}
 
 async function fetchRegularData(url: string): Promise<SearchResultsType> {
   try {
@@ -164,6 +179,8 @@ export const fetchTool = tool({
     'Fetch content from any URL. By default uses "regular" type which performs fast, direct HTML fetching without external APIs - ideal for most websites. IMPORTANT: "regular" type does NOT support PDFs and will fail on PDF URLs. Use "api" type when you need: 1) PDF content extraction (required for .pdf URLs), 2) Complex JavaScript-rendered pages, 3) Better markdown formatting, 4) Table extraction. The "api" type requires Jina or Tavily API keys and uses Jina Reader if available, otherwise falls back to Tavily Extract.',
   inputSchema: fetchSchema,
   async *execute({ url, type = 'regular' }) {
+    assertFetchableUrl(url)
+
     // Yield initial fetching state
     yield {
       state: 'fetching' as const,

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -9,16 +9,11 @@ const CONTENT_CHARACTER_LIMIT = 50000
 const TITLE_CHARACTER_LIMIT = 100
 
 // The model sometimes fills this argument with a description of what it wants
-// rather than an address, so nothing downstream can assume it is one.
+// rather than an address, so nothing downstream can assume it is one. Parsing
+// alone is too weak a test: `new URL` reads `https:some-description` as a host
+// named after the description, which would still be looked up.
 function assertFetchableUrl(url: string): void {
-  let protocol: string | undefined
-  try {
-    protocol = new URL(url).protocol
-  } catch {
-    // Unparseable is rejected the same way a wrong protocol is.
-  }
-
-  if (protocol !== 'http:' && protocol !== 'https:') {
+  if (!/^https?:\/\//i.test(url) || !URL.canParse(url)) {
     throw new ToolFailureError('fetch', INVALID_URL_SENTINEL)
   }
 }


### PR DESCRIPTION
## Problem

The `fetch` tool accepts whatever string the model puts in its `url` argument. In production the model sometimes puts a description of what it wants there instead of an address, with values shaped like `URL To Web design Template Features`.

Two things then go wrong:

1. `fetch()` throws `TypeError: Failed to parse URL from <text>`. That message matches no branch in `classifyToolFailure`, so it falls through to the fetch fallback copy, `The page could not be read.` There was no page. The user is told a site failed when nothing was ever requested, which is the same class of misattribution #949 fixed for tool failures generally.
2. On the `type: 'api'` path with a Jina key configured, the unvalidated value is interpolated into `https://r.jina.ai/${url}` and sent to a third party as a path segment.

The model also gets no useful signal back, so it cannot tell that the argument itself was the problem.

## Root cause

`fetchSchema` (`lib/schema/fetch.tsx`) declares `url: z.string()` with no URL constraint, and `fetchTool.execute` (`lib/tools/fetch.ts`) passes the value straight into the selected fetch strategy. Nothing between the model and the network checks that the string is an address.

## Fix

- Validate `url` at the tool boundary, before any network call and before either strategy is selected. Only an absolute URL whose protocol is `http:` or `https:` is accepted.
- A rejected value raises `ToolFailureError` with a dedicated classification, so the user-facing copy names the real problem instead of blaming a page, and the model receives a message it can act on.
- The new message is registered in `TOOL_FAILURE_MESSAGES`, the provenance allowlist that lets a `tool_failed` message survive the client's re-parse.
- The `url` field's description now states that an absolute `http://` or `https://` URL is required, which targets the model behaviour at its source.

`.url()` was deliberately not added to the zod schema: a schema-level rejection takes the AI SDK's input-validation path instead of the tool-failure path, which is the path that produces the scoped copy.

Side effect worth knowing about: the platform's parse error embeds the rejected value, so until now a model-authored string was landing in the tool span's status message. The sentinel replaces it with a fixed one, which keeps that text out of traces and gives the case a stable signature to search for.

## Verification

- New tests cover a natural-language argument, a scheme-less value, and a non-http protocol, each asserting that the tool fails and that no network call is made.
- An existing valid URL still reaches the network path unchanged.
- The classifier maps the new failure to its own message and that message is a member of `TOOL_FAILURE_MESSAGES`.
- `bun run test`, `bun lint`, `bun typecheck`, `bun format:check`, `bun run build` all pass locally.
