### PR TITLE
feat: add Serping API search provider

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -74,6 +74,10 @@ TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]
 # Get your API key at: https://www.firecrawl.dev/app
 # FIRECRAWL_API_KEY=[YOUR_FIRECRAWL_API_KEY]
 
+# Option 4: Serping API (Real-time Google search results)
+# Get your API key at: https://serpingapi.com/
+# SERPINGAPI_API_KEY=[YOUR_SERPINGAPI_API_KEY]
+
 # Brave Search (Optional - video/image support for general searches)
 # Get your API key at: https://brave.com/search/api/
 # BRAVE_SEARCH_API_KEY=[YOUR_BRAVE_SEARCH_API_KEY]
@@ -113,7 +117,7 @@ ANONYMOUS_USER_ID=anonymous-user
 # Search Configuration
 # -----------------------------------------------------------------------------
 # Select search provider (default: tavily)
-# SEARCH_API=tavily  # Options: tavily, searxng, exa, firecrawl
+# SEARCH_API=tavily  # Options: tavily, searxng, exa, firecrawl, serpingapi
 
 # SearXNG (Self-hosted)
 # SEARXNG_API_URL=http://localhost:8080

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -173,6 +173,15 @@ SEARXNG_LIMITER=false
 
 Modify `searxng-settings.yml` to enable/disable specific search engines, change UI settings, or adjust server options. See the [SearXNG documentation](https://docs.searxng.org/admin/settings/settings.html#settings-yml) for details.
 
+### Serping API
+
+Serping API provides real-time Google search results. The free tier includes 250 searches per month.
+
+```bash
+SEARCH_API=serpingapi
+SERPINGAPI_API_KEY=[YOUR_SERPINGAPI_API_KEY]
+```
+
 ### Brave Search (Optional)
 
 Brave Search provides enhanced support for video and image searches:

--- a/lib/tools/search/providers/index.ts
+++ b/lib/tools/search/providers/index.ts
@@ -3,6 +3,7 @@ import { BraveSearchProvider } from './brave'
 import { ExaSearchProvider } from './exa'
 import { FirecrawlSearchProvider } from './firecrawl'
 import { SearXNGSearchProvider } from './searxng'
+import { SerpingApiSearchProvider } from './serpingapi'
 import { TavilySearchProvider } from './tavily'
 
 export type SearchProviderType =
@@ -11,6 +12,7 @@ export type SearchProviderType =
   | 'searxng'
   | 'firecrawl'
   | 'brave'
+  | 'serpingapi'
 export const DEFAULT_PROVIDER: SearchProviderType = 'tavily'
 
 export function createSearchProvider(
@@ -30,6 +32,8 @@ export function createSearchProvider(
       return new BraveSearchProvider()
     case 'firecrawl':
       return new FirecrawlSearchProvider()
+    case 'serpingapi':
+      return new SerpingApiSearchProvider()
     default:
       // Default to TavilySearchProvider if an unknown provider is specified
       return new TavilySearchProvider()
@@ -40,5 +44,6 @@ export { BraveSearchProvider } from './brave'
 export type { ExaSearchProvider } from './exa'
 export type { FirecrawlSearchProvider } from './firecrawl'
 export { SearXNGSearchProvider } from './searxng'
+export { SerpingApiSearchProvider } from './serpingapi'
 export { TavilySearchProvider } from './tavily'
 export type { SearchProvider }

--- a/lib/tools/search/providers/serpingapi.ts
+++ b/lib/tools/search/providers/serpingapi.ts
@@ -1,0 +1,60 @@
+import { SearchResults } from '@/lib/types'
+
+import { BaseSearchProvider } from './base'
+
+interface SerpingApiOrganicResult {
+  title?: string
+  link: string
+  snippet?: string
+  position?: number
+}
+
+export class SerpingApiSearchProvider extends BaseSearchProvider {
+  async search(
+    query: string,
+    maxResults: number = 10,
+    _searchDepth: 'basic' | 'advanced' = 'basic',
+    includeDomains: string[] = [],
+    excludeDomains: string[] = []
+  ): Promise<SearchResults> {
+    const apiKey = process.env.SERPINGAPI_API_KEY
+    this.validateApiKey(apiKey, 'SERPINGAPI')
+
+    const response = await fetch('https://api.serpingapi.com/v1/search', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey
+      },
+      body: JSON.stringify({
+        q: query,
+        num: Math.min(Math.max(maxResults, 1), 100)
+        // Note: the Serping API does not support includeDomains/excludeDomains
+      })
+    })
+
+    if (!response.ok) {
+      console.error(
+        `Serping API error: ${response.status} ${response.statusText}`
+      )
+      throw this.createHttpError(response, 'Serping API')
+    }
+
+    const data = await response.json()
+    const results = ((data.organic as SerpingApiOrganicResult[]) ?? [])
+      .filter(result => result.link)
+      .slice(0, maxResults)
+      .map(result => ({
+        title: result.title || 'No title',
+        url: result.link,
+        content: result.snippet || ''
+      }))
+
+    return {
+      results,
+      query,
+      images: [],
+      number_of_results: results.length
+    }
+  }
+}


### PR DESCRIPTION
This adds [serpingapi.com](https://serpingapi.com) as a search provider option (`SEARCH_API=serpingapi`).

**Disclosure: I run this service.** It's a small SERP API (real-time Google results as JSON, one POST endpoint); the free tier is 250 searches/month with no credit card, which makes it an easy default for self-hosters trying out Morphic. Happy to adjust anything to fit the project's conventions.

### Changes

- `lib/tools/search/providers/serpingapi.ts` — new provider extending `BaseSearchProvider`, modeled on the Tavily/Brave providers: POST to `/v1/search` with `X-API-Key` auth, maps `organic[]` (`title`/`link`/`snippet`) into `SearchResults` items (`title`/`url`/`content`)
- `lib/tools/search/providers/index.ts` — adds `serpingapi` to `SearchProviderType` and the factory
- `.env.local.example` — documents `SERPINGAPI_API_KEY` and adds `serpingapi` to the `SEARCH_API` options
- `docs/CONFIGURATION.md` — short section under Search Providers

### Notes

- Like Firecrawl, the API doesn't support `includeDomains`/`excludeDomains`, so those are accepted but not forwarded (noted in a comment).
- It returns web results only; `images` is returned empty and video/image `content_types` remain the domain of the dedicated general provider (Brave), unchanged.
- Errors go through `createHttpError` so the recoverable-error fallback classification works as with the other fetch-based providers.

`bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (614 passed) and `bun run build` all pass.
