### PR TITLE
feat(analytics): record thumb clicks and their outcome

### DIFF
--- a/components/__tests__/message-actions.test.tsx
+++ b/components/__tests__/message-actions.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import { render } from '@testing-library/react'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { captureClient } from '@/lib/analytics/posthog-client'
 
@@ -19,8 +19,15 @@ vi.mock('../library/library-context', () => ({
 }))
 
 describe('MessageActions', () => {
+  const originalFetch = global.fetch
+
   beforeEach(() => {
     vi.clearAllMocks()
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
   })
 
   test('records one feedback control impression when the row becomes visible', () => {
@@ -138,6 +145,118 @@ describe('MessageActions', () => {
       hasFeedback: false,
       chatId: 'chat-1',
       isGuest: false
+    })
+  })
+
+  test('records a thumbs up click and successful feedback response', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response)
+    render(
+      <MessageActions
+        message="Answer"
+        messageId="feedback-success-1"
+        traceId="trace-1"
+        chatId="chat-1"
+        isGuest
+        status="ready"
+        visible
+      />
+    )
+    vi.mocked(captureClient).mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Good response' }))
+
+    await waitFor(() => {
+      expect(captureClient).toHaveBeenCalledTimes(2)
+    })
+    expect(captureClient).toHaveBeenNthCalledWith(
+      1,
+      'feedback_control_clicked',
+      {
+        score: 1,
+        chatId: 'chat-1',
+        isGuest: true
+      }
+    )
+    expect(captureClient).toHaveBeenNthCalledWith(2, 'feedback_recorded', {
+      score: 1,
+      chatId: 'chat-1',
+      isGuest: true
+    })
+  })
+
+  test('records a failed feedback response', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 503
+    } as Response)
+    render(
+      <MessageActions
+        message="Answer"
+        messageId="feedback-response-failure-1"
+        traceId="trace-1"
+        chatId="chat-1"
+        status="ready"
+        visible
+      />
+    )
+    vi.mocked(captureClient).mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Good response' }))
+
+    await waitFor(() => {
+      expect(captureClient).toHaveBeenCalledTimes(2)
+    })
+    expect(captureClient).toHaveBeenNthCalledWith(
+      1,
+      'feedback_control_clicked',
+      {
+        score: 1,
+        chatId: 'chat-1',
+        isGuest: false
+      }
+    )
+    expect(captureClient).toHaveBeenNthCalledWith(2, 'feedback_failed', {
+      score: 1,
+      chatId: 'chat-1',
+      isGuest: false,
+      status: 503,
+      reason: 'response'
+    })
+  })
+
+  test('records an exception when feedback submission throws', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'))
+    render(
+      <MessageActions
+        message="Answer"
+        messageId="feedback-exception-1"
+        traceId="trace-1"
+        chatId="chat-1"
+        status="ready"
+        visible
+      />
+    )
+    vi.mocked(captureClient).mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Good response' }))
+
+    await waitFor(() => {
+      expect(captureClient).toHaveBeenCalledTimes(2)
+    })
+    expect(captureClient).toHaveBeenNthCalledWith(
+      1,
+      'feedback_control_clicked',
+      {
+        score: 1,
+        chatId: 'chat-1',
+        isGuest: false
+      }
+    )
+    expect(captureClient).toHaveBeenNthCalledWith(2, 'feedback_failed', {
+      score: 1,
+      chatId: 'chat-1',
+      isGuest: false,
+      reason: 'exception'
     })
   })
 })

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -185,6 +185,7 @@ export function MessageActions({
   async function handleFeedback(score: number) {
     if (isSubmittingFeedback || !traceId) return
 
+    captureClient('feedback_control_clicked', { score, chatId, isGuest })
     setIsSubmittingFeedback(true)
     try {
       const response = await fetch('/api/feedback', {
@@ -198,6 +199,9 @@ export function MessageActions({
       })
 
       if (response.ok) {
+        // The route answers 200 without writing a score when tracing is off, so
+        // this records that the request succeeded, not that a score exists.
+        captureClient('feedback_recorded', { score, chatId, isGuest })
         setFeedbackScore(score)
         toast.success(
           score === 1
@@ -205,10 +209,23 @@ export function MessageActions({
             : 'Thanks for letting us know!'
         )
       } else {
+        captureClient('feedback_failed', {
+          score,
+          chatId,
+          isGuest,
+          status: response.status,
+          reason: 'response'
+        })
         console.error('Failed to submit feedback')
         toast.error('Failed to submit feedback')
       }
     } catch (error) {
+      captureClient('feedback_failed', {
+        score,
+        chatId,
+        isGuest,
+        reason: 'exception'
+      })
       console.error('Error submitting feedback:', error)
       toast.error('Failed to submit feedback')
     } finally {
@@ -246,6 +263,7 @@ export function MessageActions({
                   onClick={() => handleFeedback(1)}
                   disabled={isSubmittingFeedback || feedbackScore === 1}
                   className="rounded-full"
+                  aria-label="Good response"
                 >
                   <ThumbsUp
                     size={14}
@@ -260,6 +278,7 @@ export function MessageActions({
                   onClick={() => handleFeedback(-1)}
                   disabled={isSubmittingFeedback || feedbackScore === -1}
                   className="rounded-full"
+                  aria-label="Bad response"
                 >
                   <ThumbsDown
                     size={14}


### PR DESCRIPTION
## Problem

`MessageActions` records an impression of the feedback control (`feedback_control_shown`, added in #968) but records nothing at all when a thumb is actually clicked. The only trace a click leaves anywhere is a Langfuse score written server-side by `app/api/feedback/route.ts`, on a separate surface with no matching client-side event.

That makes the impression-to-click conversion unreadable, because two distinct outcomes are indistinguishable from "the user never clicked":

- the POST returns a non-ok status: the client shows a toast and records nothing
- the fetch throws: same

So a low ratio of scores to impressions cannot currently be attributed. It could be users declining to rate answers, or it could be clicks failing on the way to Langfuse, and nothing recorded today separates the two.

An impression event whose conversion cannot be computed is the shape that got `note_save_button_shown` removed in #896.

## Root cause

`handleFeedback` in `components/message-actions.tsx` never calls `captureClient`. Its sibling `handleSaveNote`, in the same file, already carries a full funnel (`note_save_clicked` / `note_saved` / `note_save_failed`); the feedback path was never given one.

## Fix

Instrument `handleFeedback` following the same convention already used in this file:

- `feedback_control_clicked`, which pairs with the existing `feedback_control_shown`. Emitted after the existing early return, so a click that cannot do anything is not counted.
- `feedback_recorded` on an ok response.
- `feedback_failed` on a non-ok response (carrying `status` and `reason: 'response'`) and on a thrown fetch (`reason: 'exception'`).

No behaviour changes, and `app/api/feedback/route.ts` is untouched.

`feedback_recorded` deliberately means "the request succeeded", not "a score exists". The route also answers `200` without writing a score when `isTracingEnabled()` is false, and the client cannot tell that apart from a recorded one. That branch is not reachable from the UI today, because a turn with tracing off carries no `traceId` and the thumb buttons then do not render at all, but the event's name should not promise more than the client can actually observe. A comment in the code states this, so differencing the event against the scores actually present stays a meaningful check rather than a tautology.

Both thumb buttons also gained an `aria-label` ("Good response" / "Bad response"). They previously had no accessible name, which is also why the new tests can select them.

## Verification

- `bun lint`, `bun typecheck`, `bun format:check`, `bun run build`: all clean
- `bun run test`: 560 passed, 3 skipped
- Three new tests in `components/__tests__/message-actions.test.tsx` cover the ok, non-ok, and thrown-fetch branches, asserting both the event order and the emitted properties
