### PR TITLE
fix(tools): read JSON and plain text in the regular fetch path

### DIFF
--- a/lib/tools/__tests__/fetch.test.ts
+++ b/lib/tools/__tests__/fetch.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchTool } from '@/lib/tools/fetch'
+
+const url = 'https://example.com/resource'
+
+async function fetchRegular(body: string, contentType: string) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(body, { headers: { 'content-type': contentType } })
+    )
+  )
+
+  const result = fetchTool.execute?.(
+    { url, type: 'regular' },
+    { toolCallId: 'fetch', messages: [], context: {} }
+  )
+  const iterator = (result as AsyncIterable<unknown>)[Symbol.asyncIterator]()
+
+  await iterator.next()
+  return iterator.next()
+}
+
+describe('regular fetch content types', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('returns JSON verbatim', async () => {
+    const body = '{\n  "markup": "<value>",\n  "spaced": "a   b"\n}'
+    const result = await fetchRegular(body, 'application/json; charset=utf-8')
+
+    expect(result.value).toMatchObject({
+      results: [{ content: body, title: 'example.com', url }],
+      state: 'complete'
+    })
+  })
+
+  it('accepts structured JSON media types', async () => {
+    const result = await fetchRegular('{"data":[]}', 'application/vnd.api+json')
+
+    expect(result.value).toMatchObject({ state: 'complete' })
+  })
+
+  it('returns plain text without tag stripping', async () => {
+    const body = 'Keep <literal> tags and   whitespace.'
+    const result = await fetchRegular(body, 'text/plain')
+
+    expect(result.value).toMatchObject({ results: [{ content: body }] })
+  })
+
+  it('continues to process HTML content', async () => {
+    const result = await fetchRegular(
+      '<html><title>Page title</title><body>Hello <strong>world</strong><script>bad()</script></body></html>',
+      'text/html'
+    )
+
+    expect(result.value).toMatchObject({
+      results: [{ content: 'Page title Hello world', title: 'Page title' }]
+    })
+  })
+
+  it('rejects unsupported content types', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = fetchRegular('PDF', 'application/pdf')
+
+    await expect(result).rejects.toThrow(
+      'Unsupported content type: application/pdf'
+    )
+  })
+})

--- a/lib/tools/fetch.ts
+++ b/lib/tools/fetch.ts
@@ -39,39 +39,47 @@ async function fetchRegularData(url: string): Promise<SearchResultsType> {
     }
 
     const contentType = response.headers.get('content-type') || ''
-    if (
-      !contentType.includes('text/html') &&
-      !contentType.includes('text/plain')
-    ) {
+    // The request above accepts anything, so refusing everything that is not
+    // markup turns readable text into a dead end: a JSON endpoint is the usual
+    // case. Structured bodies take the passthrough below instead of the markup
+    // pipeline, whose tag stripping deletes any run between angle brackets.
+    const mediaType = contentType.split(';', 1)[0].trim().toLowerCase()
+    const isHtmlContent =
+      mediaType === 'text/html' || mediaType === 'application/xhtml+xml'
+    const isTextContent =
+      mediaType === 'text/plain' ||
+      mediaType === 'application/json' ||
+      mediaType.endsWith('+json')
+
+    if (!isHtmlContent && !isTextContent) {
       throw new Error(`Unsupported content type: ${contentType}`)
     }
 
-    const html = await response.text()
+    const body = await response.text()
 
-    // Extract title
-    const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i)
+    const titleMatch = isHtmlContent
+      ? body.match(/<title[^>]*>([^<]*)<\/title>/i)
+      : null
     const rawTitle = titleMatch ? titleMatch[1].trim() : new URL(url).hostname
     const title =
       rawTitle.length > TITLE_CHARACTER_LIMIT
         ? rawTitle.substring(0, TITLE_CHARACTER_LIMIT) + '...'
         : rawTitle
 
-    // Process HTML content
-    let processedHtml = html
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '') // Remove scripts
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '') // Remove styles
-
-    // Replace img tags with alt text or [IMAGE] markers
-    processedHtml = processedHtml
-      .replace(/<img[^>]+alt\s*=\s*["']([^"']+)["'][^>]*>/gi, ' [IMAGE: $1] ')
-      .replace(/<img[^>]+src\s*=\s*["']([^"']+)["'][^>]*>/gi, ' [IMAGE] ')
-      .replace(/<img[^>]*>/gi, ' [IMAGE] ')
-
-    // Extract text content
-    const textContent = processedHtml
-      .replace(/<[^>]*>/g, ' ') // Remove remaining HTML tags
-      .replace(/\s+/g, ' ') // Normalize whitespace
-      .trim()
+    const textContent = isHtmlContent
+      ? body
+          .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '') // Remove scripts
+          .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '') // Remove styles
+          .replace(
+            /<img[^>]+alt\s*=\s*["']([^"']+)["'][^>]*>/gi,
+            ' [IMAGE: $1] '
+          )
+          .replace(/<img[^>]+src\s*=\s*["']([^"']+)["'][^>]*>/gi, ' [IMAGE] ')
+          .replace(/<img[^>]*>/gi, ' [IMAGE] ')
+          .replace(/<[^>]*>/g, ' ') // Remove remaining HTML tags
+          .replace(/\s+/g, ' ') // Normalize whitespace
+          .trim()
+      : body
 
     // Limit content length
     const truncatedContent =


### PR DESCRIPTION
## Problem

The `regular` fetch type refuses JSON. `fetchRegularData` sends
`Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`, so it asks the server
for anything, then throws `Unsupported content type: <type>` on everything that is not
`text/html` or `text/plain`. A JSON API response or a `.json` file fails deterministically, and the
user sees a tool failure for a URL that is perfectly readable text. The tool description warns the
model that `regular` cannot do PDFs and says nothing about JSON, so nothing routes those URLs to
the `api` type either.

The same function has a second, quieter problem: everything accepted goes through the markup
pipeline, `text/plain` included. `.replace(/<[^>]*>/g, ' ')` deletes any run between angle
brackets, so a plain-text body containing `<` and `>` comes back with the material between them
silently removed.

## Root cause

One accept list and one processing path for two different kinds of body. The list was written
around what the markup pipeline can consume rather than around what the model can read, and
nothing routes a non-markup body past that pipeline.

## Fix

Confined to `fetchRegularData`.

- The content type is parsed into a media type instead of substring-matched, then split into two
  routes: markup (`text/html`, `application/xhtml+xml`) keeps the existing pipeline unchanged, and
  text (`text/plain`, `application/json`, any `+json` subtype) is returned as-is.
- Anything else still throws, with the message byte-identical to before, so the existing error
  descriptions and their tests are untouched.
- The text route does not run the `<title>` regex and falls back to the hostname, which is the
  same title the markup route already uses for a page without one.
- `CONTENT_CHARACTER_LIMIT` and `TITLE_CHARACTER_LIMIT` apply to both routes as before.

Deliberately not widened to a blanket `text/*`, and `fetchJinaReaderData`, `fetchTavilyExtractData`
and the tool description are untouched.

## Verification

- `bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test` all pass.
- New tests for `fetchRegularData` with a mocked global fetch: a JSON body survives verbatim
  (asserted on a payload holding `<` and `>` inside a string value and on preserved runs of
  whitespace), a vendor `+json` type is accepted, plain text comes back without tag stripping,
  HTML still gets its script removed and its title extracted, and an unsupported type still throws
  the same message.
