### PR TITLE
fix(search): describe a failed provider request by its HTTP status

### DIFF
--- a/lib/tools/search/providers/__tests__/http-error.test.ts
+++ b/lib/tools/search/providers/__tests__/http-error.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getToolFailureMessage,
+  serializeToolFailure,
+  ToolFailureError
+} from '@/lib/errors/tool-error'
+
+import { SearXNGSearchProvider } from '../searxng'
+import { TavilySearchProvider } from '../tavily'
+
+describe('search provider HTTP errors', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('preserves HTTP status details for classification', async () => {
+    vi.stubEnv('TAVILY_API_KEY', 'test-key')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Promise.resolve(
+          new Response(null, { status: 403, statusText: 'Forbidden' })
+        )
+      )
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const error = await new TavilySearchProvider()
+      .search('private query', 5, 'basic', [], [])
+      .catch(error => error)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toContain('HTTP 403: Forbidden')
+    expect(error.status).toBe(403)
+
+    const toolError = new ToolFailureError('search', error)
+    expect(getToolFailureMessage(toolError)).toBe(
+      'The search service refused the request.'
+    )
+    expect(JSON.parse(serializeToolFailure(toolError))).toMatchObject({
+      error: 'The search service refused the request.',
+      retryable: false
+    })
+  })
+
+  it('classifies rate limiting as retryable', async () => {
+    vi.stubEnv('TAVILY_API_KEY', 'test-key')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 429,
+            statusText: 'Too Many Requests'
+          })
+        )
+      )
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const error = await new TavilySearchProvider()
+      .search('private query', 5, 'basic', [], [])
+      .catch(error => error)
+    const toolError = new ToolFailureError('search', error)
+
+    expect(getToolFailureMessage(toolError)).toBe(
+      'The search service is rate limiting requests. Please try again shortly.'
+    )
+    expect(JSON.parse(serializeToolFailure(toolError))).toMatchObject({
+      error:
+        'The search service is rate limiting requests. Please try again shortly.',
+      retryable: true
+    })
+  })
+
+  it('does not include the query or upstream body', async () => {
+    const query = 'private model-authored query'
+    const responseBody = 'private upstream response body'
+    vi.stubEnv('SEARXNG_API_URL', 'https://search.example.com')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Promise.resolve(
+          new Response(responseBody, {
+            status: 403,
+            statusText: 'Forbidden'
+          })
+        )
+      )
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const error = await new SearXNGSearchProvider()
+      .search(query, 5, 'basic', [], [])
+      .catch(error => error)
+
+    expect(error.message).not.toContain(query)
+    expect(error.message).not.toContain(responseBody)
+    expect(error.message).toContain('HTTP 403: Forbidden')
+  })
+
+  it('uses a fallback for an empty status text', async () => {
+    vi.stubEnv('TAVILY_API_KEY', 'test-key')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Promise.resolve(new Response(null, { status: 503, statusText: '' }))
+      )
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const error = await new TavilySearchProvider()
+      .search('private query', 5, 'basic', [], [])
+      .catch(error => error)
+
+    expect(error.message).toBe('Tavily search failed: HTTP 503: Unknown Status')
+  })
+})

--- a/lib/tools/search/providers/base.ts
+++ b/lib/tools/search/providers/base.ts
@@ -48,4 +48,17 @@ export abstract class BaseSearchProvider implements SearchProvider {
       )
     }
   }
+
+  protected createHttpError(
+    response: Response,
+    providerName: string
+  ): Error & { status: number } {
+    const statusText = response.statusText || 'Unknown Status'
+    return Object.assign(
+      new Error(
+        `${providerName} search failed: HTTP ${response.status}: ${statusText}`
+      ),
+      { status: response.status }
+    )
+  }
 }

--- a/lib/tools/search/providers/brave.ts
+++ b/lib/tools/search/providers/brave.ts
@@ -4,7 +4,7 @@ import {
   SerperSearchResultItem
 } from '@/lib/types'
 
-import { SearchProvider } from './base'
+import { BaseSearchProvider } from './base'
 
 interface BraveWebResult {
   title?: string
@@ -43,10 +43,11 @@ interface BraveImageResult {
   height?: number
 }
 
-export class BraveSearchProvider implements SearchProvider {
+export class BraveSearchProvider extends BaseSearchProvider {
   private apiKey: string | undefined
 
   constructor() {
+    super()
     this.apiKey = process.env.BRAVE_SEARCH_API_KEY
   }
 
@@ -124,7 +125,7 @@ export class BraveSearchProvider implements SearchProvider {
 
       if (!response.ok) {
         console.error(`Brave web search failed: ${response.statusText}`)
-        throw new Error('Search failed')
+        throw this.createHttpError(response, 'Brave web')
       }
 
       const data = await response.json()
@@ -161,7 +162,7 @@ export class BraveSearchProvider implements SearchProvider {
 
       if (!response.ok) {
         console.error(`Brave video search failed: ${response.statusText}`)
-        throw new Error('Search failed')
+        throw this.createHttpError(response, 'Brave video')
       }
 
       const data = await response.json()
@@ -208,7 +209,7 @@ export class BraveSearchProvider implements SearchProvider {
 
       if (!response.ok) {
         console.error(`Brave image search failed: ${response.statusText}`)
-        throw new Error('Search failed')
+        throw this.createHttpError(response, 'Brave image')
       }
 
       const data = await response.json()

--- a/lib/tools/search/providers/searxng.ts
+++ b/lib/tools/search/providers/searxng.ts
@@ -52,7 +52,7 @@ export class SearXNGSearchProvider extends BaseSearchProvider {
       if (!response.ok) {
         const errorText = await response.text()
         console.error(`SearXNG API error (${response.status}):`, errorText)
-        throw new Error('Search failed')
+        throw this.createHttpError(response, 'SearXNG')
       }
 
       const data: SearXNGResponse = await response.json()

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -51,7 +51,7 @@ export class TavilySearchProvider extends BaseSearchProvider {
       console.error(
         `Tavily API error: ${response.status} ${response.statusText}`
       )
-      throw new Error('Search failed')
+      throw this.createHttpError(response, 'Tavily')
     }
 
     const data = await response.json()


### PR DESCRIPTION
## Problem

When a search provider returns an error response, the failure reaches the user as the generic
search fallback copy and is reported as **retryable**, even when the provider answered with a
permanent 403 or 404. The same failure appears in tracing as a bare `Search failed`, which
cannot distinguish a provider outage from a rejected request or an auth problem.

The `fetch` tool does not have this problem: its failures classify correctly and are readable
in a trace.

## Root cause

`classifyToolFailure` in `lib/errors/tool-error.ts` classifies a tool failure by either the
numeric `error.status` / `error.statusCode` (via `getErrorStatus`) or a regex over the error
message (`403`/`forbidden`, `404`, `429`, `5xx`, timeout, ...).

The search providers computed the HTTP status, passed it to `console.error`, and then threw a
fixed string:

- `lib/tools/search/providers/tavily.ts`
- `lib/tools/search/providers/searxng.ts`
- `lib/tools/search/providers/brave.ts` (web, video and image paths)

```js
console.error(`Tavily API error: ${response.status} ${response.statusText}`)
throw new Error('Search failed')
```

`lib/tools/search.ts` wraps that in `ToolFailureError('search', error)`, but by then the status
is gone: `'Search failed'` matches none of the regexes and the error object carries no `status`.
Every provider failure therefore reached the fallback branch, which returns the generic message
and `retryable: true`. The classifier was correct all along, it was being starved of input.

## Fix

Providers now raise the same `HTTP <status>: <statusText>` shape the fetch tool already uses,
with the numeric status attached, through a `createHttpError` helper on `BaseSearchProvider`
that sits alongside the existing `validateApiKey` / `validateApiUrl` helpers. No change to
`tool-error.ts` and no change to any user-facing copy string.

`BraveSearchProvider` was the one provider that used `implements SearchProvider` rather than
extending `BaseSearchProvider`; it now extends it like the others, which is what gives it the
helper. The public type contract is unchanged, since `BaseSearchProvider implements SearchProvider`.

The query and the upstream response body are deliberately kept out of the message. These strings
reach both traces and user-facing copy, so the same rule applied in #955 applies here. SearXNG
still reads the response body for its `console.error`, and that value does not reach the thrown
error.

## Scope limitation (Brave)

End-to-end classification is fixed for **Tavily and SearXNG**, which throw out of `search()`.

Brave is different, and this PR does not change that: `searchWeb` / `searchVideos` /
`searchImages` each wrap their body in a `try/catch` that only logs, so the error never leaves
`search()` and `search()` resolves with an empty result set. That is pre-existing behaviour, and
the bare `'Search failed'` string was swallowed in exactly the same way, so nothing regresses
here. What changes for Brave is only that the error it logs now identifies the status and the
sub-search.

Making Brave propagate is deliberately left out, because it is a semantics decision rather than a
bug fix: the three sub-searches run in parallel via `Promise.all`, so propagating would have to
define whether one failed content type fails the whole search or whether partial results should
still be returned. Filed separately as #963.

## Verification

New tests in `lib/tools/search/providers/__tests__/http-error.test.ts` drive a real provider with
a mocked `fetch` and then pipe the resulting error through the real `ToolFailureError` +
`getToolFailureMessage` / `serializeToolFailure`, so the assertion is end to end rather than on
the message string alone:

- a 403 yields the refused copy and `retryable: false` (previously the generic copy and `retryable: true`)
- a 429 yields the rate limited copy and `retryable: true`
- the thrown message contains neither the query nor the upstream response body
- an empty `statusText` does not produce a malformed message

All four tests fail on `main` and pass with this change.

Gates: `bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (487 passed, 3 skipped),
`bun run build`.