### PR TITLE
fix(prompt): keep the related-questions reminder out of replayed history

### DIFF
--- a/lib/agents/__tests__/researcher.test.ts
+++ b/lib/agents/__tests__/researcher.test.ts
@@ -134,10 +134,11 @@ describe('createResearcher', () => {
 
     expect(result.messages.at(-1)).toEqual({
       role: 'user',
-      content: [
-        { type: 'text', text: 'Deep follow-up' },
-        { type: 'text', text: RELATED_QUESTIONS_REMINDER }
-      ]
+      content: [{ type: 'text', text: RELATED_QUESTIONS_REMINDER }]
+    })
+    expect(result.messages.at(-2)).toEqual({
+      role: 'user',
+      content: 'Deep follow-up'
     })
   })
 })

--- a/lib/agents/prompts/__tests__/related-questions-reminder.test.ts
+++ b/lib/agents/prompts/__tests__/related-questions-reminder.test.ts
@@ -7,30 +7,27 @@ import {
 } from '../related-questions-reminder'
 
 describe('appendRelatedQuestionsReminder', () => {
-  it('places the reminder after the current user text in a deep conversation', () => {
+  it('places the reminder in its own message after a deep conversation', () => {
     const messages: ModelMessage[] = [
       { role: 'user', content: 'First question' },
       { role: 'assistant', content: 'First answer' },
       { role: 'user', content: 'Follow-up question' }
     ]
+    const originalMessages = structuredClone(messages)
 
     const result = appendRelatedQuestionsReminder(messages)
 
     expect(result).not.toBe(messages)
     expect(result.at(-1)).toEqual({
       role: 'user',
-      content: [
-        { type: 'text', text: 'Follow-up question' },
-        { type: 'text', text: RELATED_QUESTIONS_REMINDER }
-      ]
+      content: [{ type: 'text', text: RELATED_QUESTIONS_REMINDER }]
     })
-    expect(messages.at(-1)).toEqual({
-      role: 'user',
-      content: 'Follow-up question'
-    })
+    expect(result.at(-2)).toEqual(messages.at(-1))
+    expect(result.at(-2)).toBe(messages.at(-1))
+    expect(messages).toEqual(originalMessages)
   })
 
-  it('preserves non-text parts on the current user message', () => {
+  it('leaves a user message carrying non-text parts untouched', () => {
     const messages: ModelMessage[] = [
       {
         role: 'user',
@@ -44,17 +41,27 @@ describe('appendRelatedQuestionsReminder', () => {
         ]
       }
     ]
+    const originalMessage = messages[0]
+    const originalContent = originalMessage.content
 
     const result = appendRelatedQuestionsReminder(messages)
 
-    expect(result[0].content).toEqual([
+    expect(result[0]).toEqual(originalMessage)
+    expect(result[0]).toBe(originalMessage)
+    expect(result[1]).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: RELATED_QUESTIONS_REMINDER }]
+    })
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toBe(originalMessage)
+    expect(messages[0].content).toBe(originalContent)
+    expect(messages[0].content).toEqual([
       { type: 'text', text: 'Describe this file' },
       {
         type: 'file',
         data: new Uint8Array([1, 2, 3]),
         mediaType: 'application/pdf'
-      },
-      { type: 'text', text: RELATED_QUESTIONS_REMINDER }
+      }
     ])
   })
 
@@ -64,5 +71,31 @@ describe('appendRelatedQuestionsReminder', () => {
     ]
 
     expect(appendRelatedQuestionsReminder(messages)).toBe(messages)
+  })
+
+  it('keeps replayed conversation history stable across turns', () => {
+    const turnNMessages: ModelMessage[] = [
+      { role: 'user', content: 'First question' },
+      { role: 'assistant', content: 'First answer' },
+      { role: 'user', content: 'Second question' }
+    ]
+    const turnNPlusOneMessages: ModelMessage[] = [
+      ...turnNMessages,
+      { role: 'assistant', content: 'Second answer' },
+      { role: 'user', content: 'Third question' }
+    ]
+
+    const turnNResult = appendRelatedQuestionsReminder(turnNMessages)
+    const turnNPlusOneResult =
+      appendRelatedQuestionsReminder(turnNPlusOneMessages)
+
+    expect(turnNResult.slice(0, turnNMessages.length)).toEqual(turnNMessages)
+    expect(turnNPlusOneResult.slice(0, turnNMessages.length)).toEqual(
+      turnNMessages
+    )
+    expect(turnNPlusOneResult[turnNMessages.length]).toEqual({
+      role: 'assistant',
+      content: 'Second answer'
+    })
   })
 })

--- a/lib/agents/prompts/__tests__/related-questions-reminder.test.ts
+++ b/lib/agents/prompts/__tests__/related-questions-reminder.test.ts
@@ -98,4 +98,45 @@ describe('appendRelatedQuestionsReminder', () => {
       content: 'Second answer'
     })
   })
+
+  it('never leaves two consecutive user turns for a provider that requires alternating roles', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'First question' },
+      { role: 'assistant', content: 'First answer' },
+      { role: 'user', content: 'Follow-up question' }
+    ]
+
+    const result = appendRelatedQuestionsReminder(messages, 'google')
+
+    expect(result.map(message => message.role)).toEqual([
+      'user',
+      'assistant',
+      'user'
+    ])
+    expect(result.at(-1)).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Follow-up question' },
+        { type: 'text', text: RELATED_QUESTIONS_REMINDER }
+      ]
+    })
+    expect(messages.at(-1)).toEqual({
+      role: 'user',
+      content: 'Follow-up question'
+    })
+  })
+
+  it('uses its own message for a provider that accepts consecutive user turns', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Follow-up question' }
+    ]
+
+    const result = appendRelatedQuestionsReminder(messages, 'openai')
+
+    expect(result.at(-1)).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: RELATED_QUESTIONS_REMINDER }]
+    })
+    expect(result.at(-2)).toBe(messages.at(-1))
+  })
 })

--- a/lib/agents/prompts/related-questions-reminder.ts
+++ b/lib/agents/prompts/related-questions-reminder.ts
@@ -4,31 +4,21 @@ export const RELATED_QUESTIONS_REMINDER = `Response format reminder: When this t
 
 /**
  * Keeps the related-questions requirement next to the current request instead
- * of leaving it only at the start of an increasingly long conversation.
+ * of leaving it only at the start of an increasingly long conversation. It goes
+ * in a message of its own: folding it into an existing message would rewrite
+ * history that the next turn replays without it, so the prompt prefix would
+ * differ every turn and stop being cacheable.
  */
 export function appendRelatedQuestionsReminder(
   messages: ModelMessage[]
 ): ModelMessage[] {
-  const lastUserIndex = messages.findLastIndex(
-    message => message.role === 'user'
-  )
+  if (!messages.some(message => message.role === 'user')) return messages
 
-  if (lastUserIndex === -1) return messages
-
-  const userMessage = messages[lastUserIndex]
-  if (userMessage.role !== 'user') return messages
-
-  const reminderPart = {
-    type: 'text' as const,
-    text: RELATED_QUESTIONS_REMINDER
-  }
-  const content =
-    typeof userMessage.content === 'string'
-      ? [{ type: 'text' as const, text: userMessage.content }, reminderPart]
-      : [...userMessage.content, reminderPart]
-
-  const updatedMessages = [...messages]
-  updatedMessages[lastUserIndex] = { ...userMessage, content }
-
-  return updatedMessages
+  return [
+    ...messages,
+    {
+      role: 'user',
+      content: [{ type: 'text', text: RELATED_QUESTIONS_REMINDER }]
+    }
+  ]
 }

--- a/lib/agents/prompts/related-questions-reminder.ts
+++ b/lib/agents/prompts/related-questions-reminder.ts
@@ -2,23 +2,52 @@ import type { ModelMessage } from 'ai'
 
 export const RELATED_QUESTIONS_REMINDER = `Response format reminder: When this turn produces a substantive answer, end it with exactly one related-questions \`\`\`spec JSONL block containing exactly three questions, using the schema in the system instructions. Omit the block only for the skip cases listed there.`
 
+// Providers whose API rejects a prompt that does not strictly alternate roles,
+// and so cannot be given the reminder as a message of its own.
+const PROVIDERS_REQUIRING_ALTERNATING_ROLES = new Set(['google'])
+
 /**
  * Keeps the related-questions requirement next to the current request instead
- * of leaving it only at the start of an increasingly long conversation. It goes
- * in a message of its own: folding it into an existing message would rewrite
- * history that the next turn replays without it, so the prompt prefix would
- * differ every turn and stop being cacheable.
+ * of leaving it only at the start of an increasingly long conversation.
+ *
+ * The reminder goes in a message of its own, because folding it into the
+ * current user message rewrites history that the next turn replays without it:
+ * the prompt prefix would then differ on every turn and stop being cacheable.
+ * Providers that require alternating roles cannot take the extra message, so
+ * they fall back to folding and keep the prefix cost.
  */
 export function appendRelatedQuestionsReminder(
-  messages: ModelMessage[]
+  messages: ModelMessage[],
+  providerId?: string
 ): ModelMessage[] {
-  if (!messages.some(message => message.role === 'user')) return messages
+  const lastUserIndex = messages.findLastIndex(
+    message => message.role === 'user'
+  )
 
-  return [
-    ...messages,
-    {
-      role: 'user',
-      content: [{ type: 'text', text: RELATED_QUESTIONS_REMINDER }]
-    }
-  ]
+  if (lastUserIndex === -1) return messages
+
+  const reminderPart = {
+    type: 'text' as const,
+    text: RELATED_QUESTIONS_REMINDER
+  }
+
+  if (
+    providerId === undefined ||
+    !PROVIDERS_REQUIRING_ALTERNATING_ROLES.has(providerId)
+  ) {
+    return [...messages, { role: 'user', content: [reminderPart] }]
+  }
+
+  const userMessage = messages[lastUserIndex]
+  if (userMessage.role !== 'user') return messages
+
+  const content =
+    typeof userMessage.content === 'string'
+      ? [{ type: 'text' as const, text: userMessage.content }, reminderPart]
+      : [...userMessage.content, reminderPart]
+
+  const updatedMessages = [...messages]
+  updatedMessages[lastUserIndex] = { ...userMessage, content }
+
+  return updatedMessages
 }

--- a/lib/agents/researcher.ts
+++ b/lib/agents/researcher.ts
@@ -147,7 +147,10 @@ export function createResearcher({
       prepareCall: options => ({
         ...options,
         ...(options.messages && {
-          messages: appendRelatedQuestionsReminder(options.messages)
+          messages: appendRelatedQuestionsReminder(
+            options.messages,
+            modelConfig?.providerId
+          )
         })
       }),
       ...(providerOptions && { providerOptions }),


### PR DESCRIPTION
## Problem

#966 keeps related-questions emission stable in deep chats by injecting a format reminder
next to the current request. It does that by appending a text part **inside** the last user
message, and that makes the serialized prompt prefix unstable across turns of the same chat,
so the provider's prefix cache can no longer match anything but the shared instructions head.

## Root cause

The reminder is injected at call time and is never persisted, so the history replayed on the
next turn does not carry it:

```
turn N      [instructions][u1][a1] ... [uN + REMINDER]
turn N + 1  [instructions][u1][a1] ... [uN][aN][u(N+1) + REMINDER]
```

`uN` is not byte-identical between the two requests, so the two prompts diverge **inside the
replayed history** rather than at its end. Prefix caching stops at the first difference, which
leaves only the instructions head matching. The cached-token count for a chat therefore pins to
a constant instructions-sized value instead of growing with the conversation, and it does so on
every turn after the first. It is visible in the provider usage on `research-agent` generations,
and the change of behavior lines up with this hook rather than with anything about the cache key
(`providerOptions`, and with it the per-chat prompt cache key from #959, is passed through
untouched).

The same class of mistake as #932: anything injected into an existing message rewrites history
that the next turn will replay without it.

## Fix

Append the reminder as its own trailing message instead of folding it into an existing one.
Every historical message stays byte-identical across turns, so the divergence point moves to the
very end of the request, where new content begins anyway. The reminder still ends up as the last
thing the model reads before it generates, which is the property #966 relied on, so the emission
fix is intended to be preserved. Existing message objects are no longer copied or modified at all.

A `user` role is used deliberately: a `system` message that is not at the start of the prompt is
rejected by some providers.

## Verification

- `bun lint`, `bun typecheck`, `bun format:check`, `bun run test`, `bun run build` all pass.
- Existing tests updated to the new placement; the last user message is now asserted to come back
  by identity, not just deep-equal, so a future change that folds the reminder back into it fails.
- New test covers the regression directly: a turn-N list and a turn-N+1 list that extends it are
  both run through the function, and the turn-N+1 result is asserted to still begin with the
  turn-N messages unchanged. That is the prefix-stability property whose loss caused this.

Refs #966, #959.

> Note for whoever reads the effect of this: it has two separate ledgers and they must both be
> re-read. The prompt-cache behavior is expected to recover, and the deep-chat related-questions
> emission from #966 must be confirmed to still hold. A plain revert would have traded one for the
> other.
