### PR TITLE
fix(tracing): record the turn's input and output on the research span

### DIFF
--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -69,6 +69,7 @@ vi.mock('@/lib/utils/usage-logging', () => ({
 import { researcher } from '@/lib/agents/researcher'
 import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'
 import { describeStreamError } from '@/lib/streaming/helpers/describe-stream-error'
+import { EMPTY_RESPONSE_STATUS_MESSAGE } from '@/lib/streaming/helpers/is-empty-response'
 import { prepareMessages } from '@/lib/streaming/helpers/prepare-messages'
 
 type StreamOptions = {
@@ -86,7 +87,12 @@ type UIMessageStreamResponseOptions = {
   }) => Promise<void>
 }
 
-function createFakeResult(isAborted = false) {
+function createFakeResult(
+  isAborted = false,
+  parts: Array<{ type: string; text?: string }> = [
+    { type: 'text', text: 'Answer' }
+  ]
+) {
   return {
     consumeStream: vi.fn(),
     toUIMessageStreamResponse: vi.fn(
@@ -95,7 +101,7 @@ function createFakeResult(isAborted = false) {
           responseMessage: {
             id: 'response-id',
             role: 'assistant',
-            parts: [{ type: 'text', text: 'Answer' }]
+            parts
           },
           isAborted
         })
@@ -157,7 +163,7 @@ describe('createChatStreamResponse', () => {
     await createChatStreamResponse(createConfig(createAbortedSignal()))
     await mocks.finishPromise
 
-    expect(mocks.span.update).not.toHaveBeenCalled()
+    expect(mocks.span.update).toHaveBeenCalledWith({ input: 'hello' })
     expect(mocks.span.end).toHaveBeenCalledOnce()
     expect(mocks.forceFlush).toHaveBeenCalledOnce()
   })
@@ -175,14 +181,16 @@ describe('createChatStreamResponse', () => {
     await createChatStreamResponse(createConfig(controller.signal))
     await mocks.finishPromise
 
-    expect(mocks.span.update).toHaveBeenCalledWith({
-      level: 'ERROR',
-      statusMessage: describeStreamError(streamError),
-      metadata: {
-        streamErrorPhase: 'generation',
-        streamErrorShape: { name: 'AbortError' }
-      }
-    })
+    expect(mocks.span.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'ERROR',
+        statusMessage: describeStreamError(streamError),
+        metadata: {
+          streamErrorPhase: 'generation',
+          streamErrorShape: { name: 'AbortError' }
+        }
+      })
+    )
   })
 
   it('marks a failure raised before the stream as the preparation phase', async () => {
@@ -191,14 +199,16 @@ describe('createChatStreamResponse', () => {
 
     await createChatStreamResponse(createConfig())
 
-    expect(mocks.span.update).toHaveBeenCalledWith({
-      level: 'ERROR',
-      statusMessage: describeStreamError(prepareError),
-      metadata: {
-        streamErrorPhase: 'preparation',
-        streamErrorShape: { name: 'TypeError' }
-      }
-    })
+    expect(mocks.span.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'ERROR',
+        statusMessage: describeStreamError(prepareError),
+        metadata: {
+          streamErrorPhase: 'preparation',
+          streamErrorShape: { name: 'TypeError' }
+        }
+      })
+    )
     expect(mocks.stream).not.toHaveBeenCalled()
   })
 
@@ -215,19 +225,83 @@ describe('createChatStreamResponse', () => {
     await createChatStreamResponse(createConfig())
     await mocks.finishPromise
 
-    expect(mocks.span.update).toHaveBeenCalledWith({
-      level: 'ERROR',
-      statusMessage: describeStreamError(streamError),
-      metadata: {
-        streamErrorPhase: 'generation',
-        streamErrorShape: {
-          name: 'StreamFailure',
-          errno: 91
+    expect(mocks.span.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'ERROR',
+        statusMessage: describeStreamError(streamError),
+        metadata: {
+          streamErrorPhase: 'generation',
+          streamErrorShape: {
+            name: 'StreamFailure',
+            errno: 91
+          }
         }
-      }
-    })
+      })
+    )
     expect(JSON.stringify(mocks.span.update.mock.calls)).not.toContain(
       'private failure detail'
     )
+  })
+
+  it('records the user message and the finished answer on the root span', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
+      output: 'Answer'
+    })
+  })
+
+  it('keeps the input and omits the output for an aborted turn', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult(true))
+
+    await createChatStreamResponse(createConfig(createAbortedSignal()))
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({ input: 'hello' })
+  })
+
+  it('takes the input from the prepared messages when the turn has no message', async () => {
+    vi.mocked(prepareMessages).mockResolvedValueOnce([
+      {
+        id: 'earlier-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'earlier question' }]
+      },
+      {
+        id: 'earlier-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'earlier answer' }]
+      }
+    ] as any)
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse({
+      ...createConfig(),
+      message: null,
+      trigger: 'regenerate-assistant-message' as const
+    })
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'earlier question',
+      output: 'Answer'
+    })
+  })
+
+  it('keeps the empty-response failure alongside the root span input', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult(false, []))
+
+    await createChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
+      level: 'ERROR',
+      statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
+    })
   })
 })

--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -255,6 +255,21 @@ describe('createChatStreamResponse', () => {
     })
   })
 
+  it('omits the output when the answer is only whitespace', async () => {
+    mocks.stream.mockResolvedValue(
+      createFakeResult(false, [{ type: 'text', text: '   \n' }])
+    )
+
+    await createChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
+      level: 'ERROR',
+      statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
+    })
+  })
+
   it('omits the output when the stream failed after partial text', async () => {
     const streamError = new Error('upstream stopped')
     streamError.name = 'AbortError'

--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -134,6 +134,15 @@ function createConfig(abortSignal: AbortSignal = new AbortController().signal) {
   }
 }
 
+function createConfigWithParts(parts: unknown[]) {
+  const config = createConfig()
+
+  return {
+    ...config,
+    message: { ...config.message, parts: parts as typeof config.message.parts }
+  }
+}
+
 describe('createChatStreamResponse', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -321,6 +330,121 @@ describe('createChatStreamResponse', () => {
       input: 'earlier question',
       output: 'Answer'
     })
+  })
+
+  it('describes a file-only turn on the root span input', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(
+      createConfigWithParts([
+        {
+          type: 'file',
+          filename: 'report.pdf',
+          mediaType: 'application/pdf',
+          url: 'https://example.com/report.pdf'
+        }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: '"report.pdf" (application/pdf)',
+      output: 'Answer'
+    })
+  })
+
+  it('describes a pasted-content-only turn without its content', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(
+      createConfigWithParts([
+        { type: 'data-pastedContent', data: { text: 'secret'.repeat(100) } }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'pasted content (600 characters)',
+      output: 'Answer'
+    })
+    expect(JSON.stringify(mocks.span.update.mock.calls)).not.toContain('secret')
+  })
+
+  it('keeps the URL of a URL-card-only turn', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(
+      createConfigWithParts([
+        { type: 'data-sourceUrl', data: { url: 'https://example.com/a' } }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'URL card: https://example.com/a',
+      output: 'Answer'
+    })
+  })
+
+  it('describes both a file and pasted content on the same turn', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(
+      createConfigWithParts([
+        {
+          type: 'file',
+          filename: 'notes.txt',
+          mediaType: 'text/plain',
+          url: 'https://example.com/notes.txt'
+        },
+        { type: 'data-pastedContent', data: { text: 'ab' } }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: '"notes.txt" (text/plain), pasted content (2 characters)',
+      output: 'Answer'
+    })
+  })
+
+  it('describes the structured parts of the prepared history on a regenerate turn', async () => {
+    vi.mocked(prepareMessages).mockResolvedValueOnce([
+      {
+        id: 'earlier-user',
+        role: 'user',
+        parts: [
+          {
+            type: 'file',
+            filename: 'earlier.png',
+            mediaType: 'image/png',
+            url: 'https://example.com/earlier.png'
+          }
+        ]
+      }
+    ] as any)
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse({
+      ...createConfig(),
+      message: null,
+      trigger: 'regenerate-assistant-message' as const
+    })
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: '"earlier.png" (image/png)',
+      output: 'Answer'
+    })
+  })
+
+  it('leaves the input unset for a turn with no parts', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(createConfigWithParts([]))
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({ output: 'Answer' })
   })
 
   it('keeps the empty-response failure alongside the root span input', async () => {

--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -255,6 +255,22 @@ describe('createChatStreamResponse', () => {
     })
   })
 
+  it('omits the output when the stream failed after partial text', async () => {
+    const streamError = new Error('upstream stopped')
+    streamError.name = 'AbortError'
+    mocks.stream.mockImplementation(async (options: StreamOptions) => {
+      options.onError({ error: streamError })
+      return createFakeResult(false, [{ type: 'text', text: 'Partial ans' }])
+    })
+
+    await createChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    const update = mocks.span.update.mock.calls.at(-1)?.[0]
+    expect(update).toMatchObject({ input: 'hello', level: 'ERROR' })
+    expect(update).not.toHaveProperty('output')
+  })
+
   it('keeps the input and omits the output for an aborted turn', async () => {
     mocks.stream.mockResolvedValue(createFakeResult(true))
 

--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -163,7 +163,10 @@ describe('createEphemeralChatStreamResponse', () => {
     await mocks.finishPromise
 
     expect(mocks.serializedError).toBe(serializeToolFailure(toolError))
-    expect(mocks.span.update).not.toHaveBeenCalled()
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
+      output: 'Answer'
+    })
     expect(mocks.span.end).toHaveBeenCalledOnce()
     expect(mocks.forceFlush).toHaveBeenCalledOnce()
   })
@@ -181,17 +184,19 @@ describe('createEphemeralChatStreamResponse', () => {
     await createEphemeralChatStreamResponse(createConfig())
     await mocks.finishPromise
 
-    expect(mocks.span.update).toHaveBeenCalledWith({
-      level: 'ERROR',
-      statusMessage: describeStreamError(streamError),
-      metadata: {
-        streamErrorPhase: 'generation',
-        streamErrorShape: {
-          name: 'StreamFailure',
-          code: 'STREAM_CODE'
+    expect(mocks.span.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'ERROR',
+        statusMessage: describeStreamError(streamError),
+        metadata: {
+          streamErrorPhase: 'generation',
+          streamErrorShape: {
+            name: 'StreamFailure',
+            code: 'STREAM_CODE'
+          }
         }
-      }
-    })
+      })
+    )
     expect(mocks.span.end).toHaveBeenCalledOnce()
     expect(mocks.forceFlush).toHaveBeenCalledOnce()
   })
@@ -207,7 +212,7 @@ describe('createEphemeralChatStreamResponse', () => {
     await createEphemeralChatStreamResponse(createConfig(createAbortedSignal()))
     await mocks.finishPromise
 
-    expect(mocks.span.update).not.toHaveBeenCalled()
+    expect(mocks.span.update).toHaveBeenCalledWith({ input: 'hello' })
     expect(mocks.span.end).toHaveBeenCalledOnce()
     expect(mocks.forceFlush).toHaveBeenCalledOnce()
   })
@@ -219,21 +224,25 @@ describe('createEphemeralChatStreamResponse', () => {
     await mocks.finishPromise
 
     expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
       level: 'ERROR',
       statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
     })
   })
 
-  it('does not update the span for a response with text', async () => {
+  it('does not mark the span as failed for a response with text', async () => {
     mocks.stream.mockResolvedValue(createFakeResult())
 
     await createEphemeralChatStreamResponse(createConfig(createAbortedSignal()))
     await mocks.finishPromise
 
-    expect(mocks.span.update).not.toHaveBeenCalled()
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
+      output: 'Answer'
+    })
   })
 
-  it('does not update the span for an aborted turn', async () => {
+  it('keeps the input and omits the output for an aborted turn', async () => {
     mocks.stream.mockResolvedValue(
       createFakeResult({ parts: [], isAborted: true })
     )
@@ -241,7 +250,38 @@ describe('createEphemeralChatStreamResponse', () => {
     await createEphemeralChatStreamResponse(createConfig(createAbortedSignal()))
     await mocks.finishPromise
 
-    expect(mocks.span.update).not.toHaveBeenCalled()
+    expect(mocks.span.update).toHaveBeenCalledWith({ input: 'hello' })
+  })
+
+  it('takes the input from the last user message of the history', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse({
+      ...createConfig(),
+      messages: [
+        {
+          id: 'first-user',
+          role: 'user' as const,
+          parts: [{ type: 'text' as const, text: 'first question' }]
+        },
+        {
+          id: 'first-assistant',
+          role: 'assistant' as const,
+          parts: [{ type: 'text' as const, text: 'first answer' }]
+        },
+        {
+          id: 'second-user',
+          role: 'user' as const,
+          parts: [{ type: 'text' as const, text: 'second question' }]
+        }
+      ]
+    })
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'second question',
+      output: 'Answer'
+    })
   })
 
   it('preserves the stream error when the response is empty', async () => {
@@ -256,6 +296,7 @@ describe('createEphemeralChatStreamResponse', () => {
 
     expect(mocks.span.update).toHaveBeenCalledOnce()
     expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
       level: 'ERROR',
       statusMessage: describeStreamError(streamError),
       metadata: {

--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -201,6 +201,24 @@ describe('createEphemeralChatStreamResponse', () => {
     expect(mocks.forceFlush).toHaveBeenCalledOnce()
   })
 
+  it('omits the output when the stream failed after partial text', async () => {
+    const streamError = new Error('upstream stopped')
+    streamError.name = 'AbortError'
+    mocks.stream.mockImplementation(async (options: StreamOptions) => {
+      options.onError({ error: streamError })
+      return createFakeResult({
+        parts: [{ type: 'text', text: 'Partial ans' }]
+      })
+    })
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    const update = mocks.span.update.mock.calls.at(-1)?.[0]
+    expect(update).toMatchObject({ input: 'hello', level: 'ERROR' })
+    expect(update).not.toHaveProperty('output')
+  })
+
   it('does not mark the span as failed for an aborted stream error', async () => {
     const streamError = new Error('request stopped')
     streamError.name = 'AbortError'

--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -122,6 +122,20 @@ function createConfig(abortSignal: AbortSignal = new AbortController().signal) {
   }
 }
 
+function createConfigWithParts(parts: unknown[]) {
+  const config = createConfig()
+
+  return {
+    ...config,
+    messages: [
+      {
+        ...config.messages[0],
+        parts: parts as (typeof config.messages)[0]['parts']
+      }
+    ]
+  }
+}
+
 describe('createEphemeralChatStreamResponse', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -313,6 +327,91 @@ describe('createEphemeralChatStreamResponse', () => {
       input: 'second question',
       output: 'Answer'
     })
+  })
+
+  it('describes a file-only turn on the root span input', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse(
+      createConfigWithParts([
+        {
+          type: 'file',
+          filename: 'report.pdf',
+          mediaType: 'application/pdf',
+          url: 'https://example.com/report.pdf'
+        }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: '"report.pdf" (application/pdf)',
+      output: 'Answer'
+    })
+  })
+
+  it('describes a pasted-content-only turn without its content', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse(
+      createConfigWithParts([
+        { type: 'data-pastedContent', data: { text: 'secret'.repeat(100) } }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'pasted content (600 characters)',
+      output: 'Answer'
+    })
+    expect(JSON.stringify(mocks.span.update.mock.calls)).not.toContain('secret')
+  })
+
+  it('keeps the URL of a URL-card-only turn', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse(
+      createConfigWithParts([
+        { type: 'data-sourceUrl', data: { url: 'https://example.com/a' } }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'URL card: https://example.com/a',
+      output: 'Answer'
+    })
+  })
+
+  it('describes both a file and pasted content on the same turn', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse(
+      createConfigWithParts([
+        {
+          type: 'file',
+          filename: 'notes.txt',
+          mediaType: 'text/plain',
+          url: 'https://example.com/notes.txt'
+        },
+        { type: 'data-pastedContent', data: { text: 'ab' } }
+      ])
+    )
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: '"notes.txt" (text/plain), pasted content (2 characters)',
+      output: 'Answer'
+    })
+  })
+
+  it('leaves the input unset for a turn with no parts', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse(createConfigWithParts([]))
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({ output: 'Answer' })
   })
 
   it('preserves the stream error when the response is empty', async () => {

--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -201,6 +201,19 @@ describe('createEphemeralChatStreamResponse', () => {
     expect(mocks.forceFlush).toHaveBeenCalledOnce()
   })
 
+  it('omits the output when the answer is only whitespace', async () => {
+    mocks.stream.mockResolvedValue(
+      createFakeResult({ parts: [{ type: 'text', text: '   \n' }] })
+    )
+
+    await createEphemeralChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    const update = mocks.span.update.mock.calls.at(-1)?.[0]
+    expect(update).toMatchObject({ input: 'hello', level: 'ERROR' })
+    expect(update).not.toHaveProperty('output')
+  })
+
   it('omits the output when the stream failed after partial text', async () => {
     const streamError = new Error('upstream stopped')
     streamError.name = 'AbortError'

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -125,9 +125,12 @@ export async function createChatStreamResponse(
                 statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
               }
             : null
+        // A stream that failed mid-answer leaves partial text behind. That is
+        // not the turn's answer, so it is not recorded as one.
         const update = {
           ...(rootInput !== undefined && { input: rootInput }),
-          ...(rootOutput !== undefined && { output: rootOutput }),
+          ...(!hasStreamError &&
+            rootOutput !== undefined && { output: rootOutput }),
           ...failureUpdate
         }
         if (Object.keys(update).length > 0) rootSpan.update(update)

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -106,22 +106,31 @@ export async function createChatStreamResponse(
     // span is closed, and by then the signal no longer says whether the user
     // cancelled this turn or the failure was the model's own.
     let streamErrorWasCancelled = false
+    // Overall IO of the trace lives on the root observation. A regenerate turn
+    // carries no incoming message, so its input comes from the prepared history.
+    let rootInput = getTextFromParts(message?.parts) || undefined
+    let rootOutput: string | undefined
 
     const endTracing = async () => {
       if (rootSpan) {
-        if (hasStreamError) {
-          const update = buildStreamErrorSpanUpdate(
-            streamError,
-            streamErrorWasCancelled,
-            streamErrorPhase
-          )
-          if (update) rootSpan.update(update)
-        } else if (hasEmptyResponse) {
-          rootSpan.update({
-            level: 'ERROR',
-            statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
-          })
+        const failureUpdate = hasStreamError
+          ? buildStreamErrorSpanUpdate(
+              streamError,
+              streamErrorWasCancelled,
+              streamErrorPhase
+            )
+          : hasEmptyResponse
+            ? {
+                level: 'ERROR' as const,
+                statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
+              }
+            : null
+        const update = {
+          ...(rootInput !== undefined && { input: rootInput }),
+          ...(rootOutput !== undefined && { output: rootOutput }),
+          ...failureUpdate
         }
+        if (Object.keys(update).length > 0) rootSpan.update(update)
         rootSpan.end()
         await langfuseSpanProcessor.forceFlush()
       }
@@ -151,6 +160,13 @@ export async function createChatStreamResponse(
       )
       const messagesToModel = await prepareMessages(context, message)
       perfTime('prepareMessages completed (stream)', prepareStart)
+
+      if (rootInput === undefined) {
+        rootInput =
+          getTextFromParts(
+            messagesToModel.findLast(m => m.role === 'user')?.parts
+          ) || undefined
+      }
 
       // Get the researcher agent with search mode
       const researchAgent = researcher({
@@ -257,6 +273,7 @@ export async function createChatStreamResponse(
             perfTime('researchAgent.stream completed', llmStart)
             if (isAborted || !responseMessage) return
 
+            rootOutput = getTextFromParts(responseMessage.parts) || undefined
             hasEmptyResponse = isEmptyResponse(responseMessage)
 
             // Persist stream results to database

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -31,6 +31,7 @@ import { compactHistoricalMessages } from './helpers/compact-historical-messages
 import { convertDataPart } from './helpers/convert-data-part'
 import { assignDataPartNonces } from './helpers/data-part-nonce'
 import { dedupeAttachments } from './helpers/dedupe-attachments'
+import { describeTurnInput } from './helpers/describe-turn-input'
 import {
   EMPTY_RESPONSE_STATUS_MESSAGE,
   isEmptyResponse
@@ -108,7 +109,7 @@ export async function createChatStreamResponse(
     let streamErrorWasCancelled = false
     // Overall IO of the trace lives on the root observation. A regenerate turn
     // carries no incoming message, so its input comes from the prepared history.
-    let rootInput = getTextFromParts(message?.parts) || undefined
+    let rootInput = describeTurnInput(message?.parts)
     let rootOutput: string | undefined
 
     const endTracing = async () => {
@@ -166,10 +167,9 @@ export async function createChatStreamResponse(
       perfTime('prepareMessages completed (stream)', prepareStart)
 
       if (rootInput === undefined) {
-        rootInput =
-          getTextFromParts(
-            messagesToModel.findLast(m => m.role === 'user')?.parts
-          ) || undefined
+        rootInput = describeTurnInput(
+          messagesToModel.findLast(m => m.role === 'user')?.parts
+        )
       }
 
       // Get the researcher agent with search mode

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -125,12 +125,13 @@ export async function createChatStreamResponse(
                 statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
               }
             : null
-        // A stream that failed mid-answer leaves partial text behind. That is
-        // not the turn's answer, so it is not recorded as one.
+        // A turn that failed mid-answer or produced no answer text still has
+        // whatever was streamed before it. That is not the turn's answer, so
+        // it is not recorded as one.
+        const hasAnswer = !hasStreamError && !hasEmptyResponse
         const update = {
           ...(rootInput !== undefined && { input: rootInput }),
-          ...(!hasStreamError &&
-            rootOutput !== undefined && { output: rootOutput }),
+          ...(hasAnswer && rootOutput !== undefined && { output: rootOutput }),
           ...failureUpdate
         }
         if (Object.keys(update).length > 0) rootSpan.update(update)

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -19,6 +19,7 @@ import {
   shouldTruncateMessages,
   truncateMessages
 } from '../utils/context-window'
+import { getTextFromParts } from '../utils/message-utils'
 import { isUsageLogging, logUsage } from '../utils/usage-logging'
 
 import { capHistoricalAttachments } from './helpers/cap-historical-attachments'
@@ -73,22 +74,33 @@ export async function createEphemeralChatStreamResponse(
     // span is closed, and by then the signal no longer says whether the user
     // cancelled this turn or the failure was the model's own.
     let streamErrorWasCancelled = false
+    // Overall IO of the trace lives on the root observation. The turn is driven
+    // by the last user message of the submitted history.
+    const rootInput =
+      getTextFromParts(messages.findLast(m => m.role === 'user')?.parts) ||
+      undefined
+    let rootOutput: string | undefined
 
     const endTracing = async () => {
       if (rootSpan) {
-        if (hasStreamError) {
-          const update = buildStreamErrorSpanUpdate(
-            streamError,
-            streamErrorWasCancelled,
-            streamErrorPhase
-          )
-          if (update) rootSpan.update(update)
-        } else if (hasEmptyResponse) {
-          rootSpan.update({
-            level: 'ERROR',
-            statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
-          })
+        const failureUpdate = hasStreamError
+          ? buildStreamErrorSpanUpdate(
+              streamError,
+              streamErrorWasCancelled,
+              streamErrorPhase
+            )
+          : hasEmptyResponse
+            ? {
+                level: 'ERROR' as const,
+                statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
+              }
+            : null
+        const update = {
+          ...(rootInput !== undefined && { input: rootInput }),
+          ...(rootOutput !== undefined && { output: rootOutput }),
+          ...failureUpdate
         }
+        if (Object.keys(update).length > 0) rootSpan.update(update)
         rootSpan.end()
         await langfuseSpanProcessor.forceFlush()
       }
@@ -162,6 +174,7 @@ export async function createEphemeralChatStreamResponse(
         },
         onEnd: async ({ responseMessage, isAborted }) => {
           if (!isAborted && responseMessage) {
+            rootOutput = getTextFromParts(responseMessage.parts) || undefined
             hasEmptyResponse = isEmptyResponse(responseMessage)
           }
           await endTracing()

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -27,6 +27,7 @@ import { compactHistoricalMessages } from './helpers/compact-historical-messages
 import { convertDataPart } from './helpers/convert-data-part'
 import { assignDataPartNonces } from './helpers/data-part-nonce'
 import { dedupeAttachments } from './helpers/dedupe-attachments'
+import { describeTurnInput } from './helpers/describe-turn-input'
 import {
   EMPTY_RESPONSE_STATUS_MESSAGE,
   isEmptyResponse
@@ -76,9 +77,9 @@ export async function createEphemeralChatStreamResponse(
     let streamErrorWasCancelled = false
     // Overall IO of the trace lives on the root observation. The turn is driven
     // by the last user message of the submitted history.
-    const rootInput =
-      getTextFromParts(messages.findLast(m => m.role === 'user')?.parts) ||
-      undefined
+    const rootInput = describeTurnInput(
+      messages.findLast(m => m.role === 'user')?.parts
+    )
     let rootOutput: string | undefined
 
     const endTracing = async () => {

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -95,12 +95,13 @@ export async function createEphemeralChatStreamResponse(
                 statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
               }
             : null
-        // A stream that failed mid-answer leaves partial text behind. That is
-        // not the turn's answer, so it is not recorded as one.
+        // A turn that failed mid-answer or produced no answer text still has
+        // whatever was streamed before it. That is not the turn's answer, so
+        // it is not recorded as one.
+        const hasAnswer = !hasStreamError && !hasEmptyResponse
         const update = {
           ...(rootInput !== undefined && { input: rootInput }),
-          ...(!hasStreamError &&
-            rootOutput !== undefined && { output: rootOutput }),
+          ...(hasAnswer && rootOutput !== undefined && { output: rootOutput }),
           ...failureUpdate
         }
         if (Object.keys(update).length > 0) rootSpan.update(update)

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -95,9 +95,12 @@ export async function createEphemeralChatStreamResponse(
                 statusMessage: EMPTY_RESPONSE_STATUS_MESSAGE
               }
             : null
+        // A stream that failed mid-answer leaves partial text behind. That is
+        // not the turn's answer, so it is not recorded as one.
         const update = {
           ...(rootInput !== undefined && { input: rootInput }),
-          ...(rootOutput !== undefined && { output: rootOutput }),
+          ...(!hasStreamError &&
+            rootOutput !== undefined && { output: rootOutput }),
           ...failureUpdate
         }
         if (Object.keys(update).length > 0) rootSpan.update(update)

--- a/lib/streaming/helpers/__tests__/describe-turn-input.test.ts
+++ b/lib/streaming/helpers/__tests__/describe-turn-input.test.ts
@@ -1,0 +1,134 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { describeTurnInput } from '@/lib/streaming/helpers/describe-turn-input'
+
+function createParts(parts: unknown[]): UIMessage['parts'] {
+  return parts as UIMessage['parts']
+}
+
+describe('describeTurnInput', () => {
+  it('returns the typed text when there is any', () => {
+    expect(
+      describeTurnInput(createParts([{ type: 'text', text: 'hello' }]))
+    ).toBe('hello')
+  })
+
+  it('prefers the text over the structured parts', () => {
+    expect(
+      describeTurnInput(
+        createParts([
+          {
+            type: 'data-pastedContent',
+            data: { text: 'a'.repeat(2000) }
+          },
+          { type: 'text', text: 'summarize this' }
+        ])
+      )
+    ).toBe('summarize this')
+  })
+
+  it('describes a file part by name and media type', () => {
+    expect(
+      describeTurnInput(
+        createParts([
+          {
+            type: 'file',
+            filename: 'report.pdf',
+            mediaType: 'application/pdf',
+            url: 'https://example.com/report.pdf'
+          }
+        ])
+      )
+    ).toBe('"report.pdf" (application/pdf)')
+  })
+
+  it('describes pasted content by size without its content', () => {
+    const description = describeTurnInput(
+      createParts([
+        { type: 'data-pastedContent', data: { text: 'secret'.repeat(100) } }
+      ])
+    )
+
+    expect(description).toBe('pasted content (600 characters)')
+    expect(description).not.toContain('secret')
+  })
+
+  it('describes quoted context by size', () => {
+    expect(
+      describeTurnInput(
+        createParts([{ type: 'data-quotedContext', data: { text: 'quoted' } }])
+      )
+    ).toBe('quoted context (6 characters)')
+  })
+
+  it('describes a note by its neutralized title and size', () => {
+    expect(
+      describeTurnInput(
+        createParts([
+          {
+            type: 'data-noteContext',
+            data: { title: '<b>My\nnote</b>', text: 'body' }
+          }
+        ])
+      )
+    ).toBe('note "&lt;b&gt;My note&lt;/b&gt;" (4 characters)')
+  })
+
+  it('describes a note without a title', () => {
+    expect(
+      describeTurnInput(
+        createParts([{ type: 'data-noteContext', data: { text: 'body' } }])
+      )
+    ).toBe('note (4 characters)')
+  })
+
+  it('keeps a source URL verbatim', () => {
+    expect(
+      describeTurnInput(
+        createParts([
+          { type: 'data-sourceUrl', data: { url: 'https://example.com/a' } }
+        ])
+      )
+    ).toBe('URL card: https://example.com/a')
+  })
+
+  it('joins several structured parts in part order', () => {
+    expect(
+      describeTurnInput(
+        createParts([
+          {
+            type: 'file',
+            filename: 'notes.txt',
+            mediaType: 'text/plain',
+            url: 'https://example.com/notes.txt'
+          },
+          { type: 'data-pastedContent', data: { text: 'ab' } }
+        ])
+      )
+    ).toBe('"notes.txt" (text/plain), pasted content (2 characters)')
+  })
+
+  it('returns undefined for a message with no parts', () => {
+    expect(describeTurnInput(createParts([]))).toBeUndefined()
+    expect(describeTurnInput(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for whitespace-only text', () => {
+    expect(
+      describeTurnInput(createParts([{ type: 'text', text: '   ' }]))
+    ).toBeUndefined()
+  })
+
+  it('ignores structured parts that carry nothing', () => {
+    expect(
+      describeTurnInput(
+        createParts([
+          { type: 'data-pastedContent', data: { text: '' } },
+          { type: 'data-sourceUrl', data: {} },
+          { type: 'data-unknownKind', data: { text: 'x' } }
+        ])
+      )
+    ).toBeUndefined()
+  })
+})

--- a/lib/streaming/helpers/attachment-parts.ts
+++ b/lib/streaming/helpers/attachment-parts.ts
@@ -14,15 +14,21 @@ export function isFilePart(part: UIMessage['parts'][number]) {
   return part.type === 'file'
 }
 
-export function describeAttachment(part: FilePartLike) {
-  // The filename is user-supplied, so neutralize it the way source excerpts are
-  // neutralized: no markup, no newlines, bounded length.
-  const filename = (part.filename ?? '')
+/**
+ * Renders a user-supplied label the way source excerpts are neutralized: no
+ * markup, no newlines, bounded length.
+ */
+export function neutralizeLabel(value: string | undefined, maxChars: number) {
+  return (value ?? '')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/\s+/g, ' ')
     .trim()
-    .slice(0, MAX_FILENAME_CHARS)
+    .slice(0, maxChars)
+}
+
+export function describeAttachment(part: FilePartLike) {
+  const filename = neutralizeLabel(part.filename, MAX_FILENAME_CHARS)
   const mediaType = (part.mediaType ?? 'file').replace(/[^\w.+/-]/g, '')
 
   return filename

--- a/lib/streaming/helpers/describe-turn-input.ts
+++ b/lib/streaming/helpers/describe-turn-input.ts
@@ -1,0 +1,79 @@
+import type { UIMessage } from 'ai'
+
+import { getTextFromParts } from '../../utils/message-utils'
+
+import {
+  describeAttachment,
+  isFilePart,
+  neutralizeLabel
+} from './attachment-parts'
+
+const MAX_NOTE_TITLE_CHARS = 80
+
+function getDataText(data: unknown, key: string): string {
+  const value = (data as Record<string, unknown> | undefined)?.[key]
+  return typeof value === 'string' ? value : ''
+}
+
+/**
+ * Describes one structured part by kind and weight, never by content: a pasted
+ * block runs to tens of thousands of characters, and the content itself already
+ * reaches the child generations. A URL is short and is itself the input, so it
+ * is kept verbatim.
+ */
+function describePart(part: UIMessage['parts'][number]): string | undefined {
+  if (isFilePart(part)) {
+    return describeAttachment(part as { mediaType?: string; filename?: string })
+  }
+
+  const data = (part as { data?: unknown }).data
+
+  if (part.type === 'data-pastedContent') {
+    const text = getDataText(data, 'text')
+    return text ? `pasted content (${text.length} characters)` : undefined
+  }
+
+  if (part.type === 'data-quotedContext') {
+    const text = getDataText(data, 'text')
+    return text ? `quoted context (${text.length} characters)` : undefined
+  }
+
+  if (part.type === 'data-noteContext') {
+    const text = getDataText(data, 'text')
+    if (!text) return undefined
+    const title = neutralizeLabel(
+      getDataText(data, 'title'),
+      MAX_NOTE_TITLE_CHARS
+    )
+    const label = title ? `note "${title}"` : 'note'
+    return `${label} (${text.length} characters)`
+  }
+
+  if (part.type === 'data-sourceUrl') {
+    const url = getDataText(data, 'url')
+    return url ? `URL card: ${url}` : undefined
+  }
+
+  return undefined
+}
+
+/**
+ * The turn's input as recorded on the root observation.
+ *
+ * Typed text is the input whenever there is any. A turn can carry nothing but
+ * structured parts, and dropping those would leave the trace with no input at
+ * all, so they are summarized instead. A message that carries nothing usable
+ * stays unset rather than recording an empty input.
+ */
+export function describeTurnInput(
+  parts?: UIMessage['parts']
+): string | undefined {
+  const text = getTextFromParts(parts)
+  if (text.trim()) return text
+
+  const described = (parts ?? [])
+    .map(describePart)
+    .filter((description): description is string => Boolean(description))
+
+  return described.length > 0 ? described.join(', ') : undefined
+}


### PR DESCRIPTION
The root `research` span was never given the turn's input or output. A trace therefore showed nothing about the turn itself, and the only content on it lived in the child generations, whose input is the whole model-facing payload rather than the question that was asked.

This fills both in.

## Notes

- `input` is the user message that drove the turn, `output` is the finished answer.
- A regenerate turn submits no message, so its input comes from the prepared history instead.
- On an aborted or failed turn the input is still recorded and the output is left unset rather than empty.
- The `level` and `statusMessage` set on the same span are unchanged.
- No new content reaches Langfuse. The same text is already present on the child generations.

## Verification

Both stream paths are covered by the existing test files, extended for the normal turn, the aborted turn, the regenerate turn, and the empty response.

`bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (509 passed, 3 skipped) and `bun run build` all pass.
