### PR TITLE
feat(upload): accept MP4 so video-capable models can read a clip

### DIFF
--- a/app/api/upload/__tests__/route.test.ts
+++ b/app/api/upload/__tests__/route.test.ts
@@ -78,6 +78,13 @@ function pdfUploadBytes(bytes = 1234) {
   return contents
 }
 
+function mp4UploadBytes(bytes = 1234) {
+  const contents = new Uint8Array(bytes)
+  contents.set([0x00, 0x00, 0x00, 0x20])
+  contents.set(Buffer.from('ftypisom', 'ascii'), 4)
+  return contents
+}
+
 function md5OfUpload(bytes = 1234) {
   return createHash('md5').update(pdfUploadBytes(bytes)).digest('hex')
 }
@@ -133,9 +140,9 @@ describe('POST /api/upload', () => {
   })
 
   it('rejects allowed declared types with unsupported content', async () => {
-    const contents = new Uint8Array([
-      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d
-    ])
+    // Bytes that open no supported format: not a JPEG, PNG, MP4 container or
+    // PDF header.
+    const contents = new Uint8Array(32)
 
     const response = await POST(uploadRequest(contents.byteLength, contents))
 
@@ -146,6 +153,30 @@ describe('POST /api/upload', () => {
     expect(dbActions.findChatFileCandidates).not.toHaveBeenCalled()
     expect(send).not.toHaveBeenCalled()
     expect(dbActions.createLibraryFile).not.toHaveBeenCalled()
+  })
+
+  it('stores a clip under its detected video type', async () => {
+    vi.mocked(dbActions.findChatFileCandidates).mockResolvedValue([])
+    const contents = mp4UploadBytes()
+
+    const { file } = await (
+      await POST(
+        uploadRequest(contents.byteLength, contents, {
+          name: 'clip.mp4',
+          type: 'video/mp4'
+        })
+      )
+    ).json()
+
+    expect(file.mediaType).toBe('video/mp4')
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ ContentType: 'video/mp4' })
+      })
+    )
+    expect(dbActions.createLibraryFile).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: 'video/mp4' })
+    )
   })
 
   it('stores a mislabelled file under the type its bytes say it is', async () => {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -81,7 +81,7 @@ export async function POST(req: NextRequest) {
         {
           error: 'Unsupported file content',
           message:
-            'The file contents are not a JPEG, PNG, or PDF even though the file name suggests otherwise.'
+            'The file contents are not a JPEG, PNG, MP4, or PDF even though the file name suggests otherwise.'
         },
         { status: 400 }
       )

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -70,7 +70,12 @@ const PASTE_CARD_MIN_CHARS = 400
 // L0 prototype: client-only, no fetch — the URL rides into the query at send
 // time so the existing fetch tool picks it up.
 const BARE_URL_RE = /^https?:\/\/\S+$/
-const ALLOWED_FILE_TYPES = ['image/png', 'image/jpeg', 'application/pdf']
+const ALLOWED_FILE_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'video/mp4',
+  'application/pdf'
+]
 
 function getSearchModeSnapshot(): SearchMode {
   return getCookie('searchMode') === 'adaptive' ? 'adaptive' : 'quick'

--- a/components/file-upload-button.tsx
+++ b/components/file-upload-button.tsx
@@ -10,10 +10,13 @@ import { cn } from '@/lib/utils'
 import { Button } from './ui/button'
 
 const allowedImageTypes = ['image/png', 'image/jpeg']
+const allowedVideoTypes = ['video/mp4']
 const allowedOtherTypes = ['application/pdf']
 
 const isAllowedFileType = (file: File) =>
-  allowedImageTypes.includes(file.type) || allowedOtherTypes.includes(file.type)
+  allowedImageTypes.includes(file.type) ||
+  allowedVideoTypes.includes(file.type) ||
+  allowedOtherTypes.includes(file.type)
 
 export function FileUploadButton({
   onFileSelect
@@ -66,7 +69,7 @@ export function FileUploadButton({
       <input
         ref={inputRef}
         type="file"
-        accept="image/png,image/jpeg,application/pdf"
+        accept="image/png,image/jpeg,video/mp4,application/pdf"
         hidden
         multiple
         onChange={e => {

--- a/hooks/use-file-dropzone.ts
+++ b/hooks/use-file-dropzone.ts
@@ -17,7 +17,7 @@ export function useFileDropzone({
   setUploadedFiles,
   chatId,
   maxFiles = 3,
-  allowedTypes = ['image/png', 'image/jpeg', 'application/pdf']
+  allowedTypes = ['image/png', 'image/jpeg', 'video/mp4', 'application/pdf']
 }: UseFileDropzoneProps) {
   const [isDragging, setIsDragging] = useState(false)
 

--- a/lib/storage/__tests__/file-signature.test.ts
+++ b/lib/storage/__tests__/file-signature.test.ts
@@ -29,11 +29,48 @@ describe('detectFileMediaType', () => {
     ).toBe('application/pdf')
   })
 
-  it('rejects the MP4 content from the production upload', () => {
+  it('detects MP4 content', () => {
+    expect(
+      detectFileMediaType(
+        Buffer.from([
+          0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32
+        ])
+      )
+    ).toBe('video/mp4')
+  })
+
+  it('detects the ISO container from the production upload as MP4', () => {
+    // A clip named image.jpg is reported as an image by the browser. Reading
+    // the bytes is what keeps it from being sent to the model as a broken
+    // image, which used to fail the whole turn.
     expect(
       detectFileMediaType(
         Buffer.from([
           0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d
+        ])
+      )
+    ).toBe('video/mp4')
+  })
+
+  it('rejects an ISO container that is not an MP4 brand', () => {
+    // QuickTime shares the container. Passing it off as MP4 would move the
+    // failure from the upload to the provider.
+    expect(
+      detectFileMediaType(
+        Buffer.concat([
+          Buffer.from([0x00, 0x00, 0x00, 0x20]),
+          Buffer.from('ftypqt  ', 'ascii')
+        ])
+      )
+    ).toBeNull()
+  })
+
+  it('rejects an ISO container whose brand is cut off', () => {
+    expect(
+      detectFileMediaType(
+        Buffer.concat([
+          Buffer.from([0x00, 0x00, 0x00, 0x20]),
+          Buffer.from('ftypiso', 'ascii')
         ])
       )
     ).toBeNull()

--- a/lib/storage/file-signature.ts
+++ b/lib/storage/file-signature.ts
@@ -1,10 +1,37 @@
+/**
+ * Order is also detection order. PDF is the only format matched by scanning a
+ * window instead of a fixed offset, so it stays last and the formats that claim
+ * specific bytes get to answer for them first.
+ */
 export const ALLOWED_FILE_TYPES = [
   'image/jpeg',
   'image/png',
+  'video/mp4',
   'application/pdf'
 ] as const
 
 export type SupportedFileType = (typeof ALLOWED_FILE_TYPES)[number]
+
+/**
+ * ISO base media file format brands that mean the container holds an MP4.
+ *
+ * The container is shared with formats that are not MP4 — QuickTime movies
+ * (`qt  `) and M4A audio among them — and the brand in the `ftyp` box is what
+ * separates them. Accepting the box alone would send audio to the model as a
+ * video, which fails the turn at the provider instead of at the upload.
+ */
+const MP4_BRANDS = new Set([
+  'avc1',
+  'dash',
+  'iso2',
+  'iso4',
+  'iso5',
+  'iso6',
+  'isom',
+  'mmp4',
+  'mp41',
+  'mp42'
+])
 
 const signatures: Record<SupportedFileType, (buffer: Buffer) => boolean> = {
   'image/jpeg': buffer =>
@@ -13,6 +40,11 @@ const signatures: Record<SupportedFileType, (buffer: Buffer) => boolean> = {
     buffer
       .subarray(0, 8)
       .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])),
+  // The `ftyp` box opens the file with its own 4-byte length, so the box type
+  // sits at bytes 4..8 and the brand always follows it at bytes 8..12.
+  'video/mp4': buffer =>
+    buffer.subarray(4, 8).equals(Buffer.from('ftyp', 'ascii')) &&
+    MP4_BRANDS.has(buffer.subarray(8, 12).toString('ascii')),
   'application/pdf': buffer =>
     buffer.subarray(0, 1024).indexOf(Buffer.from('%PDF-', 'ascii')) !== -1
 }

--- a/lib/utils/__tests__/attachment-tokens.test.ts
+++ b/lib/utils/__tests__/attachment-tokens.test.ts
@@ -4,7 +4,8 @@ import {
   BYTES_PER_TOKEN,
   estimateAttachmentTokens,
   IMAGE_ATTACHMENT_TOKENS,
-  UNKNOWN_ATTACHMENT_TOKENS
+  UNKNOWN_ATTACHMENT_TOKENS,
+  VIDEO_ATTACHMENT_TOKENS
 } from '../attachment-tokens'
 
 describe('estimateAttachmentTokens', () => {
@@ -12,6 +13,18 @@ describe('estimateAttachmentTokens', () => {
     expect(
       estimateAttachmentTokens({ mediaType: 'image/png', size: 20_000_000 })
     ).toBe(IMAGE_ATTACHMENT_TOKENS)
+  })
+
+  it('uses a fixed estimate for video, not its byte length', () => {
+    // Byte expansion would price one clip above the whole attachment budget and
+    // drop every other file replayed to the model.
+    expect(
+      estimateAttachmentTokens({ mediaType: 'video/mp4', size: 5_000_000 })
+    ).toBe(VIDEO_ATTACHMENT_TOKENS)
+  })
+
+  it('costs a clip above a single image', () => {
+    expect(VIDEO_ATTACHMENT_TOKENS).toBeGreaterThan(IMAGE_ATTACHMENT_TOKENS)
   })
 
   it('estimates known PDF sizes from their byte length', () => {

--- a/lib/utils/attachment-tokens.ts
+++ b/lib/utils/attachment-tokens.ts
@@ -1,4 +1,8 @@
 export const IMAGE_ATTACHMENT_TOKENS = 10_000
+// A clip is sampled into frames, so it costs a small multiple of a single
+// image rather than what its bytes expand into. The upload size ceiling bounds
+// how long a clip can be, which is what keeps a fixed estimate usable here.
+export const VIDEO_ATTACHMENT_TOKENS = 5 * IMAGE_ATTACHMENT_TOKENS
 export const BYTES_PER_TOKEN = 3.9
 export const UNKNOWN_ATTACHMENT_TOKENS = 50_000
 
@@ -10,8 +14,11 @@ export function estimateAttachmentTokens({
   size?: number | null
 }): number {
   // An image is tiled by the provider, so its cost does not follow its byte
-  // length. Every other document is charged for what its bytes expand into.
+  // length. A video is sampled the same way, and reading it by byte length
+  // instead would price one short clip above a whole conversation and evict
+  // every other attachment to make room for it.
   if (mediaType?.startsWith('image/')) return IMAGE_ATTACHMENT_TOKENS
+  if (mediaType?.startsWith('video/')) return VIDEO_ATTACHMENT_TOKENS
 
   if (typeof size === 'number' && Number.isFinite(size) && size >= 0) {
     return Math.ceil(size / BYTES_PER_TOKEN)


### PR DESCRIPTION
Reason: Uploaded attachments are forwarded to the selected model, but the upload path accepts only JPEG, PNG and PDF, so a clip cannot reach a model that reads video.

## Problem

Attachments become `file` parts and are handed to whichever model the chat is using, with no per-format branching on the way out. The formats that may enter, though, are fixed at the upload boundary: JPEG, PNG and PDF. A model that accepts video therefore cannot be given a clip — the file is refused before it is ever stored, so the capability is unreachable no matter which model is selected.

MP4 was not deliberately excluded. It was simply absent from the allowlist, and the content check added in #952 rejected the ISO container as a consequence.

## Changes

- `lib/storage/file-signature.ts` detects MP4 from the ISO base media `ftyp` box: the box type at bytes 4..8, then the brand at bytes 8..12 checked against the MP4-compatible brands. The brand check is what keeps the shared container from over-matching — QuickTime (`qt  `) and M4A audio ride in the same box, and accepting the box alone would move their failure from the upload to the provider request. `video/mp4` is ordered ahead of PDF because PDF is the one format matched by scanning a window rather than a fixed offset.
- `video/mp4` is added to the declared-type gate (shared with the signature module) and to the three client allowlists that guard the attachment menu, the standalone picker and the drag-and-drop zone. The 400 message that enumerates the readable formats is updated to match.
- `lib/utils/attachment-tokens.ts` estimates a clip from a frame-sampled fixed cost, the same reasoning already applied to images, instead of falling through to the byte-length branch. Byte length is the wrong model for video and not merely imprecise: a clip at the upload ceiling estimates over a million tokens, which exceeds the whole 200k attachment budget from #951 and would evict every other attachment replayed to the model, and would trip context-window truncation on the turn that carries it. The estimate is deliberately above a single image's.

The existing signature test asserted that the production ISO container is rejected; it now asserts the container is detected as video, which keeps the original regression covered — a clip named `image.jpg` is still not sent to the model as a broken image. The route test's "unsupported content" fixture was that same container, so it is replaced with bytes that open no supported format.

## Scope

The 5MB upload ceiling is unchanged, so this admits short clips rather than arbitrary video. Raising that limit is a storage and cost decision, not part of making the format reachable, and it is left alone deliberately. Attachment previews already render a non-image as a labelled chip and a link, so a clip shows up as `MP4` without new UI.

## Verification

- `bun run test` — 542 passed, 3 skipped, 61 files. New coverage: MP4 detection, the production container now detected as video, a non-MP4 brand and a truncated brand both rejected, a clip stored under its detected type across the object write and the library row, and the fixed video token estimate.
- `bun lint`, `bun typecheck`, `bun run format:check`, `bun run build` all pass.
- Detection was also exercised against the `ftyp` boxes real encoders write (`isomiso2avc1mp41`, `mp42mp41isomavc1`, `dashiso6avc1mp41`), all detected as `video/mp4`, with a QuickTime and an M4A header rejected and JPEG/PNG detection unchanged.
