### PR TITLE
feat(tracing): record the turn's carried context weight by kind

### DIFF
--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -435,7 +435,10 @@ describe('createChatStreamResponse', () => {
 
     expect(mocks.span.update).toHaveBeenCalledWith({
       input: '"earlier.png" (image/png)',
-      output: 'Answer'
+      output: 'Answer',
+      metadata: {
+        carriedContext: { attachments: 1, attachmentTokens: 10_000 }
+      }
     })
   })
 

--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -236,6 +236,30 @@ describe('createEphemeralChatStreamResponse', () => {
     expect(mocks.stream).not.toHaveBeenCalled()
   })
 
+  it('keeps the carried context and the failure metadata on one update', async () => {
+    const streamError = new Error('stream failed')
+    mocks.stream.mockImplementation(async (options: StreamOptions) => {
+      options.onError({ error: streamError })
+      return createFakeResult()
+    })
+
+    await createEphemeralChatStreamResponse(
+      createConfigWithParts([
+        { type: 'data-pastedContent', data: { text: 'ab' } }
+      ])
+    )
+    await mocks.finishPromise
+
+    const update = mocks.span.update.mock.calls.at(-1)?.[0]
+    expect(update).toMatchObject({
+      level: 'ERROR',
+      metadata: {
+        carriedContext: { pastedChars: 2 },
+        streamErrorPhase: 'generation'
+      }
+    })
+  })
+
   it('omits the output when the answer is only whitespace', async () => {
     mocks.stream.mockResolvedValue(
       createFakeResult({ parts: [{ type: 'text', text: '   \n' }] })
@@ -367,7 +391,10 @@ describe('createEphemeralChatStreamResponse', () => {
 
     expect(mocks.span.update).toHaveBeenCalledWith({
       input: '"report.pdf" (application/pdf)',
-      output: 'Answer'
+      output: 'Answer',
+      metadata: {
+        carriedContext: { attachments: 1, attachmentTokens: 50_000 }
+      }
     })
   })
 
@@ -383,7 +410,8 @@ describe('createEphemeralChatStreamResponse', () => {
 
     expect(mocks.span.update).toHaveBeenCalledWith({
       input: 'pasted content (600 characters)',
-      output: 'Answer'
+      output: 'Answer',
+      metadata: { carriedContext: { pastedChars: 600 } }
     })
     expect(JSON.stringify(mocks.span.update.mock.calls)).not.toContain('secret')
   })
@@ -422,7 +450,14 @@ describe('createEphemeralChatStreamResponse', () => {
 
     expect(mocks.span.update).toHaveBeenCalledWith({
       input: '"notes.txt" (text/plain), pasted content (2 characters)',
-      output: 'Answer'
+      output: 'Answer',
+      metadata: {
+        carriedContext: {
+          attachments: 1,
+          attachmentTokens: 50_000,
+          pastedChars: 2
+        }
+      }
     })
   })
 

--- a/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-ephemeral-chat-stream-response.test.ts
@@ -10,7 +10,8 @@ const mocks = vi.hoisted(() => ({
   },
   forceFlush: vi.fn(),
   finishPromise: Promise.resolve(),
-  serializedError: undefined as string | undefined
+  serializedError: undefined as string | undefined,
+  shouldTruncateMessages: vi.fn(() => false)
 }))
 
 vi.mock('ai', () => ({
@@ -37,6 +38,11 @@ vi.mock('@/instrumentation', () => ({
 
 vi.mock('@/lib/agents/researcher', () => ({
   researcher: vi.fn(() => ({ stream: mocks.stream }))
+}))
+
+vi.mock('@/lib/utils/context-window', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/utils/context-window')>()),
+  shouldTruncateMessages: mocks.shouldTruncateMessages
 }))
 
 vi.mock('@/lib/utils/telemetry', () => ({
@@ -256,6 +262,26 @@ describe('createEphemeralChatStreamResponse', () => {
       metadata: {
         carriedContext: { pastedChars: 2 },
         streamErrorPhase: 'generation'
+      }
+    })
+  })
+
+  it('flags a turn whose converted history hit the context window', async () => {
+    mocks.shouldTruncateMessages.mockReturnValueOnce(true)
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createEphemeralChatStreamResponse(
+      createConfigWithParts([
+        { type: 'data-pastedContent', data: { text: 'ab' } }
+      ])
+    )
+    await mocks.finishPromise
+
+    const update = mocks.span.update.mock.calls.at(-1)?.[0]
+    expect(update).toMatchObject({
+      metadata: {
+        carriedContext: { pastedChars: 2 },
+        contextWindowTruncated: true
       }
     })
   })

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -45,6 +45,7 @@ import {
   type StreamErrorStage
 } from './helpers/stream-error-diagnostics'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
+import { summarizeCarriedContext } from './helpers/summarize-carried-context'
 import type { StreamContext } from './helpers/types'
 import { BaseStreamConfig } from './types'
 
@@ -113,6 +114,7 @@ export async function createChatStreamResponse(
     // carries no incoming message, so its input comes from the prepared history.
     let rootInput = describeTurnInput(message?.parts)
     let rootOutput: string | undefined
+    let carriedContext: Record<string, number> | undefined
 
     const endTracing = async () => {
       if (rootSpan) {
@@ -132,10 +134,22 @@ export async function createChatStreamResponse(
         // whatever was streamed before it. That is not the turn's answer, so
         // it is not recorded as one.
         const hasAnswer = !hasStreamError && !hasEmptyResponse
+        // A failure update carries its own metadata (#945), so the two are
+        // merged rather than spread as siblings: whichever came last would
+        // otherwise drop the other one entirely.
+        const failureMetadata =
+          failureUpdate && 'metadata' in failureUpdate
+            ? failureUpdate.metadata
+            : undefined
+        const metadata = {
+          ...(carriedContext !== undefined && { carriedContext }),
+          ...failureMetadata
+        }
         const update = {
           ...(rootInput !== undefined && { input: rootInput }),
           ...(hasAnswer && rootOutput !== undefined && { output: rootOutput }),
-          ...failureUpdate
+          ...failureUpdate,
+          ...(Object.keys(metadata).length > 0 && { metadata })
         }
         if (Object.keys(update).length > 0) rootSpan.update(update)
         rootSpan.end()
@@ -195,6 +209,7 @@ export async function createChatStreamResponse(
           compactHistoricalMessages(messagesWithAttachmentSizes)
         )
       )
+      carriedContext = summarizeCarriedContext(messagesToConvert)
 
       // Convert to model messages and apply context window management
       streamErrorStage = 'convert-messages'

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -115,6 +115,7 @@ export async function createChatStreamResponse(
     let rootInput = describeTurnInput(message?.parts)
     let rootOutput: string | undefined
     let carriedContext: Record<string, number> | undefined
+    let contextWindowTruncated = false
 
     const endTracing = async () => {
       if (rootSpan) {
@@ -143,6 +144,7 @@ export async function createChatStreamResponse(
             : undefined
         const metadata = {
           ...(carriedContext !== undefined && { carriedContext }),
+          ...(contextWindowTruncated && { contextWindowTruncated }),
           ...failureMetadata
         }
         const update = {
@@ -222,6 +224,7 @@ export async function createChatStreamResponse(
         const maxTokens = getMaxAllowedTokens(model)
         const originalCount = modelMessages.length
         modelMessages = truncateMessages(modelMessages, maxTokens, model.id)
+        contextWindowTruncated = true
 
         if (process.env.NODE_ENV === 'development') {
           console.log(

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -39,6 +39,7 @@ import {
   type StreamErrorStage
 } from './helpers/stream-error-diagnostics'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
+import { summarizeCarriedContext } from './helpers/summarize-carried-context'
 import { BaseStreamConfig } from './types'
 
 import { langfuseSpanProcessor } from '@/instrumentation'
@@ -83,6 +84,7 @@ export async function createEphemeralChatStreamResponse(
       messages.findLast(m => m.role === 'user')?.parts
     )
     let rootOutput: string | undefined
+    let carriedContext: Record<string, number> | undefined
 
     const endTracing = async () => {
       if (rootSpan) {
@@ -102,10 +104,22 @@ export async function createEphemeralChatStreamResponse(
         // whatever was streamed before it. That is not the turn's answer, so
         // it is not recorded as one.
         const hasAnswer = !hasStreamError && !hasEmptyResponse
+        // A failure update carries its own metadata (#945), so the two are
+        // merged rather than spread as siblings: whichever came last would
+        // otherwise drop the other one entirely.
+        const failureMetadata =
+          failureUpdate && 'metadata' in failureUpdate
+            ? failureUpdate.metadata
+            : undefined
+        const metadata = {
+          ...(carriedContext !== undefined && { carriedContext }),
+          ...failureMetadata
+        }
         const update = {
           ...(rootInput !== undefined && { input: rootInput }),
           ...(hasAnswer && rootOutput !== undefined && { output: rootOutput }),
-          ...failureUpdate
+          ...failureUpdate,
+          ...(Object.keys(metadata).length > 0 && { metadata })
         }
         if (Object.keys(update).length > 0) rootSpan.update(update)
         rootSpan.end()
@@ -119,6 +133,7 @@ export async function createEphemeralChatStreamResponse(
       const messagesToConvert = dedupeAttachments(
         capHistoricalAttachments(compactHistoricalMessages(messagesWithoutSpec))
       )
+      carriedContext = summarizeCarriedContext(messagesToConvert)
 
       streamErrorStage = 'convert-messages'
       let modelMessages = await convertToModelMessages(messagesToConvert, {

--- a/lib/streaming/create-ephemeral-chat-stream-response.ts
+++ b/lib/streaming/create-ephemeral-chat-stream-response.ts
@@ -85,6 +85,7 @@ export async function createEphemeralChatStreamResponse(
     )
     let rootOutput: string | undefined
     let carriedContext: Record<string, number> | undefined
+    let contextWindowTruncated = false
 
     const endTracing = async () => {
       if (rootSpan) {
@@ -113,6 +114,7 @@ export async function createEphemeralChatStreamResponse(
             : undefined
         const metadata = {
           ...(carriedContext !== undefined && { carriedContext }),
+          ...(contextWindowTruncated && { contextWindowTruncated }),
           ...failureMetadata
         }
         const update = {
@@ -144,6 +146,7 @@ export async function createEphemeralChatStreamResponse(
       if (shouldTruncateMessages(modelMessages, model)) {
         const maxTokens = getMaxAllowedTokens(model)
         modelMessages = truncateMessages(modelMessages, maxTokens, model.id)
+        contextWindowTruncated = true
       }
 
       streamErrorStage = 'build-agent'

--- a/lib/streaming/helpers/__tests__/summarize-carried-context.test.ts
+++ b/lib/streaming/helpers/__tests__/summarize-carried-context.test.ts
@@ -1,0 +1,70 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { summarizeCarriedContext } from '@/lib/streaming/helpers/summarize-carried-context'
+import { IMAGE_ATTACHMENT_TOKENS } from '@/lib/utils/attachment-tokens'
+
+function createMessages(parts: unknown[]): UIMessage[] {
+  return [{ id: 'message-1', role: 'user', parts: parts as UIMessage['parts'] }]
+}
+
+describe('summarizeCarriedContext', () => {
+  it('returns undefined for text-only history', () => {
+    expect(
+      summarizeCarriedContext(createMessages([{ type: 'text', text: 'hello' }]))
+    ).toBeUndefined()
+  })
+
+  it('counts file parts and their estimated tokens', () => {
+    expect(
+      summarizeCarriedContext(
+        createMessages([
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            url: 'https://example.com/a'
+          },
+          {
+            type: 'file',
+            mediaType: 'application/pdf',
+            size: 39,
+            url: 'https://example.com/b'
+          }
+        ])
+      )
+    ).toEqual({
+      attachments: 2,
+      attachmentTokens: IMAGE_ATTACHMENT_TOKENS + 10
+    })
+  })
+
+  it('counts each structured text kind by characters', () => {
+    expect(
+      summarizeCarriedContext(
+        createMessages([
+          { type: 'data-pastedContent', data: { text: 'paste' } },
+          { type: 'data-quotedContext', data: { text: 'quote' } },
+          { type: 'data-noteContext', data: { text: 'note' } }
+        ])
+      )
+    ).toEqual({ pastedChars: 5, quotedChars: 5, noteChars: 4 })
+  })
+
+  it('omits zero-valued keys and ignores non-string data text', () => {
+    expect(
+      summarizeCarriedContext(
+        createMessages([
+          {
+            type: 'file',
+            mediaType: 'application/pdf',
+            size: 0,
+            url: 'https://example.com/a'
+          },
+          { type: 'data-pastedContent', data: { text: '' } },
+          { type: 'data-quotedContext', data: { text: 42 } },
+          { type: 'data-noteContext', data: { text: null } }
+        ])
+      )
+    ).toEqual({ attachments: 1 })
+  })
+})

--- a/lib/streaming/helpers/summarize-carried-context.ts
+++ b/lib/streaming/helpers/summarize-carried-context.ts
@@ -18,8 +18,14 @@ import { isFilePart } from './attachment-parts'
  *
  * Run this on the messages that are about to be converted, after the history
  * guards. An attachment they turned into a placeholder is a text part by then
- * and is correctly not counted, so this reports what reached the model rather
- * than what the conversation holds.
+ * and is correctly not counted, so this reports the weight the guards left
+ * rather than what the conversation holds.
+ *
+ * It cannot be taken any later than that: `truncateMessages` runs on converted
+ * messages, where a pasted block is already indistinguishable from any other
+ * text, so the kinds this reports no longer exist there. A turn that reached
+ * that last resort therefore carries less than this says, and is flagged with
+ * `contextWindowTruncated` so the two cases are never confused.
  */
 export function summarizeCarriedContext(
   messages: UIMessage[]

--- a/lib/streaming/helpers/summarize-carried-context.ts
+++ b/lib/streaming/helpers/summarize-carried-context.ts
@@ -1,0 +1,59 @@
+import type { UIMessage } from 'ai'
+
+import { estimateAttachmentTokens } from '@/lib/utils/attachment-tokens'
+
+import { isFilePart } from './attachment-parts'
+
+/**
+ * The weight a turn carries in structured parts, split by kind.
+ *
+ * An attachment and a pasted block are the same thing to a bill: both are
+ * replayed on every later turn and both can be the largest thing in a request.
+ * The trace could not tell them apart, because `describeTurnInput` summarizes
+ * structured parts only when the turn has no typed text, and nothing described
+ * the history at all.
+ *
+ * Kind and size only, never content, for the same reason `describeTurnInput`
+ * gives: the content itself already reaches the child generations.
+ *
+ * Run this on the messages that are about to be converted, after the history
+ * guards. An attachment they turned into a placeholder is a text part by then
+ * and is correctly not counted, so this reports what reached the model rather
+ * than what the conversation holds.
+ */
+export function summarizeCarriedContext(
+  messages: UIMessage[]
+): Record<string, number> | undefined {
+  let attachments = 0
+  let attachmentTokens = 0
+  let pastedChars = 0
+  let quotedChars = 0
+  let noteChars = 0
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (isFilePart(part)) {
+        attachments += 1
+        attachmentTokens += estimateAttachmentTokens(part)
+        continue
+      }
+
+      const text = (part as { data?: { text?: unknown } }).data?.text
+      if (typeof text !== 'string') continue
+
+      if (part.type === 'data-pastedContent') pastedChars += text.length
+      if (part.type === 'data-quotedContext') quotedChars += text.length
+      if (part.type === 'data-noteContext') noteChars += text.length
+    }
+  }
+
+  const summary = {
+    ...(attachments > 0 && { attachments }),
+    ...(attachmentTokens > 0 && { attachmentTokens }),
+    ...(pastedChars > 0 && { pastedChars }),
+    ...(quotedChars > 0 && { quotedChars }),
+    ...(noteChars > 0 && { noteChars })
+  }
+
+  return Object.keys(summary).length > 0 ? summary : undefined
+}


### PR DESCRIPTION
Refs #986.

## Problem

Nothing in tracing says how much of a request is carried structured content, or which kind it is. An attachment and a pasted block behave the same way economically: both are replayed on every later turn, and either can be the largest thing in the request. Today they cannot be told apart after the fact, so a thread that is expensive because of one is indistinguishable from a thread that is expensive because of the other.

## Root cause

`describeTurnInput` summarizes structured parts only when the turn carries no typed text (see its doc comment: typed text is the input whenever there is any). A turn with both a paste and a sentence of text records the sentence alone. Nothing summarizes the replayed history at all, at any weight.

## Fix

Instrumentation only. Nothing about what is sent to the model changes.

- New `summarizeCarriedContext` totals, by kind, the attachment count, the estimated attachment tokens, and the character counts of pasted, quoted, and note context. Kind and size only, never content, on the same rule `describeTurnInput` already states.
- It runs on the message array that is about to be converted, after the history guards. An attachment those guards turned into a placeholder is a text part by then and is correctly not counted, so the record describes what reached the model rather than what the conversation holds.
- Zero-valued keys are omitted and an all-zero turn returns nothing, so an ordinary text turn adds no metadata.
- The result goes on the root `research` observation's metadata.

One thing worth calling out in review: the failure update built by `buildStreamErrorSpanUpdate` already carries its own `metadata` (the #945 diagnostics). Spreading a second `metadata` key beside it would have silently dropped one of the two depending on order, so the two objects are merged and the failure keys win on collision. A test asserts a failing turn keeps both.

## Verification

- `bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test` all pass.
- New unit tests for the helper: text-only history summarizes to nothing, file parts contribute a count and an estimate, each structured text kind contributes its characters, zero-valued keys are absent, and a non-string `data.text` contributes nothing.
- The four existing root-span assertions that pin the exact update object are extended with the new metadata, which is what documents the change in behavior. The existing assertion that pasted content never reaches the span still holds unchanged.
- New test covering the metadata merge on a failing turn.
