### PR TITLE
feat(analytics): record whether the feedback control was offered

### DIFF
--- a/components/__tests__/message-actions.test.tsx
+++ b/components/__tests__/message-actions.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { captureClient } from '@/lib/analytics/posthog-client'
+
+import { MessageActions } from '../message-actions'
+
+vi.mock('@/lib/analytics/posthog-client', () => ({
+  captureClient: vi.fn()
+}))
+
+vi.mock('../library/library-context', () => ({
+  useLibrary: () => ({
+    openLibrary: vi.fn(),
+    upsertCachedNote: vi.fn()
+  })
+}))
+
+describe('MessageActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('records one feedback control impression when the row becomes visible', () => {
+    const { rerender } = render(
+      <React.StrictMode>
+        <MessageActions
+          message="Answer"
+          messageId="message-1"
+          traceId="trace-1"
+          chatId="chat-1"
+          isGuest
+          status="streaming"
+          visible={false}
+        />
+      </React.StrictMode>
+    )
+
+    expect(captureClient).not.toHaveBeenCalled()
+
+    rerender(
+      <React.StrictMode>
+        <MessageActions
+          message="Answer"
+          messageId="message-1"
+          traceId="trace-1"
+          chatId="chat-1"
+          isGuest
+          status="ready"
+          visible
+        />
+      </React.StrictMode>
+    )
+
+    expect(captureClient).toHaveBeenCalledTimes(1)
+    expect(captureClient).toHaveBeenCalledWith('feedback_control_shown', {
+      hasTraceId: true,
+      chatId: 'chat-1',
+      isGuest: true
+    })
+
+    rerender(
+      <React.StrictMode>
+        <MessageActions
+          className="parent-state-changed"
+          message="Answer"
+          messageId="message-1"
+          traceId="trace-1"
+          chatId="chat-1"
+          isGuest
+          status="ready"
+          visible
+        />
+      </React.StrictMode>
+    )
+
+    expect(captureClient).toHaveBeenCalledTimes(1)
+  })
+
+  test('records a missing trace id for a newly presented message', () => {
+    const { rerender } = render(
+      <MessageActions
+        message="First answer"
+        messageId="message-1"
+        chatId="chat-1"
+        status="ready"
+        visible
+      />
+    )
+
+    rerender(
+      <MessageActions
+        message="Second answer"
+        messageId="message-2"
+        chatId="chat-1"
+        status="ready"
+        visible
+      />
+    )
+
+    expect(captureClient).toHaveBeenCalledTimes(2)
+    expect(captureClient).toHaveBeenLastCalledWith('feedback_control_shown', {
+      hasTraceId: false,
+      chatId: 'chat-1',
+      isGuest: false
+    })
+  })
+})

--- a/components/__tests__/message-actions.test.tsx
+++ b/components/__tests__/message-actions.test.tsx
@@ -28,7 +28,7 @@ describe('MessageActions', () => {
       <React.StrictMode>
         <MessageActions
           message="Answer"
-          messageId="message-1"
+          messageId="visible-1"
           traceId="trace-1"
           chatId="chat-1"
           isGuest
@@ -44,7 +44,7 @@ describe('MessageActions', () => {
       <React.StrictMode>
         <MessageActions
           message="Answer"
-          messageId="message-1"
+          messageId="visible-1"
           traceId="trace-1"
           chatId="chat-1"
           isGuest
@@ -57,6 +57,7 @@ describe('MessageActions', () => {
     expect(captureClient).toHaveBeenCalledTimes(1)
     expect(captureClient).toHaveBeenCalledWith('feedback_control_shown', {
       hasTraceId: true,
+      hasFeedback: false,
       chatId: 'chat-1',
       isGuest: true
     })
@@ -66,7 +67,7 @@ describe('MessageActions', () => {
         <MessageActions
           className="parent-state-changed"
           message="Answer"
-          messageId="message-1"
+          messageId="visible-1"
           traceId="trace-1"
           chatId="chat-1"
           isGuest
@@ -79,30 +80,62 @@ describe('MessageActions', () => {
     expect(captureClient).toHaveBeenCalledTimes(1)
   })
 
+  test('does not record a second impression when the same message remounts', () => {
+    const props = {
+      message: 'Answer',
+      messageId: 'remount-1',
+      traceId: 'trace-1',
+      chatId: 'chat-1',
+      status: 'ready' as const,
+      visible: true
+    }
+
+    const first = render(<MessageActions {...props} />)
+    expect(captureClient).toHaveBeenCalledTimes(1)
+
+    // Reopening a conversation remounts every past answer.
+    first.unmount()
+    render(<MessageActions {...props} />)
+
+    expect(captureClient).toHaveBeenCalledTimes(1)
+  })
+
+  test('reports a message that already carries a score as such', () => {
+    render(
+      <MessageActions
+        message="Answer"
+        messageId="scored-1"
+        traceId="trace-1"
+        feedbackScore={-1}
+        chatId="chat-1"
+        status="ready"
+        visible
+      />
+    )
+
+    expect(captureClient).toHaveBeenCalledWith('feedback_control_shown', {
+      hasTraceId: true,
+      hasFeedback: true,
+      chatId: 'chat-1',
+      isGuest: false
+    })
+  })
+
   test('records a missing trace id for a newly presented message', () => {
-    const { rerender } = render(
+    render(
       <MessageActions
         message="First answer"
-        messageId="message-1"
+        messageId="no-trace-1"
         chatId="chat-1"
         status="ready"
         visible
       />
     )
 
-    rerender(
-      <MessageActions
-        message="Second answer"
-        messageId="message-2"
-        chatId="chat-1"
-        status="ready"
-        visible
-      />
-    )
-
-    expect(captureClient).toHaveBeenCalledTimes(2)
+    expect(captureClient).toHaveBeenCalledTimes(1)
     expect(captureClient).toHaveBeenLastCalledWith('feedback_control_shown', {
       hasTraceId: false,
+      hasFeedback: false,
       chatId: 'chat-1',
       isGuest: false
     })

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 
 import { UseChatHelpers } from '@ai-sdk/react'
@@ -71,6 +71,7 @@ export function MessageActions({
   )
   const [isSavingNote, setIsSavingNote] = useState(false)
   const [authPromptOpen, setAuthPromptOpen] = useState(false)
+  const reportedFeedbackControlMessageId = useRef<string | null>(null)
   const { openLibrary, upsertCachedNote } = useLibrary()
   const mappedMessage = useMemo(() => {
     if (!message) return ''
@@ -80,6 +81,24 @@ export function MessageActions({
   const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false)
   const isLoading = status === 'submitted' || status === 'streaming'
   const showSaveButton = libraryAvailable && (!isGuest || isCloudDeployment)
+
+  useEffect(() => {
+    if (
+      !visible ||
+      isLoading ||
+      reportedFeedbackControlMessageId.current === messageId
+    ) {
+      return
+    }
+
+    // Record the impression because a missing control otherwise looks unused.
+    reportedFeedbackControlMessageId.current = messageId
+    captureClient('feedback_control_shown', {
+      hasTraceId: Boolean(traceId),
+      chatId,
+      isGuest
+    })
+  }, [chatId, isGuest, isLoading, messageId, traceId, visible])
 
   // Keep the element mounted during loading to preserve layout; otherwise skip rendering.
   if (!visible && !isLoading) {

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 
 import { UseChatHelpers } from '@ai-sdk/react'
@@ -32,6 +32,9 @@ import {
 } from './ui/dialog'
 import { ChatShare } from './chat-share'
 import { RetryButton } from './retry-button'
+
+// Module scope so the impression survives remounts of the same message.
+const reportedFeedbackControls = new Set<string>()
 
 interface MessageActionsProps {
   message: string
@@ -71,7 +74,6 @@ export function MessageActions({
   )
   const [isSavingNote, setIsSavingNote] = useState(false)
   const [authPromptOpen, setAuthPromptOpen] = useState(false)
-  const reportedFeedbackControlMessageId = useRef<string | null>(null)
   const { openLibrary, upsertCachedNote } = useLibrary()
   const mappedMessage = useMemo(() => {
     if (!message) return ''
@@ -83,22 +85,23 @@ export function MessageActions({
   const showSaveButton = libraryAvailable && (!isGuest || isCloudDeployment)
 
   useEffect(() => {
-    if (
-      !visible ||
-      isLoading ||
-      reportedFeedbackControlMessageId.current === messageId
-    ) {
+    if (!visible || isLoading || reportedFeedbackControls.has(messageId)) {
       return
     }
 
-    // Record the impression because a missing control otherwise looks unused.
-    reportedFeedbackControlMessageId.current = messageId
+    // A control that was never offered is otherwise indistinguishable from one
+    // that was offered and ignored, so the impression is what makes the click
+    // counts readable. It has to be one per message rather than one per mount:
+    // reopening a conversation remounts every past answer, and an answer that
+    // already carries a score cannot produce another one.
+    reportedFeedbackControls.add(messageId)
     captureClient('feedback_control_shown', {
       hasTraceId: Boolean(traceId),
+      hasFeedback: feedbackScore !== null,
       chatId,
       isGuest
     })
-  }, [chatId, isGuest, isLoading, messageId, traceId, visible])
+  }, [chatId, feedbackScore, isGuest, isLoading, messageId, traceId, visible])
 
   // Keep the element mounted during loading to preserve layout; otherwise skip rendering.
   if (!visible && !isLoading) {


### PR DESCRIPTION
## Problem

Thumbs-up / thumbs-down is the only sentiment signal the app collects, and the control renders only inside `{traceId && ...}` in `components/message-actions.tsx`. The trace id reaches the component as `metadata?.traceId` (`components/answer-section.tsx`), attached server-side on the stream's `start` part (`lib/streaming/create-chat-stream-response.ts`, `lib/streaming/create-ephemeral-chat-stream-response.ts`).

So whenever the trace id does not reach the client, the whole feedback control disappears from the answer and nothing records that it happened. A change in how many scores arrive is therefore ambiguous between a change in what users do and the control simply not being rendered, and nothing we collect can tell those apart. Clicks are recorded; impressions are not, so there is no denominator to read clicks against.

## Root cause

There is no instrumentation on the render side of the feedback control, only on the submit side. Absence of scores and absence of the control produce identical data.

## Fix

Emit one `feedback_control_shown` client event per assistant message, once the actions row is actually presented (visible, and the message is no longer streaming), carrying `hasTraceId`, `chatId` and `isGuest`. A ref keyed on `messageId` keeps re-renders, hover, parent state changes and React strict-mode double effects from duplicating it.

The change is additive. Rendering, the feedback submission path, and every existing event are untouched. No message text and no trace id value are sent.

## Verification

- New tests in `components/__tests__/message-actions.test.tsx`: one impression when the row becomes visible, nothing while streaming, no duplicate under strict mode or on parent re-render, and `hasTraceId: false` recorded for a message presented without a trace id.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run test` all pass locally.

Once this is live, "the control was never offered" and "the control was offered and not used" become separable, which is what makes any later read of feedback volume interpretable.