### PR TITLE
fix(search): surface complete Brave failures

### DIFF
--- a/lib/tools/search/providers/__tests__/brave.test.ts
+++ b/lib/tools/search/providers/__tests__/brave.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getToolFailureMessage,
+  serializeToolFailure,
+  ToolFailureError
+} from '@/lib/errors/tool-error'
+
+import { BraveSearchProvider } from '../brave'
+
+describe('BraveSearchProvider', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces a classified failure when every requested search fails', async () => {
+    vi.stubEnv('BRAVE_SEARCH_API_KEY', 'test-key')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 429,
+            statusText: 'Too Many Requests'
+          })
+        )
+      )
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const error = await new BraveSearchProvider()
+      .search('query', 5, 'basic', [], [], {
+        content_types: ['web', 'image']
+      })
+      .catch(error => error)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.status).toBe(429)
+
+    const toolError = new ToolFailureError('search', error)
+    expect(getToolFailureMessage(toolError)).toBe(
+      'The search service is rate limiting requests. Please try again shortly.'
+    )
+    expect(JSON.parse(serializeToolFailure(toolError))).toMatchObject({
+      error:
+        'The search service is rate limiting requests. Please try again shortly.',
+      retryable: true
+    })
+  })
+
+  it('returns partial results when at least one requested search succeeds', async () => {
+    vi.stubEnv('BRAVE_SEARCH_API_KEY', 'test-key')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        if (input.toString().includes('/images/')) {
+          return new Response(null, {
+            status: 503,
+            statusText: 'Service Unavailable'
+          })
+        }
+
+        return Response.json({
+          web: {
+            results: [
+              {
+                title: 'Result title',
+                description: 'Result description',
+                url: 'https://example.com/result'
+              }
+            ]
+          }
+        })
+      })
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const result = await new BraveSearchProvider().search(
+      'query',
+      5,
+      'basic',
+      [],
+      [],
+      { content_types: ['web', 'image'] }
+    )
+
+    expect(result.results).toEqual([
+      {
+        title: 'Result title',
+        content: 'Result description',
+        url: 'https://example.com/result'
+      }
+    ])
+    expect(result.images).toEqual([])
+    expect(result.number_of_results).toBe(1)
+  })
+})

--- a/lib/tools/search/providers/brave.ts
+++ b/lib/tools/search/providers/brave.ts
@@ -96,7 +96,17 @@ export class BraveSearchProvider extends BaseSearchProvider {
       promises.push(this.searchImages(query, maxResults, results))
     }
 
-    await Promise.all(promises)
+    const settledSearches = await Promise.allSettled(promises)
+    const failedSearches = settledSearches.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+
+    if (
+      failedSearches.length > 0 &&
+      failedSearches.length === settledSearches.length
+    ) {
+      throw failedSearches[0].reason
+    }
 
     // Update total count
     results.number_of_results = results.results.length
@@ -138,6 +148,7 @@ export class BraveSearchProvider extends BaseSearchProvider {
         }))
     } catch (error) {
       console.error('Brave web search error:', error)
+      throw error
     }
   }
 
@@ -184,7 +195,7 @@ export class BraveSearchProvider extends BaseSearchProvider {
       )
     } catch (error) {
       console.error('Brave video search error:', error)
-      results.videos = []
+      throw error
     }
   }
 
@@ -223,7 +234,7 @@ export class BraveSearchProvider extends BaseSearchProvider {
       )
     } catch (error) {
       console.error('Brave image search error:', error)
-      results.images = []
+      throw error
     }
   }
 }


### PR DESCRIPTION
## Problem

The Brave search provider catches and logs failures from its web, video, and image requests without propagating them. When every requested content type fails, the provider therefore returns an empty successful result instead of a tool failure.

This makes provider outages, authentication failures, and rate limits indistinguishable from a valid search with no results. It also prevents the existing HTTP-status classifier from producing the appropriate user-facing error and retry behavior.

## Fix

- Allow each Brave sub-search to rethrow its status-bearing error after logging it.
- Wait for all requested sub-searches with `Promise.allSettled`.
- Return partial results when at least one requested content type succeeds.
- Propagate the first failure when every requested content type fails, allowing the existing tool-error path to classify it by HTTP status.

## Verification

- Added coverage confirming a complete Brave failure is surfaced and classified by HTTP status.
- Added coverage confirming successful partial results are preserved when another requested content type fails.
- `bun lint`
- `bun typecheck`
- `bun format:check`
- `bun run test` — 489 tests passed, 3 skipped
- `bun run build`

Fixes #963