### PR TITLE
feat(evals): add a related questions eval harness

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -13,7 +13,7 @@ on:
       trials:
         description: 'Generations per dataset item'
         required: false
-        default: '3'
+        default: '5'
         type: string
   pull_request:
     branches: [main]
@@ -62,7 +62,7 @@ jobs:
             --trials "${TRIALS}" \
             ${MODEL:+--model "$MODEL"}
         env:
-          TRIALS: ${{ inputs.trials || '3' }}
+          TRIALS: ${{ inputs.trials || '5' }}
           MODEL: ${{ inputs.model }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -54,8 +54,8 @@ jobs:
           # Secrets are absent on a fork and on any repo that has not
           # configured them. Failing there would put a red mark on every PR
           # touching evals for a reason the author cannot fix.
-          if [ -z "$LANGFUSE_PUBLIC_KEY" ] || [ -z "$OPENAI_API_KEY" ]; then
-            echo "::warning::Eval skipped: LANGFUSE_PUBLIC_KEY / OPENAI_API_KEY are not configured for this repository."
+          if [ -z "$LANGFUSE_PUBLIC_KEY" ] || [ -z "$LANGFUSE_SECRET_KEY" ] || [ -z "$OPENAI_API_KEY" ]; then
+            echo "::warning::Eval skipped: OPENAI_API_KEY / LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY are not all configured for this repository."
             exit 0
           fi
           bun run eval:related-questions -- \

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,64 @@
+name: Eval
+
+on:
+  schedule:
+    # 03:00 JST
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    inputs:
+      model:
+        description: 'provider:model to evaluate (default: the deployed adaptive model)'
+        required: false
+        type: string
+      trials:
+        description: 'Generations per dataset item'
+        required: false
+        default: '3'
+        type: string
+  pull_request:
+    branches: [main]
+    paths:
+      - 'config/models/cloud.json'
+      - 'lib/agents/prompts/**'
+      - 'lib/render/prompt.ts'
+      - 'evals/**'
+
+concurrency:
+  group: eval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  related-questions:
+    name: Related questions
+    runs-on: ubuntu-latest
+    # Secrets are not available to pull requests from forks, so the job would
+    # fail for reasons unrelated to the change. Keep it off the required checks.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.12
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run eval
+        run: |
+          bun run eval:related-questions -- \
+            --trials "${TRIALS}" \
+            ${MODEL:+--model "$MODEL"}
+        env:
+          TRIALS: ${{ inputs.trials || '3' }}
+          MODEL: ${{ inputs.model }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,9 +1,6 @@
 name: Eval
 
 on:
-  schedule:
-    # 03:00 JST
-    - cron: '0 18 * * *'
   workflow_dispatch:
     inputs:
       model:
@@ -15,13 +12,15 @@ on:
         required: false
         default: '5'
         type: string
+  # Only what changes model behaviour. A change to the harness itself moves no
+  # rate, and its own correctness is covered by the evaluator unit tests in the
+  # ordinary test job.
   pull_request:
     branches: [main]
     paths:
       - 'config/models/cloud.json'
       - 'lib/agents/prompts/**'
       - 'lib/render/prompt.ts'
-      - 'evals/**'
 
 concurrency:
   group: eval-${{ github.ref }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -51,6 +51,13 @@ jobs:
 
       - name: Run eval
         run: |
+          # Secrets are absent on a fork and on any repo that has not
+          # configured them. Failing there would put a red mark on every PR
+          # touching evals for a reason the author cannot fix.
+          if [ -z "$LANGFUSE_PUBLIC_KEY" ] || [ -z "$OPENAI_API_KEY" ]; then
+            echo "::warning::Eval skipped: LANGFUSE_PUBLIC_KEY / OPENAI_API_KEY are not configured for this repository."
+            exit 0
+          fi
           bun run eval:related-questions -- \
             --trials "${TRIALS}" \
             ${MODEL:+--model "$MODEL"}

--- a/evals/README.md
+++ b/evals/README.md
@@ -72,6 +72,12 @@ than defects. Questions whose answers expand belong in the substantive set.
 `thresholds.json` gates CI. A `null` value means the metric is reported but not
 enforced, which is the state a new metric starts in.
 
+`minSamples` is the smallest denominator a threshold may be enforced on. At the
+default of one trial the trivial set is only twelve generations, where two
+stochastic emissions already cross a tight ceiling; such a run reports its rates
+and does not fail. `completionRate` declares no minimum because it counts items
+that actually failed rather than sampling a probability.
+
 `completionRate` guards the measurement itself: the experiment runner drops an
 item whose task threw, which shrinks the denominator of every other rate. A run
 that lost more than a tenth of its items is not a valid measurement.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,125 @@
+# Evals
+
+Measured checks on model behaviour, kept separate from `__tests__` because they
+call real models, cost money, and produce rates rather than pass/fail.
+
+## Layers
+
+| Layer                | Where                 | Runs                                         | Needs keys |
+| -------------------- | --------------------- | -------------------------------------------- | ---------- |
+| Evaluator unit tests | `evals/lib/__tests__` | every PR, via `bun run test`                 | no         |
+| Experiments          | `evals/run-*.ts`      | nightly, manual, and on prompt/model changes | yes        |
+
+The first layer exists because an evaluator is code too. `analyzeRelatedQuestions`
+is tested against recorded spec blocks so a broken evaluator cannot quietly
+report a healthy rate. Those tests are part of the normal suite and run on fork
+PRs, where secrets are unavailable.
+
+## related-questions
+
+```bash
+bun run eval:related-questions                              # deployed adaptive model, 1 trial per item
+bun run eval:related-questions -- --trials 3                # 3 generations per item
+bun run eval:related-questions -- --model openai:some-model # candidate model
+bun run eval:related-questions -- --items fuji-routes       # one item, for debugging
+bun run eval:related-questions -- --help
+```
+
+Answers 22 fixed queries (10 substantive, 12 trivial) against pinned search
+results and reports:
+
+- `emissionRate`: substantive answers that carried a related questions block
+- `falsePositiveRate`: trivial answers that carried one anyway
+- `wellFormedRate`: emitted blocks that satisfy the spec contract (one block,
+  three buttons, `submitQuery`, button text identical to the query)
+
+Emission and well-formedness are separate metrics on purpose. A model that stops
+emitting and a model that emits a broken block are different failures with
+different fixes.
+
+### Why it is built this way
+
+- **Search results are fixed.** Live search would put retrieval variance into a
+  measurement about the prompt and the model.
+- **The task mirrors production.** Same prompt builder, same `providerOptions`
+  from `config/models/cloud.json`, same `toModelOutput` trimming. Reasoning
+  effort has moved emission rates before, so a run without provider options
+  would measure something the product does not do.
+- **`BRAVE_SEARCH_API_KEY` is pinned by the runner.** The adaptive prompt
+  branches on whether a general search provider is configured, so an unset key
+  would silently evaluate a different prompt. No request reaches Brave; the
+  search tool is a fixture.
+- **Each trial is its own item.** Emission is probabilistic, so one generation
+  per query measures almost nothing. `--trials` repeats each query while keeping
+  one item equal to one generation in Langfuse.
+
+### What counts as trivial
+
+An item is `trivial` only when the fixture holds exactly one unambiguous value
+answering it and no comparison or procedure is implied. "How tall is Mount
+Fuji" qualifies. "What is the typical energy density of an LFP pack" does not,
+because the fixture puts LFP and NMC side by side and the answer naturally
+becomes a comparison.
+
+The distinction matters because the label is set by the shape of the question
+while the model decides by the shape of its own answer. A loosely trivial
+question draws out a structured answer, and the block that follows it is
+arguably correct, which inflates `falsePositiveRate` with disagreement rather
+than defects. Questions whose answers expand belong in the substantive set.
+
+## Thresholds
+
+`thresholds.json` gates CI. A `null` value means the metric is reported but not
+enforced, which is the state a new metric starts in.
+
+`completionRate` guards the measurement itself: the experiment runner drops an
+item whose task threw, which shrinks the denominator of every other rate. A run
+that lost more than a tenth of its items is not a valid measurement.
+
+Rates are read at the run level, never per item. At three trials an individual
+query swings by a third from one run to the next, so a single query moving is
+noise; raise `--trials` before drawing a conclusion about one of them.
+
+**Set a baseline before enforcing anything.** Run the eval a few times on the
+current production model, then commit the numbers. Committing them rather than
+comparing against the previous Langfuse run is deliberate: a threshold that gets
+loosened should appear in a diff with an author and a reason.
+
+A violation throws `RegressionError`, which the Langfuse experiment GitHub
+Action reads to fail the job.
+
+## Datasets
+
+`evals/datasets/*.json` holds hand-written, synthetic data. It is committed, so
+a prompt change and the data it is measured against show up in the same review.
+
+Anything derived from production traces (thumbs-down turns, errored turns) must
+**not** be committed here. This repository is public. Put that data in a Langfuse
+managed dataset and fetch it at run time:
+
+```ts
+const dataset = await langfuse.dataset.get('morphic-thumbs-down-regression')
+```
+
+`experiment.run` accepts local items and Langfuse dataset items interchangeably,
+so the task and the evaluators do not change when the source does.
+
+## Credentials
+
+`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, plus the API
+key for the provider under test. The runner loads `.env.local`.
+
+Keys are required: the experiment runner uploads item scores through the
+Langfuse client whether or not spans are exported, so a keyless run fails
+partway rather than degrading to a local-only run.
+
+Experiment traces are tagged by the SDK with the `sdk-experiment` environment,
+so they can be excluded from production metrics without a separate project.
+
+## Known quirk
+
+When items are skipped, the `Input` and `Expected` lines in the printed item
+list are misaligned: the Langfuse formatter pairs `itemResults[i]` with
+`originalData[i]` after the failed entries have been filtered out. The scores,
+the outputs, and the trace links are unaffected, because each result carries its
+own item. The runner prints a warning whenever this applies.

--- a/evals/README.md
+++ b/evals/README.md
@@ -111,7 +111,9 @@ key for the provider under test. The runner loads `.env.local`.
 
 Keys are required: the experiment runner uploads item scores through the
 Langfuse client whether or not spans are exported, so a keyless run fails
-partway rather than degrading to a local-only run.
+partway rather than degrading to a local-only run. The CI job skips itself with
+a warning when they are absent, so a repository without them does not collect a
+red mark on every PR that touches `evals/`.
 
 Experiment traces are tagged by the SDK with the `sdk-experiment` environment,
 so they can be excluded from production metrics without a separate project.

--- a/evals/README.md
+++ b/evals/README.md
@@ -85,7 +85,10 @@ that lost more than a tenth of its items is not a valid measurement.
 
 Rates are read at the run level, never per item. At three trials an individual
 query swings by a third from one run to the next, so a single query moving is
-noise; raise `--trials` before drawing a conclusion about one of them.
+noise; raise `--trials` before drawing a conclusion about one of them. Whole
+runs move too: the same code measured 0.28 and 0.36 on `falsePositiveRate` in
+consecutive runs, which is why CI runs five trials and why a before/after
+comparison needs more than one run on each side.
 
 **Set a baseline before enforcing anything.** Run the eval a few times on the
 current production model, then commit the numbers. Committing them rather than

--- a/evals/README.md
+++ b/evals/README.md
@@ -5,10 +5,10 @@ call real models, cost money, and produce rates rather than pass/fail.
 
 ## Layers
 
-| Layer                | Where                 | Runs                                         | Needs keys |
-| -------------------- | --------------------- | -------------------------------------------- | ---------- |
-| Evaluator unit tests | `evals/lib/__tests__` | every PR, via `bun run test`                 | no         |
-| Experiments          | `evals/run-*.ts`      | nightly, manual, and on prompt/model changes | yes        |
+| Layer                | Where                 | Runs                                       | Needs keys |
+| -------------------- | --------------------- | ------------------------------------------ | ---------- |
+| Evaluator unit tests | `evals/lib/__tests__` | every PR, via `bun run test`               | no         |
+| Experiments          | `evals/run-*.ts`      | on prompt and model changes, and on demand | yes        |
 
 The first layer exists because an evaluator is code too. `analyzeRelatedQuestions`
 is tested against recorded spec blocks so a broken evaluator cannot quietly
@@ -73,7 +73,7 @@ than defects. Questions whose answers expand belong in the substantive set.
 enforced, which is the state a new metric starts in.
 
 `minSamples` is the smallest denominator a threshold may be enforced on, and the
-sampled rates set it at 50, which the nightly five trials reach and a local run
+sampled rates set it at 50, which the five trials CI runs reach and a local run
 does not. That is not caution for its own sake: identical code measured 1.000
 and 0.833 on `emissionRate` across two runs of thirty substantive samples, so a
 three-trial run cannot carry a ceiling or a floor. `completionRate` declares no minimum because it counts items
@@ -97,6 +97,14 @@ loosened should appear in a diff with an author and a reason.
 
 A violation throws `RegressionError`, which the Langfuse experiment GitHub
 Action reads to fail the job.
+
+Be honest about what a single gated run proves. `emissionRate` separates
+cleanly: the failure it exists to catch is a model swap that empties the block
+entirely, and fifty samples settle that. `falsePositiveRate` does not. Sampled
+three times before the trivial-skip fix it read 0.200, 0.278 and 0.361, and
+twice after it read 0.083 and 0.111, so the distributions overlap at the tails
+and no ceiling separates them on one run. That gate catches a blowup. Deciding
+that a change moved the metric still takes several runs on each side.
 
 ## Datasets
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -72,10 +72,11 @@ than defects. Questions whose answers expand belong in the substantive set.
 `thresholds.json` gates CI. A `null` value means the metric is reported but not
 enforced, which is the state a new metric starts in.
 
-`minSamples` is the smallest denominator a threshold may be enforced on. At the
-default of one trial the trivial set is only twelve generations, where two
-stochastic emissions already cross a tight ceiling; such a run reports its rates
-and does not fail. `completionRate` declares no minimum because it counts items
+`minSamples` is the smallest denominator a threshold may be enforced on, and the
+sampled rates set it at 50, which the nightly five trials reach and a local run
+does not. That is not caution for its own sake: identical code measured 1.000
+and 0.833 on `emissionRate` across two runs of thirty substantive samples, so a
+three-trial run cannot carry a ceiling or a floor. `completionRate` declares no minimum because it counts items
 that actually failed rather than sampling a probability.
 
 `completionRate` guards the measurement itself: the experiment runner drops an

--- a/evals/datasets/related-questions.json
+++ b/evals/datasets/related-questions.json
@@ -1,0 +1,182 @@
+{
+  "name": "related-questions",
+  "description": "Does the adaptive answer emit a well-formed related questions spec block on substantive answers, and skip it on trivial lookups? Search results are fixed so the measurement isolates the prompt and the model. An item is trivial only when the fixture holds exactly one unambiguous value answering it and no comparison or procedure is implied; a question whose answer naturally expands belongs in the substantive set, not the trivial one.",
+  "fixtures": {
+    "mount-fuji": [
+      {
+        "title": "Mount Fuji climbing routes",
+        "url": "https://example.com/mount-fuji-routes",
+        "content": "Mount Fuji stands 3,776 metres (12,389 ft) tall, making it the highest mountain in Japan. It has four main climbing routes. Yoshida is the most popular and has the most huts and first-aid stations. Fujinomiya is the shortest but steepest, and starts from the highest trailhead. Subashiri begins below the tree line and joins Yoshida near the summit. Gotemba is the longest and least crowded, with no huts until high on the mountain. The official climbing season runs from early July to early September. Outside the season the huts close, weather on the upper slopes is severe, and mountain rescue coverage is limited."
+      }
+    ],
+    "ev-batteries": [
+      {
+        "title": "LFP and NMC battery chemistries compared",
+        "url": "https://example.com/lfp-vs-nmc",
+        "content": "Lithium iron phosphate (LFP) cells reach roughly 160 Wh/kg at the pack level, while nickel manganese cobalt (NMC) cells reach roughly 250 Wh/kg. LFP uses no cobalt or nickel, which makes it cheaper and less exposed to supply shocks. LFP cycle life is typically 3,000 to 5,000 cycles against 1,000 to 2,000 for NMC, and LFP tolerates repeated charging to 100 percent. LFP has a higher thermal runaway threshold and is considered the safer chemistry. Its weaknesses are cold-weather performance, where usable capacity can drop sharply below freezing, and a flat voltage curve that makes state-of-charge estimation harder. Automakers have moved standard-range trims to LFP while keeping NMC for long-range and performance trims."
+      }
+    ],
+    "postgres-indexes": [
+      {
+        "title": "Choosing a Postgres index type",
+        "url": "https://example.com/postgres-index-types",
+        "content": "B-tree is the default index type in Postgres and handles equality and range queries on ordered data. GIN indexes are designed for composite values where a single row contains many keys, such as jsonb documents, arrays, and full-text search vectors; the jsonb_path_ops operator class produces a smaller GIN index that supports containment queries only. GiST supports geometric and nearest-neighbour queries. BRIN stores per-block-range summaries rather than per-row entries, so it is tiny and fast to build, but it only helps when the physical row order correlates with the indexed column, which is typical for append-only time-series tables. Every index adds write amplification on insert and update, and partial indexes with a WHERE clause reduce that cost when queries only touch a subset of rows."
+      }
+    ],
+    "sleep": [
+      {
+        "title": "Evidence on sleep quality and evening routines",
+        "url": "https://example.com/sleep-evidence",
+        "content": "Adults need 7 to 9 hours of sleep per night. Sleep proceeds in cycles of roughly 90 minutes alternating between NREM and REM stages, with deep NREM concentrated in the first half of the night and REM in the second. Caffeine has a half-life of about 5 to 6 hours, so an afternoon dose still has meaningful blood levels at bedtime. Evening light exposure, particularly in the blue part of the spectrum, suppresses melatonin release and delays sleep onset. The most consistently supported intervention is a fixed wake time, because it anchors the circadian phase more reliably than a fixed bedtime. Alcohol shortens sleep onset but fragments the second half of the night and suppresses REM."
+      }
+    ],
+    "coffee": [
+      {
+        "title": "Brewing methods and extraction",
+        "url": "https://example.com/coffee-brewing",
+        "content": "Pour-over uses a medium-fine grind and a 1:15 to 1:17 coffee-to-water ratio, producing a clean cup that highlights acidity, and takes about three minutes of active attention. Espresso uses a fine grind and roughly 9 bars of pressure to pull a 25 to 30 second shot, requiring a grinder that holds its setting and regular dialling in. French press uses a coarse grind and a four-minute steep, needs no filter papers, and produces a heavier body because oils and fines pass into the cup. Recommended brew water temperature is 92 to 96 degrees Celsius across methods. Under-extraction tastes sour and thin; over-extraction tastes bitter and drying."
+      }
+    ],
+    "hybrid-work": [
+      {
+        "title": "Research on hybrid work and productivity",
+        "url": "https://example.com/hybrid-work-research",
+        "content": "A randomised trial at a large travel agency found hybrid workers matched or slightly exceeded office productivity while attrition fell by about a third. Most published hybrid policies require two to three days per week in the office. Studies consistently find that coordination costs rise when in-office days are not aligned across a team, which is why anchor days outperform per-person choice. The clearest negative finding concerns junior employees: onboarding and skill transfer depend on incidental observation and unplanned feedback, and remote-first onboarding measurably slows time to competence. Fully remote arrangements show the widest variance in outcomes, with results depending heavily on written communication norms."
+      }
+    ]
+  },
+  "items": [
+    {
+      "id": "fuji-routes",
+      "category": "substantive",
+      "fixture": "mount-fuji",
+      "query": "Compare the main Mount Fuji climbing routes and recommend who each route suits."
+    },
+    {
+      "id": "fuji-offseason",
+      "category": "substantive",
+      "fixture": "mount-fuji",
+      "query": "What are the risks of climbing Mount Fuji outside the official season?"
+    },
+    {
+      "id": "ev-chemistry-compare",
+      "category": "substantive",
+      "fixture": "ev-batteries",
+      "query": "Compare LFP and NMC battery chemistries and explain which suits which kind of car."
+    },
+    {
+      "id": "ev-lfp-shift",
+      "category": "substantive",
+      "fixture": "ev-batteries",
+      "query": "Why are automakers shifting to LFP despite its lower energy density?"
+    },
+    {
+      "id": "pg-jsonb-index",
+      "category": "substantive",
+      "fixture": "postgres-indexes",
+      "query": "Which Postgres index should I use for a jsonb column I filter on, and what are the tradeoffs?"
+    },
+    {
+      "id": "pg-brin",
+      "category": "substantive",
+      "fixture": "postgres-indexes",
+      "query": "When does a BRIN index beat a B-tree index in Postgres?"
+    },
+    {
+      "id": "sleep-routine",
+      "category": "substantive",
+      "fixture": "sleep",
+      "query": "How should I restructure my evening routine to sleep better, and what does the evidence support?"
+    },
+    {
+      "id": "coffee-method",
+      "category": "substantive",
+      "fixture": "coffee",
+      "query": "Compare pour-over, espresso and French press, and recommend one for low-effort weekday coffee."
+    },
+    {
+      "id": "hybrid-policy",
+      "category": "substantive",
+      "fixture": "hybrid-work",
+      "query": "What does the research say about hybrid work productivity, and what should a 50-person company do?"
+    },
+    {
+      "id": "hybrid-juniors",
+      "category": "substantive",
+      "fixture": "hybrid-work",
+      "query": "How does remote work affect onboarding for junior employees?"
+    },
+    {
+      "id": "fuji-height",
+      "category": "trivial",
+      "fixture": "mount-fuji",
+      "query": "How tall is Mount Fuji?"
+    },
+    {
+      "id": "pg-default-index",
+      "category": "trivial",
+      "fixture": "postgres-indexes",
+      "query": "What is the default index type in Postgres?"
+    },
+    {
+      "id": "sleep-hours",
+      "category": "trivial",
+      "fixture": "sleep",
+      "query": "How many hours of sleep do adults need?"
+    },
+    {
+      "id": "caffeine-half-life",
+      "category": "trivial",
+      "fixture": "sleep",
+      "query": "What is the half-life of caffeine?"
+    },
+    {
+      "id": "coffee-temperature",
+      "category": "trivial",
+      "fixture": "coffee",
+      "query": "What water temperature is recommended for brewing coffee?"
+    },
+    {
+      "id": "fuji-route-count",
+      "category": "trivial",
+      "fixture": "mount-fuji",
+      "query": "How many main climbing routes does Mount Fuji have?"
+    },
+    {
+      "id": "fuji-season-start",
+      "category": "trivial",
+      "fixture": "mount-fuji",
+      "query": "When does the official Mount Fuji climbing season start?"
+    },
+    {
+      "id": "ev-cobalt",
+      "category": "trivial",
+      "fixture": "ev-batteries",
+      "query": "Does LFP use cobalt?"
+    },
+    {
+      "id": "pg-fulltext-index",
+      "category": "trivial",
+      "fixture": "postgres-indexes",
+      "query": "Which Postgres index type is used for full-text search vectors?"
+    },
+    {
+      "id": "sleep-cycle-length",
+      "category": "trivial",
+      "fixture": "sleep",
+      "query": "How long is a typical sleep cycle?"
+    },
+    {
+      "id": "coffee-press-steep",
+      "category": "trivial",
+      "fixture": "coffee",
+      "query": "How long does a French press steep?"
+    },
+    {
+      "id": "hybrid-attrition",
+      "category": "trivial",
+      "fixture": "hybrid-work",
+      "query": "By how much did attrition fall in the travel agency trial?"
+    }
+  ]
+}

--- a/evals/evaluators/related-questions.ts
+++ b/evals/evaluators/related-questions.ts
@@ -20,6 +20,8 @@ type Category = RelatedQuestionsMetadata['category']
 export type RelatedQuestionsSummary = {
   substantiveCount: number
   trivialCount: number
+  /** Answers that carried a related block, the denominator of wellFormedRate. */
+  emittedCount: number
   /** Share of substantive answers that carried a related block. */
   emissionRate: number
   /** Share of trivial answers that carried one anyway. */
@@ -127,6 +129,7 @@ export function summarizeRelatedQuestions(
   return {
     substantiveCount,
     trivialCount,
+    emittedCount: emittedTotal,
     emissionRate: substantiveCount === 0 ? 0 : emitted / substantiveCount,
     falsePositiveRate: trivialCount === 0 ? 0 : falsePositives / trivialCount,
     wellFormedRate: emittedTotal === 0 ? 0 : wellFormed / emittedTotal

--- a/evals/evaluators/related-questions.ts
+++ b/evals/evaluators/related-questions.ts
@@ -1,0 +1,162 @@
+import type { Evaluation, Evaluator, RunEvaluator } from '@langfuse/client'
+
+import type {
+  RelatedQuestionsExpected,
+  RelatedQuestionsInput,
+  RelatedQuestionsMetadata
+} from '../lib/dataset'
+import { analyzeRelatedQuestions } from '../lib/related-questions'
+
+// Mirrors the SDK's item result loosely: for a Langfuse dataset the metadata
+// arrives as `unknown`, so the category is narrowed at read time.
+type ItemResult = {
+  output?: unknown
+  metadata?: unknown
+  item?: { metadata?: unknown }
+}
+
+type Category = RelatedQuestionsMetadata['category']
+
+export type RelatedQuestionsSummary = {
+  substantiveCount: number
+  trivialCount: number
+  /** Share of substantive answers that carried a related block. */
+  emissionRate: number
+  /** Share of trivial answers that carried one anyway. */
+  falsePositiveRate: number
+  /** Share of emitted blocks that satisfy the spec contract. */
+  wellFormedRate: number
+}
+
+function answerText(output: unknown): string {
+  if (typeof output === 'string') return output
+  if (output && typeof output === 'object' && 'text' in output) {
+    const text = (output as { text?: unknown }).text
+    if (typeof text === 'string') return text
+  }
+  return ''
+}
+
+function itemCategory(result: ItemResult): Category | undefined {
+  const metadata = (result.metadata ?? result.item?.metadata) as
+    | { category?: unknown }
+    | undefined
+  const category = metadata?.category
+  return category === 'substantive' || category === 'trivial'
+    ? category
+    : undefined
+}
+
+/**
+ * Score one answer.
+ *
+ * Emission and well-formedness are reported separately. A model that stopped
+ * emitting and a model that emits a broken block need different fixes, and a
+ * single "correct" score would not say which happened.
+ */
+export const relatedQuestionsEvaluator: Evaluator<
+  RelatedQuestionsInput,
+  RelatedQuestionsExpected,
+  RelatedQuestionsMetadata
+> = async ({ output, expectedOutput }) => {
+  const analysis = analyzeRelatedQuestions(answerText(output))
+  const expected = expectedOutput?.emitsRelated ?? true
+
+  const evaluations: Evaluation[] = [
+    {
+      name: 'related_questions_emitted',
+      value: analysis.emitted ? 1 : 0,
+      dataType: 'BOOLEAN',
+      comment: analysis.emitted
+        ? `${analysis.questions.length} question(s)`
+        : 'no related block'
+    },
+    {
+      name: 'related_questions_matches_expectation',
+      value: analysis.emitted === expected ? 1 : 0,
+      dataType: 'BOOLEAN',
+      comment: `expected ${expected ? 'a block' : 'no block'}, got ${
+        analysis.emitted ? 'a block' : 'none'
+      }`
+    }
+  ]
+
+  // Well-formedness is undefined when nothing was emitted. Scoring it 0 there
+  // would double-count the emission failure and drag the rate down for a
+  // reason that has nothing to do with formatting.
+  if (analysis.emitted) {
+    evaluations.push({
+      name: 'related_questions_wellformed',
+      value: analysis.wellFormed ? 1 : 0,
+      dataType: 'BOOLEAN',
+      comment: analysis.wellFormed ? 'ok' : analysis.issues.join('; ')
+    })
+  }
+
+  return evaluations
+}
+
+export function summarizeRelatedQuestions(
+  itemResults: ItemResult[]
+): RelatedQuestionsSummary {
+  let substantiveCount = 0
+  let trivialCount = 0
+  let emitted = 0
+  let falsePositives = 0
+  let emittedTotal = 0
+  let wellFormed = 0
+
+  for (const result of itemResults) {
+    const analysis = analyzeRelatedQuestions(answerText(result.output))
+    const category = itemCategory(result)
+
+    if (analysis.emitted) {
+      emittedTotal++
+      if (analysis.wellFormed) wellFormed++
+    }
+
+    if (category === 'substantive') {
+      substantiveCount++
+      if (analysis.emitted) emitted++
+    } else if (category === 'trivial') {
+      trivialCount++
+      if (analysis.emitted) falsePositives++
+    }
+  }
+
+  return {
+    substantiveCount,
+    trivialCount,
+    emissionRate: substantiveCount === 0 ? 0 : emitted / substantiveCount,
+    falsePositiveRate: trivialCount === 0 ? 0 : falsePositives / trivialCount,
+    wellFormedRate: emittedTotal === 0 ? 0 : wellFormed / emittedTotal
+  }
+}
+
+export const relatedQuestionsRunEvaluator: RunEvaluator<
+  RelatedQuestionsInput,
+  RelatedQuestionsExpected,
+  RelatedQuestionsMetadata
+> = async ({ itemResults }) => {
+  const summary = summarizeRelatedQuestions(itemResults as ItemResult[])
+
+  return [
+    {
+      name: 'emission_rate',
+      value: summary.emissionRate,
+      dataType: 'NUMERIC',
+      comment: `substantive items: ${summary.substantiveCount}`
+    },
+    {
+      name: 'false_positive_rate',
+      value: summary.falsePositiveRate,
+      dataType: 'NUMERIC',
+      comment: `trivial items: ${summary.trivialCount}`
+    },
+    {
+      name: 'wellformed_rate',
+      value: summary.wellFormedRate,
+      dataType: 'NUMERIC'
+    }
+  ]
+}

--- a/evals/lib/__tests__/gate.test.ts
+++ b/evals/lib/__tests__/gate.test.ts
@@ -1,0 +1,49 @@
+import { RegressionError } from '@langfuse/client'
+import { describe, expect, test } from 'vitest'
+
+import { applyGate, type GateCheck } from '../gate'
+
+const result = {} as Parameters<typeof applyGate>[0]
+
+function check(overrides: Partial<GateCheck> = {}): GateCheck {
+  return {
+    metric: 'falsePositiveRate',
+    value: 0.167,
+    samples: 12,
+    threshold: { direction: 'max', value: 0.15, minSamples: 30 },
+    ...overrides
+  }
+}
+
+describe('applyGate', () => {
+  test('does not enforce a threshold below its minimum sample size', () => {
+    expect(() => applyGate(result, [check()])).not.toThrow()
+  })
+
+  test('enforces the same threshold once the sample is large enough', () => {
+    expect(() => applyGate(result, [check({ samples: 36 })])).toThrow(
+      RegressionError
+    )
+  })
+
+  test('enforces a threshold that declares no minimum', () => {
+    expect(() =>
+      applyGate(result, [
+        check({
+          metric: 'completionRate',
+          value: 0.8,
+          samples: 5,
+          threshold: { direction: 'min', value: 0.9 }
+        })
+      ])
+    ).toThrow(RegressionError)
+  })
+
+  test('ignores a metric with no threshold', () => {
+    expect(() =>
+      applyGate(result, [
+        check({ threshold: { direction: 'max', value: null, minSamples: 30 } })
+      ])
+    ).not.toThrow()
+  })
+})

--- a/evals/lib/__tests__/related-questions.test.ts
+++ b/evals/lib/__tests__/related-questions.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'vitest'
+
+import { analyzeRelatedQuestions } from '../related-questions'
+
+function relatedBlock(
+  questions: Array<{ text: string; query?: string; action?: string }>
+): string {
+  const ids = questions.map((_, index) => `q${index + 1}`)
+  const lines = [
+    '{"op":"add","path":"/root","value":"main"}',
+    `{"op":"add","path":"/elements/main","value":{"type":"Stack","props":{"direction":"vertical","gap":"sm"},"children":["header","questions"]}}`,
+    '{"op":"add","path":"/elements/header","value":{"type":"Heading","props":{"title":"Related","icon":"related"},"children":[]}}',
+    `{"op":"add","path":"/elements/questions","value":{"type":"Stack","props":{"direction":"vertical","gap":"xs"},"children":${JSON.stringify(ids)}}}`,
+    ...questions.map((question, index) => {
+      const value = {
+        type: 'Button',
+        props: {
+          text: question.text,
+          variant: 'link',
+          icon: 'arrow-right'
+        },
+        on: {
+          press: {
+            action: question.action ?? 'submitQuery',
+            params: { query: question.query ?? question.text }
+          }
+        },
+        children: []
+      }
+      return `{"op":"add","path":"/elements/${ids[index]}","value":${JSON.stringify(value)}}`
+    })
+  ]
+
+  return ['```spec', ...lines, '```'].join('\n')
+}
+
+const THREE_QUESTIONS = [
+  { text: 'Which Fuji route suits a first-time climber?' },
+  { text: 'How do hut reservations work in peak season?' },
+  { text: 'What gear is required above the 8th station?' }
+]
+
+const ANSWER = 'Mount Fuji has four main climbing routes.\n\n'
+
+describe('analyzeRelatedQuestions', () => {
+  test('accepts a well-formed block', () => {
+    const result = analyzeRelatedQuestions(
+      ANSWER + relatedBlock(THREE_QUESTIONS)
+    )
+
+    expect(result.emitted).toBe(true)
+    expect(result.wellFormed).toBe(true)
+    expect(result.issues).toEqual([])
+    expect(result.questions).toHaveLength(3)
+  })
+
+  test('reports no emission for a plain answer', () => {
+    const result = analyzeRelatedQuestions(ANSWER)
+
+    expect(result.emitted).toBe(false)
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toEqual([])
+  })
+
+  test('flags a wrong question count', () => {
+    const result = analyzeRelatedQuestions(
+      ANSWER + relatedBlock(THREE_QUESTIONS.slice(0, 2))
+    )
+
+    expect(result.emitted).toBe(true)
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toContain('2 buttons (expected 3)')
+  })
+
+  test('flags a query that does not match the button text', () => {
+    const result = analyzeRelatedQuestions(
+      ANSWER +
+        relatedBlock([
+          THREE_QUESTIONS[0],
+          THREE_QUESTIONS[1],
+          { text: 'What gear is required?', query: 'something else entirely' }
+        ])
+    )
+
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toContain('button 3: query does not match text')
+  })
+
+  test('flags a non-submitQuery action', () => {
+    const result = analyzeRelatedQuestions(
+      ANSWER +
+        relatedBlock([
+          THREE_QUESTIONS[0],
+          THREE_QUESTIONS[1],
+          { text: 'What gear is required?', action: 'openUrl' }
+        ])
+    )
+
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toContain('button 3: action is openUrl')
+  })
+
+  test('flags duplicate questions', () => {
+    const result = analyzeRelatedQuestions(
+      ANSWER +
+        relatedBlock([
+          THREE_QUESTIONS[0],
+          THREE_QUESTIONS[0],
+          THREE_QUESTIONS[1]
+        ])
+    )
+
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toContain('duplicate questions')
+  })
+
+  test('ignores an image spec block', () => {
+    const imageBlock = [
+      '```spec',
+      '{"op":"add","path":"/root","value":"grid"}',
+      '{"op":"add","path":"/elements/grid","value":{"type":"Grid","props":{"columns":2,"gap":"sm"},"children":["img1"]}}',
+      '{"op":"add","path":"/elements/img1","value":{"type":"Image","props":{"src":"https://example.com/a.jpg","sourceUrl":"https://example.com","title":"Fuji","aspectRatio":"4:3"},"children":[]}}',
+      '```'
+    ].join('\n')
+
+    const result = analyzeRelatedQuestions(
+      `${ANSWER}${imageBlock}\n\n${relatedBlock(THREE_QUESTIONS)}`
+    )
+
+    expect(result.emitted).toBe(true)
+    expect(result.wellFormed).toBe(true)
+  })
+})

--- a/evals/lib/__tests__/related-questions.test.ts
+++ b/evals/lib/__tests__/related-questions.test.ts
@@ -163,6 +163,49 @@ describe('analyzeRelatedQuestions', () => {
     expect(result.wellFormed).toBe(true)
   })
 
+  test('flags a Related heading that is not the first child', () => {
+    const reordered = [
+      '```spec',
+      '{"op":"add","path":"/root","value":"main"}',
+      '{"op":"add","path":"/elements/main","value":{"type":"Stack","props":{"direction":"vertical","gap":"sm"},"children":["questions","header"]}}',
+      '{"op":"add","path":"/elements/header","value":{"type":"Heading","props":{"title":"Related","icon":"related"},"children":[]}}',
+      '{"op":"add","path":"/elements/questions","value":{"type":"Stack","props":{"direction":"vertical","gap":"xs"},"children":["q1","q2","q3"]}}',
+      ...THREE_QUESTIONS.map(
+        (question, index) =>
+          `{"op":"add","path":"/elements/q${index + 1}","value":{"type":"Button","props":{"text":${JSON.stringify(question.text)},"variant":"link"},"on":{"press":{"action":"submitQuery","params":{"query":${JSON.stringify(question.text)}}}},"children":[]}}`
+      ),
+      '```'
+    ].join('\n')
+
+    const result = analyzeRelatedQuestions(ANSWER + reordered)
+
+    expect(result.emitted).toBe(true)
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toContain(
+      'the Related heading is not the first child of the root'
+    )
+  })
+
+  test('ignores a button that nothing renders', () => {
+    const orphaned = [
+      '```spec',
+      '{"op":"add","path":"/root","value":"main"}',
+      '{"op":"add","path":"/elements/main","value":{"type":"Stack","props":{"direction":"vertical","gap":"sm"},"children":["header","questions"]}}',
+      '{"op":"add","path":"/elements/header","value":{"type":"Heading","props":{"title":"Related","icon":"related"},"children":[]}}',
+      '{"op":"add","path":"/elements/questions","value":{"type":"Stack","props":{"direction":"vertical","gap":"xs"},"children":["q1","q2"]}}',
+      ...THREE_QUESTIONS.map(
+        (question, index) =>
+          `{"op":"add","path":"/elements/q${index + 1}","value":{"type":"Button","props":{"text":${JSON.stringify(question.text)},"variant":"link"},"on":{"press":{"action":"submitQuery","params":{"query":${JSON.stringify(question.text)}}}},"children":[]}}`
+      ),
+      '```'
+    ].join('\n')
+
+    const result = analyzeRelatedQuestions(ANSWER + orphaned)
+
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toContain('2 buttons (expected 3)')
+  })
+
   test('ignores an image spec block', () => {
     const imageBlock = [
       '```spec',

--- a/evals/lib/__tests__/related-questions.test.ts
+++ b/evals/lib/__tests__/related-questions.test.ts
@@ -143,6 +143,26 @@ describe('analyzeRelatedQuestions', () => {
     expect(result.issues).toContain('1 related block(s) failed to compile')
   })
 
+  test('flags content that follows the related block', () => {
+    const result = analyzeRelatedQuestions(
+      `${ANSWER}${relatedBlock(THREE_QUESTIONS)}\n\nOne more thought.`
+    )
+
+    expect(result.emitted).toBe(true)
+    expect(result.wellFormed).toBe(false)
+    expect(
+      result.issues.some(issue => issue.includes('follow the related block'))
+    ).toBe(true)
+  })
+
+  test('allows trailing whitespace after the related block', () => {
+    const result = analyzeRelatedQuestions(
+      `${ANSWER}${relatedBlock(THREE_QUESTIONS)}\n\n  \n`
+    )
+
+    expect(result.wellFormed).toBe(true)
+  })
+
   test('ignores an image spec block', () => {
     const imageBlock = [
       '```spec',

--- a/evals/lib/__tests__/related-questions.test.ts
+++ b/evals/lib/__tests__/related-questions.test.ts
@@ -114,6 +114,35 @@ describe('analyzeRelatedQuestions', () => {
     expect(result.issues).toContain('duplicate questions')
   })
 
+  test('does not count a malformed image block as an emission', () => {
+    const brokenImage = [
+      '```spec',
+      '{"op":"add","path":"/root","value":"grid"}',
+      '{"op":"add","path":"/elements/grid","value":{"type":"Grid","props":{"columns":2',
+      '```'
+    ].join('\n')
+
+    const result = analyzeRelatedQuestions(ANSWER + brokenImage)
+
+    expect(result.emitted).toBe(false)
+    expect(result.issues).toEqual([])
+  })
+
+  test('counts a malformed related block as a broken emission', () => {
+    const brokenRelated = [
+      '```spec',
+      '{"op":"add","path":"/root","value":"main"}',
+      '{"op":"add","path":"/elements/header","value":{"type":"Heading","props":{"title":"Related"',
+      '```'
+    ].join('\n')
+
+    const result = analyzeRelatedQuestions(ANSWER + brokenRelated)
+
+    expect(result.emitted).toBe(true)
+    expect(result.wellFormed).toBe(false)
+    expect(result.issues).toContain('1 related block(s) failed to compile')
+  })
+
   test('ignores an image spec block', () => {
     const imageBlock = [
       '```spec',

--- a/evals/lib/dataset.ts
+++ b/evals/lib/dataset.ts
@@ -1,0 +1,91 @@
+import datasetJson from '../datasets/related-questions.json'
+
+export type SearchFixture = {
+  title: string
+  url: string
+  content: string
+}
+
+export type RelatedQuestionsInput = {
+  query: string
+  results: SearchFixture[]
+}
+
+export type RelatedQuestionsExpected = {
+  emitsRelated: boolean
+}
+
+export type RelatedQuestionsMetadata = {
+  itemId: string
+  category: 'substantive' | 'trivial'
+  trial: number
+}
+
+export type RelatedQuestionsItem = {
+  input: RelatedQuestionsInput
+  expectedOutput: RelatedQuestionsExpected
+  metadata: RelatedQuestionsMetadata
+}
+
+type RawItem = {
+  id: string
+  category: string
+  fixture: string
+  query: string
+}
+
+function isCategory(value: string): value is 'substantive' | 'trivial' {
+  return value === 'substantive' || value === 'trivial'
+}
+
+/**
+ * Expand the committed dataset into experiment items.
+ *
+ * Emission is probabilistic, so a single generation per query measures almost
+ * nothing. Each query is repeated `trials` times as separate items, which keeps
+ * one item equal to one generation in Langfuse while letting the run-level
+ * evaluator compute a rate.
+ */
+export function loadRelatedQuestionsDataset({
+  trials = 1,
+  ids
+}: { trials?: number; ids?: string[] } = {}): RelatedQuestionsItem[] {
+  const fixtures = datasetJson.fixtures as Record<string, SearchFixture[]>
+  const items: RelatedQuestionsItem[] = []
+
+  const wanted = ids && ids.length > 0 ? new Set(ids) : null
+
+  for (const raw of datasetJson.items as RawItem[]) {
+    if (wanted && !wanted.has(raw.id)) continue
+
+    const results = fixtures[raw.fixture]
+    if (!results) {
+      throw new Error(
+        `Item "${raw.id}" references unknown fixture "${raw.fixture}"`
+      )
+    }
+    if (!isCategory(raw.category)) {
+      throw new Error(`Item "${raw.id}" has unknown category "${raw.category}"`)
+    }
+
+    for (let trial = 1; trial <= trials; trial++) {
+      items.push({
+        input: { query: raw.query, results },
+        expectedOutput: { emitsRelated: raw.category === 'substantive' },
+        metadata: { itemId: raw.id, category: raw.category, trial }
+      })
+    }
+  }
+
+  if (wanted) {
+    const found = new Set(items.map(item => item.metadata.itemId))
+    const missing = [...wanted].filter(id => !found.has(id))
+    if (missing.length > 0) {
+      throw new Error(`Unknown item id(s): ${missing.join(', ')}`)
+    }
+  }
+
+  return items
+}
+
+export const datasetDescription = datasetJson.description

--- a/evals/lib/gate.ts
+++ b/evals/lib/gate.ts
@@ -1,0 +1,70 @@
+import { type ExperimentResult, RegressionError } from '@langfuse/client'
+
+export type Threshold = {
+  direction: 'min' | 'max'
+  value: number | null
+}
+
+export type GateCheck = {
+  metric: string
+  value: number
+  threshold: Threshold
+}
+
+function violates(check: GateCheck): boolean {
+  if (check.threshold.value === null) return false
+  return check.threshold.direction === 'min'
+    ? check.value < check.threshold.value
+    : check.value > check.threshold.value
+}
+
+function formatCheck(check: GateCheck): string {
+  const actual = check.value.toFixed(3)
+  if (check.threshold.value === null) {
+    return `  - ${check.metric}: ${actual} (not enforced)`
+  }
+  const comparator = check.threshold.direction === 'min' ? '>=' : '<='
+  const verdict = violates(check) ? 'FAIL' : 'ok'
+  return `  - ${check.metric}: ${actual} ${comparator} ${check.threshold.value} [${verdict}]`
+}
+
+/**
+ * Compare measured metrics against the committed thresholds.
+ *
+ * Throws `RegressionError`, which the Langfuse experiment GitHub Action reads
+ * to fail the job. Metrics with a null threshold are printed but never fail the
+ * run, so a new metric can be observed for a while before it gates anything.
+ */
+export function applyGate(result: ExperimentResult, checks: GateCheck[]): void {
+  console.log('\nGate:')
+  for (const check of checks) {
+    console.log(formatCheck(check))
+  }
+
+  const failures = checks.filter(violates)
+  if (failures.length === 0) {
+    const enforced = checks.filter(check => check.threshold.value !== null)
+    console.log(
+      enforced.length === 0
+        ? '  no thresholds enforced yet'
+        : `  ${enforced.length} threshold(s) passed`
+    )
+    return
+  }
+
+  const [first] = failures
+  throw new RegressionError({
+    result,
+    metric: first.metric,
+    value: first.value,
+    threshold: first.threshold.value as number,
+    message: failures
+      .map(
+        check =>
+          `${check.metric}=${check.value.toFixed(3)} violates ${
+            check.threshold.direction
+          } ${check.threshold.value}`
+      )
+      .join(', ')
+  })
+}

--- a/evals/lib/gate.ts
+++ b/evals/lib/gate.ts
@@ -3,25 +3,45 @@ import { type ExperimentResult, RegressionError } from '@langfuse/client'
 export type Threshold = {
   direction: 'min' | 'max'
   value: number | null
+  /**
+   * Smallest denominator the threshold may be enforced on.
+   *
+   * A rate over a handful of generations is mostly noise: at one trial per
+   * query a single stochastic emission can cross a tight ceiling, which would
+   * fail the run for a reason the code did not cause. Metrics that count
+   * concrete failures rather than sampling a probability leave this unset.
+   */
+  minSamples?: number
 }
 
 export type GateCheck = {
   metric: string
   value: number
+  /** Denominator behind `value`, used to decide whether it can be enforced. */
+  samples: number
   threshold: Threshold
+}
+
+function underSampled(check: GateCheck): boolean {
+  const minSamples = check.threshold.minSamples
+  return minSamples !== undefined && check.samples < minSamples
 }
 
 function violates(check: GateCheck): boolean {
   if (check.threshold.value === null) return false
+  if (underSampled(check)) return false
   return check.threshold.direction === 'min'
     ? check.value < check.threshold.value
     : check.value > check.threshold.value
 }
 
 function formatCheck(check: GateCheck): string {
-  const actual = check.value.toFixed(3)
+  const actual = `${check.value.toFixed(3)} (n=${check.samples})`
   if (check.threshold.value === null) {
     return `  - ${check.metric}: ${actual} (not enforced)`
+  }
+  if (underSampled(check)) {
+    return `  - ${check.metric}: ${actual} (not enforced below n=${check.threshold.minSamples}, raise --trials)`
   }
   const comparator = check.threshold.direction === 'min' ? '>=' : '<='
   const verdict = violates(check) ? 'FAIL' : 'ok'
@@ -43,7 +63,9 @@ export function applyGate(result: ExperimentResult, checks: GateCheck[]): void {
 
   const failures = checks.filter(violates)
   if (failures.length === 0) {
-    const enforced = checks.filter(check => check.threshold.value !== null)
+    const enforced = checks.filter(
+      check => check.threshold.value !== null && !underSampled(check)
+    )
     console.log(
       enforced.length === 0
         ? '  no thresholds enforced yet'

--- a/evals/lib/otel.ts
+++ b/evals/lib/otel.ts
@@ -1,0 +1,33 @@
+import { LangfuseSpanProcessor } from '@langfuse/otel'
+import { LangfuseVercelAiSdkIntegration } from '@langfuse/vercel-ai-sdk'
+import { registerOTel } from '@vercel/otel'
+import { registerTelemetry } from 'ai'
+
+export type Tracing = {
+  flush: () => Promise<void>
+}
+
+/**
+ * Bootstrap the same span pipeline the app uses, outside Next.js.
+ *
+ * Credentials are required rather than optional: the experiment runner uploads
+ * item scores through the Langfuse client whether or not spans are exported, so
+ * a keyless run fails partway instead of degrading to a local-only run.
+ */
+export function setupTracing(): Tracing {
+  if (!process.env.LANGFUSE_PUBLIC_KEY || !process.env.LANGFUSE_SECRET_KEY) {
+    throw new Error(
+      'LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are required. ' +
+        'Set them in .env.local (see .env.local.example) or in the CI secrets.'
+    )
+  }
+
+  const processor = new LangfuseSpanProcessor()
+  registerOTel({
+    serviceName: 'morphic-evals',
+    spanProcessors: [processor]
+  })
+  registerTelemetry(new LangfuseVercelAiSdkIntegration())
+
+  return { flush: () => processor.forceFlush() }
+}

--- a/evals/lib/related-questions.ts
+++ b/evals/lib/related-questions.ts
@@ -6,12 +6,20 @@ import { parseSpecBlock } from '@/lib/render/parse-spec-block'
 type SpecElement = {
   type: string
   props?: Record<string, unknown>
+  children?: string[]
   on?: {
     press?: {
       action?: string
       params?: Record<string, unknown>
     }
   }
+}
+
+type CompiledSpec = {
+  /** Elements reachable from the root, in the order they render. */
+  rendered: SpecElement[]
+  /** Children of the root element, in order. Rule: the heading comes first. */
+  topLevel: SpecElement[]
 }
 
 export type RelatedQuestionsAnalysis = {
@@ -46,19 +54,49 @@ function extractSpecBlocks(markdown: string): SpecBlock[] {
   return blocks
 }
 
-function compileElements(source: string): SpecElement[] | null {
+// Only elements reachable from the root render. Reading the element map
+// directly would credit a block for buttons the user never sees, and would miss
+// the required ordering entirely, since a map has no order to inspect.
+function compileElements(source: string): CompiledSpec | null {
+  let spec: ReturnType<typeof parseSpecBlock>
   try {
-    const spec = parseSpecBlock(source)
-    return Object.values(spec.elements ?? {}) as SpecElement[]
+    spec = parseSpecBlock(source)
   } catch {
     return null
   }
+
+  const elements = (spec.elements ?? {}) as Record<string, SpecElement>
+  const root = elements[spec.root as string]
+  if (!root) return { rendered: [], topLevel: [] }
+
+  const rendered: SpecElement[] = []
+  const seen = new Set<string>()
+
+  const walk = (key: string) => {
+    if (seen.has(key)) return
+    seen.add(key)
+    const element = elements[key]
+    if (!element) return
+    rendered.push(element)
+    for (const child of element.children ?? []) walk(child)
+  }
+  walk(spec.root as string)
+
+  const topLevel = (root.children ?? [])
+    .map(key => elements[key])
+    .filter((element): element is SpecElement => element !== undefined)
+
+  return { rendered, topLevel }
 }
 
-function isRelatedBlock(elements: SpecElement[]): boolean {
-  return elements.some(
+function isRelatedBlock(spec: CompiledSpec): boolean {
+  return spec.rendered.some(
     element => element.type === 'Heading' && element.props?.title === 'Related'
   )
+}
+
+function isRelatedHeading(element: SpecElement | undefined): boolean {
+  return element?.type === 'Heading' && element.props?.title === 'Related'
 }
 
 // A block that fails to compile has no elements to inspect, so its raw source is
@@ -85,21 +123,18 @@ export function analyzeRelatedQuestions(
 ): RelatedQuestionsAnalysis {
   const parsedBlocks = extractSpecBlocks(markdown).map(block => ({
     ...block,
-    elements: compileElements(block.source)
+    spec: compileElements(block.source)
   }))
   const relatedBlocks = parsedBlocks.filter(
-    (
-      block
-    ): block is (typeof parsedBlocks)[number] & {
-      elements: SpecElement[]
-    } => block.elements !== null && isRelatedBlock(block.elements)
+    (block): block is (typeof parsedBlocks)[number] & { spec: CompiledSpec } =>
+      block.spec !== null && isRelatedBlock(block.spec)
   )
 
   // A related block that fails to compile is an emission the user never sees.
   // Counting it as "not emitted" would hide the failure, so it is reported as a
   // malformed emission instead.
   const brokenRelatedCount = parsedBlocks.filter(
-    block => block.elements === null && looksLikeRelatedSource(block.source)
+    block => block.spec === null && looksLikeRelatedSource(block.source)
   ).length
 
   if (relatedBlocks.length === 0) {
@@ -130,9 +165,13 @@ export function analyzeRelatedQuestions(
     )
   }
 
-  const buttons = relatedBlocks[0].elements.filter(
-    element => element.type === 'Button'
-  )
+  // "Always include a Heading with title Related as the first child element."
+  const block = relatedBlocks[0].spec
+  if (!isRelatedHeading(block.topLevel[0])) {
+    issues.push('the Related heading is not the first child of the root')
+  }
+
+  const buttons = block.rendered.filter(element => element.type === 'Button')
   if (buttons.length !== EXPECTED_QUESTION_COUNT) {
     issues.push(
       `${buttons.length} buttons (expected ${EXPECTED_QUESTION_COUNT})`

--- a/evals/lib/related-questions.ts
+++ b/evals/lib/related-questions.ts
@@ -29,13 +29,19 @@ const SPEC_BLOCK_PATTERN = /```spec\n([\s\S]*?)```/g
 
 const EXPECTED_QUESTION_COUNT = 3
 
-function extractSpecBlocks(markdown: string): string[] {
-  const blocks: string[] = []
+type SpecBlock = {
+  source: string
+  /** Offset just past the closing fence, used to check the end-of-answer rule. */
+  end: number
+}
+
+function extractSpecBlocks(markdown: string): SpecBlock[] {
+  const blocks: SpecBlock[] = []
   // The global regex is stateful, so it is constructed fresh per call.
   const pattern = new RegExp(SPEC_BLOCK_PATTERN.source, 'g')
   let match: RegExpExecArray | null
   while ((match = pattern.exec(markdown)) !== null) {
-    blocks.push(match[1])
+    blocks.push({ source: match[1], end: match.index + match[0].length })
   }
   return blocks
 }
@@ -77,16 +83,17 @@ function looksLikeRelatedSource(source: string): boolean {
 export function analyzeRelatedQuestions(
   markdown: string
 ): RelatedQuestionsAnalysis {
-  const parsedBlocks = extractSpecBlocks(markdown).map(source => ({
-    source,
-    elements: compileElements(source)
+  const parsedBlocks = extractSpecBlocks(markdown).map(block => ({
+    ...block,
+    elements: compileElements(block.source)
   }))
-  const relatedBlocks = parsedBlocks
-    .map(block => block.elements)
-    .filter(
-      (elements): elements is SpecElement[] =>
-        elements !== null && isRelatedBlock(elements)
-    )
+  const relatedBlocks = parsedBlocks.filter(
+    (
+      block
+    ): block is (typeof parsedBlocks)[number] & {
+      elements: SpecElement[]
+    } => block.elements !== null && isRelatedBlock(block.elements)
+  )
 
   // A related block that fails to compile is an emission the user never sees.
   // Counting it as "not emitted" would hide the failure, so it is reported as a
@@ -114,7 +121,18 @@ export function analyzeRelatedQuestions(
     issues.push(`${brokenRelatedCount} related block(s) failed to compile`)
   }
 
-  const buttons = relatedBlocks[0].filter(element => element.type === 'Button')
+  // Rule 1 of the spec prompt: the related fence must close the response.
+  // Anything after it is content the user sees below their follow-up buttons.
+  const trailing = markdown.slice(relatedBlocks[0].end).trim()
+  if (trailing !== '') {
+    issues.push(
+      `${trailing.length} char(s) of content follow the related block`
+    )
+  }
+
+  const buttons = relatedBlocks[0].elements.filter(
+    element => element.type === 'Button'
+  )
   if (buttons.length !== EXPECTED_QUESTION_COUNT) {
     issues.push(
       `${buttons.length} buttons (expected ${EXPECTED_QUESTION_COUNT})`

--- a/evals/lib/related-questions.ts
+++ b/evals/lib/related-questions.ts
@@ -1,0 +1,141 @@
+import { parseSpecBlock } from '@/lib/render/parse-spec-block'
+
+// Structural view of a compiled spec element. The compiled catalog types are
+// wider than what this check needs, and pinning the shape here keeps the
+// evaluator honest about the contract it asserts.
+type SpecElement = {
+  type: string
+  props?: Record<string, unknown>
+  on?: {
+    press?: {
+      action?: string
+      params?: Record<string, unknown>
+    }
+  }
+}
+
+export type RelatedQuestionsAnalysis = {
+  /** A spec block carrying a "Related" heading was present. */
+  emitted: boolean
+  /** Question text of every Button in the first related block, in order. */
+  questions: string[]
+  /** The block satisfies the contract the prompt asks for. */
+  wellFormed: boolean
+  /** Human-readable reasons wellFormed is false. Empty when it is true. */
+  issues: string[]
+}
+
+const SPEC_BLOCK_PATTERN = /```spec\n([\s\S]*?)```/g
+
+const EXPECTED_QUESTION_COUNT = 3
+
+function extractSpecBlocks(markdown: string): string[] {
+  const blocks: string[] = []
+  // The global regex is stateful, so it is constructed fresh per call.
+  const pattern = new RegExp(SPEC_BLOCK_PATTERN.source, 'g')
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(markdown)) !== null) {
+    blocks.push(match[1])
+  }
+  return blocks
+}
+
+function compileElements(source: string): SpecElement[] | null {
+  try {
+    const spec = parseSpecBlock(source)
+    return Object.values(spec.elements ?? {}) as SpecElement[]
+  } catch {
+    return null
+  }
+}
+
+function isRelatedBlock(elements: SpecElement[]): boolean {
+  return elements.some(
+    element => element.type === 'Heading' && element.props?.title === 'Related'
+  )
+}
+
+/**
+ * Inspect a model answer for the related questions spec block.
+ *
+ * Emission is deliberately separated from well-formedness: a model that stops
+ * emitting the block and a model that emits a malformed one are different
+ * failures with different fixes, and collapsing them into one pass/fail hides
+ * which one happened.
+ */
+export function analyzeRelatedQuestions(
+  markdown: string
+): RelatedQuestionsAnalysis {
+  const parsedBlocks = extractSpecBlocks(markdown).map(compileElements)
+  const relatedBlocks = parsedBlocks.filter(
+    (elements): elements is SpecElement[] =>
+      elements !== null && isRelatedBlock(elements)
+  )
+
+  // A block that carries a "Related" heading but fails to compile is an
+  // emission the user never sees. Counting it as "not emitted" would hide the
+  // failure, so it is reported as a malformed emission instead.
+  const unparseableCount = parsedBlocks.filter(
+    elements => elements === null
+  ).length
+
+  if (relatedBlocks.length === 0) {
+    return unparseableCount > 0
+      ? {
+          emitted: true,
+          questions: [],
+          wellFormed: false,
+          issues: [`${unparseableCount} spec block(s) failed to compile`]
+        }
+      : { emitted: false, questions: [], wellFormed: false, issues: [] }
+  }
+
+  const issues: string[] = []
+  if (relatedBlocks.length > 1) {
+    issues.push(`${relatedBlocks.length} related blocks (expected 1)`)
+  }
+  if (unparseableCount > 0) {
+    issues.push(`${unparseableCount} spec block(s) failed to compile`)
+  }
+
+  const buttons = relatedBlocks[0].filter(element => element.type === 'Button')
+  if (buttons.length !== EXPECTED_QUESTION_COUNT) {
+    issues.push(
+      `${buttons.length} buttons (expected ${EXPECTED_QUESTION_COUNT})`
+    )
+  }
+
+  const questions: string[] = []
+  buttons.forEach((button, index) => {
+    const text = button.props?.text
+    const action = button.on?.press?.action
+    const query = button.on?.press?.params?.query
+
+    if (typeof text !== 'string' || text.trim() === '') {
+      issues.push(`button ${index + 1}: missing text`)
+    } else {
+      questions.push(text)
+    }
+
+    if (action !== 'submitQuery') {
+      issues.push(`button ${index + 1}: action is ${String(action)}`)
+    }
+
+    // Rule 4 of the spec prompt. A mismatch sends the user a different query
+    // than the one they tapped.
+    if (typeof text === 'string' && query !== text) {
+      issues.push(`button ${index + 1}: query does not match text`)
+    }
+  })
+
+  if (new Set(questions).size !== questions.length) {
+    issues.push('duplicate questions')
+  }
+
+  return {
+    emitted: true,
+    questions,
+    wellFormed: issues.length === 0,
+    issues
+  }
+}

--- a/evals/lib/related-questions.ts
+++ b/evals/lib/related-questions.ts
@@ -55,6 +55,17 @@ function isRelatedBlock(elements: SpecElement[]): boolean {
   )
 }
 
+// A block that fails to compile has no elements to inspect, so its raw source is
+// the only evidence of what it was meant to be. Image blocks are a separate and
+// legitimate feature, so a broken one must not be counted as a related-question
+// emission.
+function looksLikeRelatedSource(source: string): boolean {
+  return (
+    /"title"\s*:\s*"Related"/.test(source) ||
+    /"action"\s*:\s*"submitQuery"/.test(source)
+  )
+}
+
 /**
  * Inspect a model answer for the related questions spec block.
  *
@@ -66,26 +77,31 @@ function isRelatedBlock(elements: SpecElement[]): boolean {
 export function analyzeRelatedQuestions(
   markdown: string
 ): RelatedQuestionsAnalysis {
-  const parsedBlocks = extractSpecBlocks(markdown).map(compileElements)
-  const relatedBlocks = parsedBlocks.filter(
-    (elements): elements is SpecElement[] =>
-      elements !== null && isRelatedBlock(elements)
-  )
+  const parsedBlocks = extractSpecBlocks(markdown).map(source => ({
+    source,
+    elements: compileElements(source)
+  }))
+  const relatedBlocks = parsedBlocks
+    .map(block => block.elements)
+    .filter(
+      (elements): elements is SpecElement[] =>
+        elements !== null && isRelatedBlock(elements)
+    )
 
-  // A block that carries a "Related" heading but fails to compile is an
-  // emission the user never sees. Counting it as "not emitted" would hide the
-  // failure, so it is reported as a malformed emission instead.
-  const unparseableCount = parsedBlocks.filter(
-    elements => elements === null
+  // A related block that fails to compile is an emission the user never sees.
+  // Counting it as "not emitted" would hide the failure, so it is reported as a
+  // malformed emission instead.
+  const brokenRelatedCount = parsedBlocks.filter(
+    block => block.elements === null && looksLikeRelatedSource(block.source)
   ).length
 
   if (relatedBlocks.length === 0) {
-    return unparseableCount > 0
+    return brokenRelatedCount > 0
       ? {
           emitted: true,
           questions: [],
           wellFormed: false,
-          issues: [`${unparseableCount} spec block(s) failed to compile`]
+          issues: [`${brokenRelatedCount} related block(s) failed to compile`]
         }
       : { emitted: false, questions: [], wellFormed: false, issues: [] }
   }
@@ -94,8 +110,8 @@ export function analyzeRelatedQuestions(
   if (relatedBlocks.length > 1) {
     issues.push(`${relatedBlocks.length} related blocks (expected 1)`)
   }
-  if (unparseableCount > 0) {
-    issues.push(`${unparseableCount} spec block(s) failed to compile`)
+  if (brokenRelatedCount > 0) {
+    issues.push(`${brokenRelatedCount} related block(s) failed to compile`)
   }
 
   const buttons = relatedBlocks[0].filter(element => element.type === 'Button')

--- a/evals/run-related-questions.ts
+++ b/evals/run-related-questions.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env bun
+/**
+ * Measure the related questions emission rate of the deployed adaptive
+ * configuration against a fixed dataset.
+ *
+ *   bun run eval:related-questions
+ *   bun run eval:related-questions -- --trials 3 --model openai:gpt-5.6-luna
+ *
+ * See evals/README.md for what this measures and why.
+ */
+import { config as dotenvConfig } from 'dotenv'
+
+dotenvConfig({ path: '.env.local' })
+
+// The adaptive prompt branches on whether a general search provider is
+// configured, so an unset key would silently measure a different prompt than
+// the deployed one. Pinned before anything reads it. The fixture search tool
+// means no request ever reaches Brave.
+process.env.BRAVE_SEARCH_API_KEY ||= 'eval-pinned-general-provider'
+
+type Args = {
+  model?: string
+  trials: number
+  concurrency: number
+  runName?: string
+  gate: boolean
+  ids?: string[]
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { trials: 1, concurrency: 5, gate: true }
+
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i]
+    const next = () => {
+      const value = argv[++i]
+      if (value === undefined) throw new Error(`${flag} requires a value`)
+      return value
+    }
+
+    switch (flag) {
+      case '--model':
+        args.model = next()
+        break
+      case '--trials':
+        args.trials = Number(next())
+        break
+      case '--concurrency':
+        args.concurrency = Number(next())
+        break
+      case '--run-name':
+        args.runName = next()
+        break
+      case '--items':
+        args.ids = next()
+          .split(',')
+          .map(id => id.trim())
+          .filter(Boolean)
+        break
+      case '--no-gate':
+        args.gate = false
+        break
+      case '--help':
+        console.log(
+          [
+            'Usage: bun run eval:related-questions [options]',
+            '',
+            '  --model <id>        provider:model to evaluate (default: the deployed adaptive model)',
+            '  --trials <n>        generations per dataset item (default: 1)',
+            '  --concurrency <n>   parallel generations (default: 5)',
+            '  --run-name <name>   exact Langfuse run name (default: name + timestamp)',
+            '  --items <a,b>       run only these dataset item ids',
+            '  --no-gate           report metrics without failing on threshold violations'
+          ].join('\n')
+        )
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${flag}`)
+    }
+  }
+
+  if (!Number.isFinite(args.trials) || args.trials < 1) {
+    throw new Error('--trials must be a positive number')
+  }
+  if (!Number.isFinite(args.concurrency) || args.concurrency < 1) {
+    throw new Error('--concurrency must be a positive number')
+  }
+
+  return args
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+
+  // Imported after dotenv: the provider registry reads API keys at module load.
+  const { LangfuseClient } = await import('@langfuse/client')
+  const { datasetDescription, loadRelatedQuestionsDataset } = await import(
+    './lib/dataset'
+  )
+  const { applyGate } = await import('./lib/gate')
+  type Threshold = import('./lib/gate').Threshold
+  const { setupTracing } = await import('./lib/otel')
+  const {
+    relatedQuestionsEvaluator,
+    relatedQuestionsRunEvaluator,
+    summarizeRelatedQuestions
+  } = await import('./evaluators/related-questions')
+  const { createAdaptiveAnswerTask, DEFAULT_MODEL } = await import(
+    './tasks/adaptive-answer'
+  )
+  const thresholds = (await import('./thresholds.json')).default
+
+  const model = args.model ?? DEFAULT_MODEL
+  const data = loadRelatedQuestionsDataset({
+    trials: args.trials,
+    ids: args.ids
+  })
+  const tracing = setupTracing()
+
+  console.log(`model:       ${model}`)
+  console.log(`items:       ${data.length} (${args.trials} trial(s) per query)`)
+  console.log(`concurrency: ${args.concurrency}\n`)
+
+  const langfuse = new LangfuseClient()
+
+  const result = await langfuse.experiment.run({
+    name: 'related-questions',
+    runName: args.runName,
+    description: datasetDescription,
+    metadata: { model, trials: args.trials },
+    data,
+    task: createAdaptiveAnswerTask({ model, tracingEnabled: true }),
+    evaluators: [relatedQuestionsEvaluator],
+    runEvaluators: [relatedQuestionsRunEvaluator],
+    maxConcurrency: args.concurrency
+  })
+
+  console.log(await result.format({ includeItemResults: true }))
+
+  // The runner drops an item whose task threw, which silently shrinks the
+  // denominator of every rate below. A run that lost items is not a valid
+  // measurement, so completion is gated like any other metric.
+  const completionRate = result.itemResults.length / data.length
+  if (result.itemResults.length < data.length) {
+    console.log(
+      `\n${data.length - result.itemResults.length} of ${data.length} item(s) failed and were skipped.`
+    )
+    console.log(
+      'Note: with skipped items the "Input" and "Expected" lines printed above are misaligned (a Langfuse formatter bug). The scores and traces are correct.'
+    )
+  }
+
+  const summary = summarizeRelatedQuestions(result.itemResults)
+  const config = thresholds['related-questions'] as Record<string, Threshold>
+
+  try {
+    if (args.gate) {
+      applyGate(result, [
+        {
+          metric: 'completionRate',
+          value: completionRate,
+          threshold: config.completionRate
+        },
+        ...(
+          ['emissionRate', 'falsePositiveRate', 'wellFormedRate'] as const
+        ).map(metric => ({
+          metric,
+          value: summary[metric],
+          threshold: config[metric]
+        }))
+      ])
+    }
+  } finally {
+    await tracing.flush()
+    if (result.datasetRunUrl) console.log(`\n${result.datasetRunUrl}`)
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/evals/run-related-questions.ts
+++ b/evals/run-related-questions.ts
@@ -160,15 +160,27 @@ async function main() {
         {
           metric: 'completionRate',
           value: completionRate,
+          samples: data.length,
           threshold: config.completionRate
         },
-        ...(
-          ['emissionRate', 'falsePositiveRate', 'wellFormedRate'] as const
-        ).map(metric => ({
-          metric,
-          value: summary[metric],
-          threshold: config[metric]
-        }))
+        {
+          metric: 'emissionRate',
+          value: summary.emissionRate,
+          samples: summary.substantiveCount,
+          threshold: config.emissionRate
+        },
+        {
+          metric: 'falsePositiveRate',
+          value: summary.falsePositiveRate,
+          samples: summary.trivialCount,
+          threshold: config.falsePositiveRate
+        },
+        {
+          metric: 'wellFormedRate',
+          value: summary.wellFormedRate,
+          samples: summary.emittedCount,
+          threshold: config.wellFormedRate
+        }
       ])
     }
   } finally {

--- a/evals/tasks/adaptive-answer.ts
+++ b/evals/tasks/adaptive-answer.ts
@@ -4,7 +4,9 @@ import { z } from 'zod'
 import cloudConfig from '@/config/models/cloud.json'
 
 import { getAdaptiveModePrompt } from '@/lib/agents/prompts/search-mode-prompts'
+import { fetchTool } from '@/lib/tools/fetch'
 import { createSearchTool } from '@/lib/tools/search'
+import { createTodoTools } from '@/lib/tools/todo'
 import { getModel } from '@/lib/utils/registry'
 
 import { type RelatedQuestionsInput, type SearchFixture } from '../lib/dataset'
@@ -18,9 +20,11 @@ const ADAPTIVE = cloudConfig.models.adaptive
 export const DEFAULT_MODEL = `${ADAPTIVE.providerId}:${ADAPTIVE.id}`
 export const DEFAULT_PROVIDER_OPTIONS = ADAPTIVE.providerOptions
 
-// The answer only needs to reach a conclusion, not to research exhaustively.
-// A low cap keeps a runaway loop from dominating the run's cost.
-const MAX_STEPS = 6
+// Production allows 50 steps in adaptive mode. The fixture search returns the
+// same results every time, so a healthy run converges in a handful of steps;
+// this cap only bounds a loop that is going nowhere. A run that hits it is
+// rejected rather than measured, see the finish reason check below.
+const MAX_STEPS = 20
 
 // The provider intermittently returns a response the SDK cannot parse, at a few
 // percent of calls. The experiment runner drops an item whose task throws, so
@@ -91,12 +95,19 @@ export function createAdaptiveAnswerTask({
     const result = await generateText({
       model: getModel(model),
       instructions: getAdaptiveModePrompt(),
+      // The adaptive agent activates search, fetch and todoWrite, and the
+      // prompt tells the model those tools exist. Handing it only search would
+      // force a different trajectory and so a different answer shape, which is
+      // the thing being measured. todoWrite is the production tool as-is: its
+      // state is per-instance and never leaves the process.
       tools: {
         search: createFixtureSearchTool({
           results: input.results,
           toModelOutput,
           onQuery: query => searchQueries.push(query)
-        })
+        }),
+        fetch: createFixtureFetchTool(input.results),
+        ...createTodoTools()
       },
       stopWhen: isStepCount(MAX_STEPS),
       providerOptions,
@@ -107,12 +118,43 @@ export function createAdaptiveAnswerTask({
       }
     })
 
+    // A loop cut off at the step cap leaves an answer the model never finished,
+    // and an unfinished answer carries no related block for reasons that have
+    // nothing to do with the prompt. Reject it so the retry runs and, if it
+    // keeps happening, completionRate reports it.
+    if (result.finishReason === 'tool-calls') {
+      throw new Error(`Step cap of ${MAX_STEPS} reached before an answer`)
+    }
+    if (result.text.trim() === '') {
+      throw new Error('Model produced no answer text')
+    }
+
     return {
       text: result.text,
       searchQueries,
       steps: result.steps.length
     }
   }
+}
+
+// Mirrors the production fetch tool's contract while serving the item's own
+// fixture, so the model can follow a URL out of the search results without the
+// answer depending on what that page says today.
+function createFixtureFetchTool(results: SearchFixture[]) {
+  return tool({
+    description: fetchTool.description,
+    inputSchema: fetchTool.inputSchema,
+    async execute({ url }: { url: string }) {
+      const match = results.find(result => result.url === url)
+      return {
+        state: 'complete' as const,
+        query: url,
+        results: match ? [match] : results,
+        images: [],
+        number_of_results: match ? 1 : results.length
+      }
+    }
+  })
 }
 
 function createFixtureSearchTool({

--- a/evals/tasks/adaptive-answer.ts
+++ b/evals/tasks/adaptive-answer.ts
@@ -1,0 +1,147 @@
+import { generateText, isStepCount, tool } from 'ai'
+import { z } from 'zod'
+
+import cloudConfig from '@/config/models/cloud.json'
+
+import { getAdaptiveModePrompt } from '@/lib/agents/prompts/search-mode-prompts'
+import { createSearchTool } from '@/lib/tools/search'
+import { getModel } from '@/lib/utils/registry'
+
+import { type RelatedQuestionsInput, type SearchFixture } from '../lib/dataset'
+
+// Narrow enough to satisfy the SDK's JSON-shaped provider options, wide enough
+// to carry another provider's settings when a model swap is being evaluated.
+type ProviderOptions = Record<string, Record<string, string | number | boolean>>
+
+const ADAPTIVE = cloudConfig.models.adaptive
+
+export const DEFAULT_MODEL = `${ADAPTIVE.providerId}:${ADAPTIVE.id}`
+export const DEFAULT_PROVIDER_OPTIONS = ADAPTIVE.providerOptions
+
+// The answer only needs to reach a conclusion, not to research exhaustively.
+// A low cap keeps a runaway loop from dominating the run's cost.
+const MAX_STEPS = 6
+
+// The provider intermittently returns a response the SDK cannot parse, at a few
+// percent of calls. The experiment runner drops an item whose task throws, so
+// without a retry that noise lands directly in the measured rates. The SDK's own
+// retry does not cover this error class.
+const DEFAULT_RETRIES = 2
+
+export type AdaptiveAnswerOutput = {
+  text: string
+  searchQueries: string[]
+  steps: number
+}
+
+/**
+ * Replay one query against the deployed adaptive configuration with the search
+ * results pinned.
+ *
+ * Production faithfulness is the point: the same prompt builder, the same
+ * providerOptions, and the same `toModelOutput` trimming the real search tool
+ * applies. Reasoning effort in particular has moved emission rates before, so a
+ * run without providerOptions would measure something the product does not do.
+ */
+export function createAdaptiveAnswerTask({
+  model = DEFAULT_MODEL,
+  providerOptions = DEFAULT_PROVIDER_OPTIONS,
+  tracingEnabled = true,
+  retries = DEFAULT_RETRIES
+}: {
+  model?: string
+  providerOptions?: ProviderOptions
+  tracingEnabled?: boolean
+  retries?: number
+} = {}) {
+  // Built once: it reaches out to the search provider config, not the network.
+  const toModelOutput = createSearchTool(model).toModelOutput
+
+  // The item type is the SDK's union of a local item and a Langfuse dataset
+  // item, whose input is `unknown`. Narrowing here is what lets the same task
+  // run against a managed dataset later without another code path.
+  return async function adaptiveAnswer(item: {
+    input?: unknown
+  }): Promise<AdaptiveAnswerOutput> {
+    const input = item.input as RelatedQuestionsInput | undefined
+    if (!input?.query || !Array.isArray(input.results)) {
+      throw new Error('Experiment item input must be { query, results }')
+    }
+
+    let lastError: unknown
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        return await generate(input)
+      } catch (error) {
+        lastError = error
+        const message = error instanceof Error ? error.message : String(error)
+        console.warn(
+          `[eval] attempt ${attempt + 1}/${retries + 1} failed for "${input.query}": ${message}`
+        )
+      }
+    }
+    throw lastError
+  }
+
+  async function generate(
+    input: RelatedQuestionsInput
+  ): Promise<AdaptiveAnswerOutput> {
+    const searchQueries: string[] = []
+
+    const result = await generateText({
+      model: getModel(model),
+      instructions: getAdaptiveModePrompt(),
+      tools: {
+        search: createFixtureSearchTool({
+          results: input.results,
+          toModelOutput,
+          onQuery: query => searchQueries.push(query)
+        })
+      },
+      stopWhen: isStepCount(MAX_STEPS),
+      providerOptions,
+      prompt: input.query,
+      telemetry: {
+        isEnabled: tracingEnabled,
+        functionId: 'eval-adaptive-answer'
+      }
+    })
+
+    return {
+      text: result.text,
+      searchQueries,
+      steps: result.steps.length
+    }
+  }
+}
+
+function createFixtureSearchTool({
+  results,
+  toModelOutput,
+  onQuery
+}: {
+  results: SearchFixture[]
+  toModelOutput: ReturnType<typeof createSearchTool>['toModelOutput']
+  onQuery: (query: string) => void
+}) {
+  return tool({
+    description: 'Search the web for information.',
+    inputSchema: z.object({
+      query: z.string(),
+      type: z.enum(['optimized', 'general']).optional(),
+      max_results: z.number().optional()
+    }),
+    async execute({ query }) {
+      onQuery(query)
+      return {
+        state: 'complete' as const,
+        query,
+        results,
+        images: [],
+        number_of_results: results.length,
+        toolCallId: 'fixture-search'
+      }
+    },
+    toModelOutput: toModelOutput as never
+  })
+}

--- a/evals/thresholds.json
+++ b/evals/thresholds.json
@@ -8,12 +8,12 @@
     "emissionRate": {
       "direction": "min",
       "value": 0.85,
-      "minSamples": 30
+      "minSamples": 50
     },
     "falsePositiveRate": {
       "direction": "max",
       "value": null,
-      "minSamples": 30
+      "minSamples": 50
     },
     "wellFormedRate": {
       "direction": "min",

--- a/evals/thresholds.json
+++ b/evals/thresholds.json
@@ -1,0 +1,9 @@
+{
+  "note": "Thresholds gate CI. A null value means the metric is measured and reported but not enforced. Run the eval to get a baseline, then commit the numbers here so any later change to them shows up in a diff.",
+  "related-questions": {
+    "completionRate": { "direction": "min", "value": 0.9 },
+    "emissionRate": { "direction": "min", "value": 0.85 },
+    "falsePositiveRate": { "direction": "max", "value": null },
+    "wellFormedRate": { "direction": "min", "value": 0.9 }
+  }
+}

--- a/evals/thresholds.json
+++ b/evals/thresholds.json
@@ -1,9 +1,24 @@
 {
-  "note": "Thresholds gate CI. A null value means the metric is measured and reported but not enforced. Run the eval to get a baseline, then commit the numbers here so any later change to them shows up in a diff.",
+  "note": "Thresholds gate CI. A null value means the metric is measured and reported but not enforced. minSamples is the smallest denominator the threshold may be enforced on, so a low-trial run reports without failing. Run the eval to get a baseline, then commit the numbers here so any later change to them shows up in a diff.",
   "related-questions": {
-    "completionRate": { "direction": "min", "value": 0.9 },
-    "emissionRate": { "direction": "min", "value": 0.85 },
-    "falsePositiveRate": { "direction": "max", "value": null },
-    "wellFormedRate": { "direction": "min", "value": 0.9 }
+    "completionRate": {
+      "direction": "min",
+      "value": 0.9
+    },
+    "emissionRate": {
+      "direction": "min",
+      "value": 0.85,
+      "minSamples": 30
+    },
+    "falsePositiveRate": {
+      "direction": "max",
+      "value": null,
+      "minSamples": 30
+    },
+    "wellFormedRate": {
+      "direction": "min",
+      "value": 0.9,
+      "minSamples": 30
+    }
   }
 }

--- a/evals/thresholds.json
+++ b/evals/thresholds.json
@@ -18,7 +18,7 @@
     "wellFormedRate": {
       "direction": "min",
       "value": 0.9,
-      "minSamples": 30
+      "minSamples": 50
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "backfill:file-keys": "bun run scripts/backfill-file-object-keys.ts",
     "test": "NODE_ENV=test vitest run",
     "test:watch": "vitest --watch",
-    "chat": "bun run scripts/chat-cli.ts"
+    "chat": "bun run scripts/chat-cli.ts",
+    "eval:related-questions": "bun run evals/run-related-questions.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.39",


### PR DESCRIPTION
## What

Adds `evals/`, a Langfuse experiment that measures whether the adaptive answer emits a well-formed related questions spec block on substantive answers and skips it on trivial lookups.

```bash
bun run eval:related-questions -- --trials 3
```

22 hand-written queries (10 substantive, 12 trivial) run against pinned search fixtures, so the measurement isolates the prompt and the model rather than retrieval variance.

## Why it is built this way

- **The task mirrors production.** Same prompt builder, same `providerOptions` from `config/models/cloud.json`, same `toModelOutput` trimming. Reasoning effort has moved emission rates before, so a run without provider options would measure something the product does not do.
- **`BRAVE_SEARCH_API_KEY` is pinned by the runner.** The adaptive prompt branches on whether a general search provider is configured, so an unset key would silently evaluate a different prompt. No request reaches Brave; the search tool is a fixture.
- **Emission and well-formedness are separate metrics.** A model that stops emitting and a model that emits a broken block are different failures with different fixes.
- **Each trial is its own item.** Emission is probabilistic, so one generation per query measures almost nothing.

## Layers

| Layer | Where | Runs | Needs keys |
| --- | --- | --- | --- |
| Evaluator unit tests | `evals/lib/__tests__` | every PR, via `bun run test` | no |
| Experiment | `evals/run-related-questions.ts` | on prompt and model changes, and on demand | yes |

The first layer exists because an evaluator is code too. It runs on fork PRs, where secrets are unavailable. The experiment job is skipped for fork PRs and is not a required check.

The experiment deliberately does not run nightly, and does not run on changes to `evals/` itself. A nightly run measures a system that has not changed since the night before, at a hundred and ten generations a time, and drift shows up in production with far more samples and no cost. A harness change moves no rate. What is left is the one case CI does better than after-the-fact analysis: a prompt or model change, measured before it ships.

## Baseline

`openai:gpt-5.6-luna` with `reasoningEffort: low`, 22 queries x 3 trials, two runs pooled:

| Metric | Value |
| --- | --- |
| completionRate | 1.000 |
| emissionRate | 0.917 (55/60) |
| falsePositiveRate | 0.319 (23/72) |
| wellFormedRate | 0.974 |

`falsePositiveRate` is reported but **not** enforced here. Roughly a third of trivial lookups get a related questions block appended, on questions like "when does the official Mount Fuji climbing season start" where the fixture holds a single unambiguous value. That is a defect to fix, not a baseline to protect; #977 addresses the prompt and enforces the metric afterwards.

Thresholds enforce only at 50 samples, which the nightly five trials reach and a three-trial local run does not. Identical code measured 1.000 and 0.833 on `emissionRate` across two runs of thirty substantive samples, so thirty cannot carry a floor.

## Notes for reviewers

- `completionRate` is gated because the experiment runner drops an item whose task throws, which shrinks the denominator of every other rate without lowering it. The provider intermittently returns an unparseable response (and once flagged a battery-chemistry question as a policy violation), so the task retries before giving up.
- When items are skipped, the `Input` and `Expected` lines in the printed item list are misaligned: the Langfuse formatter pairs `itemResults[i]` with `originalData[i]` after failed entries are filtered out. Scores, outputs and trace links are unaffected, since each result carries its own item. The runner warns when this applies.
- Rates are read at the run level, never per item. At three trials an individual query swings by a third between runs.
- Experiment traces are tagged by the SDK with the `sdk-experiment` environment, so they do not need a separate Langfuse project to stay out of production metrics.

## Test plan

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun format:check`
- [x] `bun run test` (543 passed, includes 7 new evaluator tests)
- [x] `bun run build`
- [x] Full experiment run against the deployed adaptive model, results in Langfuse


