### PR TITLE
fix(analytics): remove feedback control impression

### DIFF
--- a/components/__tests__/message-actions.test.tsx
+++ b/components/__tests__/message-actions.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -30,122 +28,19 @@ describe('MessageActions', () => {
     global.fetch = originalFetch
   })
 
-  test('records one feedback control impression when the row becomes visible', () => {
-    const { rerender } = render(
-      <React.StrictMode>
-        <MessageActions
-          message="Answer"
-          messageId="visible-1"
-          traceId="trace-1"
-          chatId="chat-1"
-          isGuest
-          status="streaming"
-          visible={false}
-        />
-      </React.StrictMode>
-    )
-
-    expect(captureClient).not.toHaveBeenCalled()
-
-    rerender(
-      <React.StrictMode>
-        <MessageActions
-          message="Answer"
-          messageId="visible-1"
-          traceId="trace-1"
-          chatId="chat-1"
-          isGuest
-          status="ready"
-          visible
-        />
-      </React.StrictMode>
-    )
-
-    expect(captureClient).toHaveBeenCalledTimes(1)
-    expect(captureClient).toHaveBeenCalledWith('feedback_control_shown', {
-      hasTraceId: true,
-      hasFeedback: false,
-      chatId: 'chat-1',
-      isGuest: true
-    })
-
-    rerender(
-      <React.StrictMode>
-        <MessageActions
-          className="parent-state-changed"
-          message="Answer"
-          messageId="visible-1"
-          traceId="trace-1"
-          chatId="chat-1"
-          isGuest
-          status="ready"
-          visible
-        />
-      </React.StrictMode>
-    )
-
-    expect(captureClient).toHaveBeenCalledTimes(1)
-  })
-
-  test('does not record a second impression when the same message remounts', () => {
-    const props = {
-      message: 'Answer',
-      messageId: 'remount-1',
-      traceId: 'trace-1',
-      chatId: 'chat-1',
-      status: 'ready' as const,
-      visible: true
-    }
-
-    const first = render(<MessageActions {...props} />)
-    expect(captureClient).toHaveBeenCalledTimes(1)
-
-    // Reopening a conversation remounts every past answer.
-    first.unmount()
-    render(<MessageActions {...props} />)
-
-    expect(captureClient).toHaveBeenCalledTimes(1)
-  })
-
-  test('reports a message that already carries a score as such', () => {
+  test('does not record an event when the feedback control is shown', () => {
     render(
       <MessageActions
         message="Answer"
-        messageId="scored-1"
+        messageId="feedback-shown-1"
         traceId="trace-1"
-        feedbackScore={-1}
         chatId="chat-1"
         status="ready"
         visible
       />
     )
 
-    expect(captureClient).toHaveBeenCalledWith('feedback_control_shown', {
-      hasTraceId: true,
-      hasFeedback: true,
-      chatId: 'chat-1',
-      isGuest: false
-    })
-  })
-
-  test('records a missing trace id for a newly presented message', () => {
-    render(
-      <MessageActions
-        message="First answer"
-        messageId="no-trace-1"
-        chatId="chat-1"
-        status="ready"
-        visible
-      />
-    )
-
-    expect(captureClient).toHaveBeenCalledTimes(1)
-    expect(captureClient).toHaveBeenLastCalledWith('feedback_control_shown', {
-      hasTraceId: false,
-      hasFeedback: false,
-      chatId: 'chat-1',
-      isGuest: false
-    })
+    expect(captureClient).not.toHaveBeenCalled()
   })
 
   test('records a thumbs up click and successful feedback response', async () => {

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import Link from 'next/link'
 
 import { UseChatHelpers } from '@ai-sdk/react'
@@ -32,9 +32,6 @@ import {
 } from './ui/dialog'
 import { ChatShare } from './chat-share'
 import { RetryButton } from './retry-button'
-
-// Module scope so the impression survives remounts of the same message.
-const reportedFeedbackControls = new Set<string>()
 
 interface MessageActionsProps {
   message: string
@@ -83,25 +80,6 @@ export function MessageActions({
   const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false)
   const isLoading = status === 'submitted' || status === 'streaming'
   const showSaveButton = libraryAvailable && (!isGuest || isCloudDeployment)
-
-  useEffect(() => {
-    if (!visible || isLoading || reportedFeedbackControls.has(messageId)) {
-      return
-    }
-
-    // A control that was never offered is otherwise indistinguishable from one
-    // that was offered and ignored, so the impression is what makes the click
-    // counts readable. It has to be one per message rather than one per mount:
-    // reopening a conversation remounts every past answer, and an answer that
-    // already carries a score cannot produce another one.
-    reportedFeedbackControls.add(messageId)
-    captureClient('feedback_control_shown', {
-      hasTraceId: Boolean(traceId),
-      hasFeedback: feedbackScore !== null,
-      chatId,
-      isGuest
-    })
-  }, [chatId, feedbackScore, isGuest, isLoading, messageId, traceId, visible])
 
   // Keep the element mounted during loading to preserve layout; otherwise skip rendering.
   if (!visible && !isLoading) {


### PR DESCRIPTION
## Problem

`feedback_control_shown` fires whenever a completed assistant answer is presented. It was introduced in #968 to determine whether sparse feedback resulted from users ignoring the control or from the control not rendering because a trace ID was missing.

That delivery question is now settled, and #981 instruments the interaction path directly through `feedback_control_clicked`, `feedback_recorded`, and `feedback_failed`. The impression event therefore continues generating one client event per presented answer without answering an active question.

## Decision

Drop the impression event, following the precedent established in #896.

This explicitly retires the offered-control denominator. Feedback usage should now be read from direct click and outcome events rather than treating `feedback_control_shown` as a continuing exposure metric. There are no checked-in dashboards, queries, or other consumers that require migration.

## Changes

- Remove the `feedback_control_shown` effect and its module-level deduplication set.
- Remove tests covering the retired impression behavior.
- Add a regression test confirming that rendering the feedback control does not emit an analytics event.
- Keep `feedback_control_clicked`, `feedback_recorded`, and `feedback_failed` unchanged.

## Verification

- `bun lint`
- `bun typecheck`
- `bun format:check`
- `bun run test` — 560 passed, 3 skipped
- `bun run build`

Closes #984