### PR TITLE
fix: stabilize related questions in deep chats

### DIFF
--- a/lib/agents/__tests__/researcher.test.ts
+++ b/lib/agents/__tests__/researcher.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Model } from '@/lib/types/models'
 
+import { RELATED_QUESTIONS_REMINDER } from '../prompts/related-questions-reminder'
+
 const mocks = vi.hoisted(() => ({
   agentOptions: undefined as Record<string, any> | undefined
 }))
@@ -112,6 +114,30 @@ describe('createResearcher', () => {
 
     expect(mocks.agentOptions?.providerOptions).toEqual({
       openai: { reasoningEffort: 'low' }
+    })
+  })
+
+  it('places the related-questions reminder after conversation history', () => {
+    createResearcher({
+      model: 'openai:model-id',
+      modelConfig: createModel('openai')
+    })
+
+    const prepareCall = mocks.agentOptions?.prepareCall
+    const result = prepareCall({
+      messages: [
+        { role: 'user', content: 'Initial question' },
+        { role: 'assistant', content: 'Initial answer' },
+        { role: 'user', content: 'Deep follow-up' }
+      ]
+    })
+
+    expect(result.messages.at(-1)).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Deep follow-up' },
+        { type: 'text', text: RELATED_QUESTIONS_REMINDER }
+      ]
     })
   })
 })

--- a/lib/agents/prompts/__tests__/related-questions-reminder.test.ts
+++ b/lib/agents/prompts/__tests__/related-questions-reminder.test.ts
@@ -1,0 +1,68 @@
+import type { ModelMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import {
+  appendRelatedQuestionsReminder,
+  RELATED_QUESTIONS_REMINDER
+} from '../related-questions-reminder'
+
+describe('appendRelatedQuestionsReminder', () => {
+  it('places the reminder after the current user text in a deep conversation', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'First question' },
+      { role: 'assistant', content: 'First answer' },
+      { role: 'user', content: 'Follow-up question' }
+    ]
+
+    const result = appendRelatedQuestionsReminder(messages)
+
+    expect(result).not.toBe(messages)
+    expect(result.at(-1)).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Follow-up question' },
+        { type: 'text', text: RELATED_QUESTIONS_REMINDER }
+      ]
+    })
+    expect(messages.at(-1)).toEqual({
+      role: 'user',
+      content: 'Follow-up question'
+    })
+  })
+
+  it('preserves non-text parts on the current user message', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this file' },
+          {
+            type: 'file',
+            data: new Uint8Array([1, 2, 3]),
+            mediaType: 'application/pdf'
+          }
+        ]
+      }
+    ]
+
+    const result = appendRelatedQuestionsReminder(messages)
+
+    expect(result[0].content).toEqual([
+      { type: 'text', text: 'Describe this file' },
+      {
+        type: 'file',
+        data: new Uint8Array([1, 2, 3]),
+        mediaType: 'application/pdf'
+      },
+      { type: 'text', text: RELATED_QUESTIONS_REMINDER }
+    ])
+  })
+
+  it('leaves messages unchanged when there is no user message', () => {
+    const messages: ModelMessage[] = [
+      { role: 'assistant', content: 'Existing answer' }
+    ]
+
+    expect(appendRelatedQuestionsReminder(messages)).toBe(messages)
+  })
+})

--- a/lib/agents/prompts/related-questions-reminder.ts
+++ b/lib/agents/prompts/related-questions-reminder.ts
@@ -1,0 +1,34 @@
+import type { ModelMessage } from 'ai'
+
+export const RELATED_QUESTIONS_REMINDER = `Response format reminder: When this turn produces a substantive answer, end it with exactly one related-questions \`\`\`spec JSONL block containing exactly three questions, using the schema in the system instructions. Omit the block only for the skip cases listed there.`
+
+/**
+ * Keeps the related-questions requirement next to the current request instead
+ * of leaving it only at the start of an increasingly long conversation.
+ */
+export function appendRelatedQuestionsReminder(
+  messages: ModelMessage[]
+): ModelMessage[] {
+  const lastUserIndex = messages.findLastIndex(
+    message => message.role === 'user'
+  )
+
+  if (lastUserIndex === -1) return messages
+
+  const userMessage = messages[lastUserIndex]
+  if (userMessage.role !== 'user') return messages
+
+  const reminderPart = {
+    type: 'text' as const,
+    text: RELATED_QUESTIONS_REMINDER
+  }
+  const content =
+    typeof userMessage.content === 'string'
+      ? [{ type: 'text' as const, text: userMessage.content }, reminderPart]
+      : [...userMessage.content, reminderPart]
+
+  const updatedMessages = [...messages]
+  updatedMessages[lastUserIndex] = { ...userMessage, content }
+
+  return updatedMessages
+}

--- a/lib/agents/researcher.ts
+++ b/lib/agents/researcher.ts
@@ -11,6 +11,7 @@ import { SearchMode } from '../types/search'
 import { getModel } from '../utils/registry'
 import { isTracingEnabled } from '../utils/telemetry'
 
+import { appendRelatedQuestionsReminder } from './prompts/related-questions-reminder'
 import {
   getAdaptiveModePrompt,
   QUICK_MODE_PROMPT
@@ -143,6 +144,12 @@ export function createResearcher({
       tools,
       activeTools: activeToolsList,
       stopWhen: stepCountIs(maxSteps),
+      prepareCall: options => ({
+        ...options,
+        ...(options.messages && {
+          messages: appendRelatedQuestionsReminder(options.messages)
+        })
+      }),
       ...(providerOptions && { providerOptions }),
       // Spans join the parent Langfuse trace via OTel context propagation
       experimental_telemetry: {


### PR DESCRIPTION
## Problem

The related-questions instruction appears only near the beginning of the system prompt. As conversation history grows, the instruction becomes increasingly distant from the current request, causing related-question spec blocks to be emitted less reliably in deeper conversations.

## Fix

- Add a focused related-questions reminder next to the current user request.
- Apply the reminder through the shared researcher configuration so both persisted and ephemeral chats receive it.
- Preserve existing text and file parts without mutating the original messages.
- Keep history compaction, stored messages, tool output, and rendering unchanged.
- Add coverage for deep conversations, file attachments, missing user messages, and researcher integration.

## Verification

- `bun lint`
- `bun typecheck`
- `bun format:check`
- `bun run test` — 497 tests passed, 3 skipped
- `bun run build`

Fixes #944