### PR TITLE
fix(prompt): stop appending related questions to single-fact answers

### DIFF
--- a/evals/thresholds.json
+++ b/evals/thresholds.json
@@ -12,7 +12,7 @@
     },
     "falsePositiveRate": {
       "direction": "max",
-      "value": null,
+      "value": 0.2,
       "minSamples": 50
     },
     "wellFormedRate": {

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -16,15 +16,16 @@ describe('render prompts', () => {
     const prompt = getRelatedQuestionsSpecPrompt()
 
     expect(prompt).toContain('expected on every substantive answer')
+    expect(prompt).toContain('Decide from the answer you just wrote')
     expect(prompt).toContain(
-      'Include the spec block whenever the answer contains substantive information'
+      'Include the spec block whenever that answer compares options'
     )
     expect(prompt).toContain(
       'SKIP the spec block entirely (output nothing) only in these cases'
     )
     expect(prompt).toContain('Greetings, small talk, or thanks')
     expect(prompt).toContain(
-      'Trivial one-off lookups with no natural next step'
+      'The answer delivers a single fact, value, date, quantity, or yes/no'
     )
     expect(prompt).toContain('Meta/operational replies')
     expect(prompt).toContain('Cases where you could not answer')

--- a/lib/render/prompt.ts
+++ b/lib/render/prompt.ts
@@ -1,7 +1,7 @@
 /**
  * Returns the prompt section that instructs the LLM to output
  * related questions as a ```spec fenced block at the end of its response,
- * but only when follow-ups add value (skipped for greetings, trivial
+ * but only when follow-ups add value (skipped for greetings, single-fact
  * lookups, and non-answers).
  */
 export function getRelatedQuestionsSpecPrompt(): string {
@@ -9,11 +9,11 @@ export function getRelatedQuestionsSpecPrompt(): string {
 RELATED QUESTIONS:
 After your conclusion, generate exactly 3 follow-up questions in a \`\`\`spec fenced code block. This is expected on every substantive answer; only the narrow skip cases below are exempt.
 
-Include the spec block whenever the answer contains substantive information, analysis, comparison, or recommendations. Anchor each follow-up to concrete details from THIS answer.
+Decide from the answer you just wrote, not from what the reader might go on to wonder. Include the spec block whenever that answer compares options, recommends or advises, explains a cause or a mechanism, lays out several distinct points, or walks through steps. Anchor each follow-up to concrete details from THIS answer.
 
 SKIP the spec block entirely (output nothing) only in these cases:
 - Greetings, small talk, or thanks ("hi", "thanks", "how are you").
-- Trivial one-off lookups with no natural next step (simple math, a single fact, a yes/no).
+- The answer delivers a single fact, value, date, quantity, or yes/no, even when interesting follow-ups do exist. A lookup does not stop being a lookup because the topic is rich.
 - Meta/operational replies, acknowledgements, or task-completion notices.
 - Cases where you could not answer (refusal, clarification request, or empty result).
 - Short answers where suggested next questions would be generic or forced.


### PR DESCRIPTION
Stacked on #976. Merge that first; this PR's diff is the prompt change plus the threshold it earns.

## Problem

A third of trivial lookups were getting a related questions block appended. "When does the official Mount Fuji climbing season start?" got one on every single run.

The skip condition was:

> Trivial one-off lookups with no natural next step (simple math, a single fact, a yes/no).

`with no natural next step` is an escape hatch. Almost any fact has a conceivable follow-up, so the condition was effectively never met.

## Change

**The decision is anchored to the answer, not to the reader.** Measurement showed the model judges by the shape of the answer it just wrote, not by the shape of the question. The instruction now says so, and names what counts: compares options, recommends or advises, explains a cause or mechanism, lays out several distinct points, walks through steps.

**The trivial case names what it covers and closes the loophole.** A single fact, value, date, quantity or yes/no, `even when interesting follow-ups do exist`.

The default stays on include and the skip cases stay a concrete enumeration. A model swap has emptied this block before when the instruction leaned on hedged wording, so the fix rebalances the trivial clause rather than flipping the default.

## Measurement

`evals/related-questions`, `openai:gpt-5.6-luna` with `reasoningEffort: low`, 22 queries x 3 trials, **two runs on each side**, with the adaptive tool set the deployment activates:

| Metric | before (n=72) | after (n=72) |
| --- | --- | --- |
| falsePositiveRate | 0.319 (23/72) | **0.097 (7/72)** |
| emissionRate | 0.917 (55/60) | 0.983 (59/60) |

z = 3.3, p = 0.001 on the false positive difference. `emissionRate` did not fall, so no substantive answer was traded away.

Per query, the worst offenders go to zero:

```
3/3 -> 0/3  When does the official Mount Fuji climbing season start?
2/3 -> 0/3  What is the half-life of caffeine?
2/3 -> 0/3  How many hours of sleep do adults need?
2/3 -> 0/3  How long is a typical sleep cycle?
1/3 -> 0/3  Which Postgres index type is used for full-text search vectors?
2/3 -> 2/3  What water temperature is recommended for brewing coffee?
```

## Why two runs on each side

The before state measured 0.278 and 0.361 on consecutive runs of identical code, and `emissionRate` moved between 1.000 and 0.833. A single run would have supported almost any conclusion. Thresholds enforce only at 50 samples for the same reason, which the nightly five trials reach and a three-trial local run does not.

`falsePositiveRate` moves from reported to enforced at 0.20, and it is worth being precise about what that buys. The before state has now been sampled three times at 0.200, 0.278 and 0.361; the after state twice at 0.083 and 0.111. The distributions overlap at the tails, so **no single-run ceiling separates them cleanly**. A 0.15 ceiling would fail an ordinary after run roughly one time in twelve at sixty samples, and 0.20 lets the best before run through. The gate catches a blowup, not a quiet return to the old rate. Deciding that a change moved this metric still needs several runs on each side, as this PR did.

## Not covered

The prompt is a constant string, so the cache prefix is unaffected.

This is measured on fixed search fixtures with one model. The rate in production will differ; the harness measures the prompt, not the deployment.

## Test plan

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun format:check`
- [x] `bun run test` (543 passed, `prompt.test.ts` updated to the new wording)
- [x] `bun run eval:related-questions -- --trials 3`, twice on each side


