### PR TITLE
fix(errors): classify deterministic preparation failures

### DIFF
--- a/lib/errors/__tests__/public-error.test.ts
+++ b/lib/errors/__tests__/public-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { DeterministicPreparationError } from '@/lib/errors/deterministic-preparation-error'
 import {
   createPublicErrorResponse,
   getPublicRateLimitDetails,
@@ -220,6 +221,45 @@ describe('public error mapping', () => {
       'Retrying this message will fail the same way.'
     )
     expect(payload.retryable).toBe(false)
+  })
+
+  it('maps deterministic preparation failures to non-retryable copy', () => {
+    const payload = toPublicErrorPayload(
+      new DeterministicPreparationError(
+        'Unknown part type: private-user-content'
+      )
+    )
+
+    expect(payload.code).toBe('malformed_request')
+    expect(payload.error).toBe(
+      'This conversation could not be sent to the model. Please start a new chat.'
+    )
+    expect(payload.details).toBe(
+      'Retrying this message will fail the same way.'
+    )
+    expect(payload.retryable).toBe(false)
+    expect(JSON.stringify(payload)).not.toContain('private-user-content')
+  })
+
+  it('preserves deterministic preparation copy through serialization', () => {
+    const serialized = serializePublicError(
+      new DeterministicPreparationError('No messages found')
+    )
+    const payload = toPublicErrorPayload(new Error(serialized))
+
+    expect(payload.code).toBe('malformed_request')
+    expect(payload.retryable).toBe(false)
+  })
+
+  it('does not trust a foreign deterministic preparation error name', () => {
+    const payload = toPublicErrorPayload({
+      name: 'DeterministicPreparationError',
+      message: 'Unknown part type: private-user-content'
+    })
+
+    expect(payload.code).toBe('unknown')
+    expect(payload.retryable).toBe(true)
+    expect(payload.error).not.toContain('private-user-content')
   })
 
   it('does not honour a malformed_request code carrying foreign copy', () => {

--- a/lib/errors/deterministic-preparation-error.ts
+++ b/lib/errors/deterministic-preparation-error.ts
@@ -1,0 +1,10 @@
+/**
+ * Marks a preparation failure that depends only on the stored conversation or
+ * request state. Replaying the same turn cannot make this failure succeed.
+ */
+export class DeterministicPreparationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DeterministicPreparationError'
+  }
+}

--- a/lib/errors/public-error.ts
+++ b/lib/errors/public-error.ts
@@ -1,3 +1,4 @@
+import { DeterministicPreparationError } from './deterministic-preparation-error'
 import { isToolFailureMessage } from './tool-error'
 
 export type PublicErrorType = 'rate-limit' | 'auth' | 'forbidden' | 'general'
@@ -484,6 +485,16 @@ export function toPublicErrorPayload(
   error: unknown,
   options: PublicErrorOptions = {}
 ): PublicErrorPayload {
+  if (error instanceof DeterministicPreparationError) {
+    return {
+      error: MALFORMED_REQUEST_MESSAGE,
+      code: 'malformed_request',
+      type: 'general',
+      details: MALFORMED_REQUEST_DETAILS,
+      retryable: false
+    }
+  }
+
   if (typeof error === 'string') {
     const parsed = extractJsonCandidate(error)
     if (isRecord(parsed)) {

--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -69,6 +69,7 @@ vi.mock('@/lib/utils/usage-logging', () => ({
 
 import { loadChat, loadChatUncached } from '@/lib/actions/chat'
 import { researcher } from '@/lib/agents/researcher'
+import { DeterministicPreparationError } from '@/lib/errors/deterministic-preparation-error'
 import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'
 import { describeStreamError } from '@/lib/streaming/helpers/describe-stream-error'
 import { EMPTY_RESPONSE_STATUS_MESSAGE } from '@/lib/streaming/helpers/is-empty-response'
@@ -231,6 +232,31 @@ describe('createChatStreamResponse', () => {
         }
       })
     )
+    expect(mocks.stream).not.toHaveBeenCalled()
+  })
+
+  it('maps deterministic initial chat load failures to public errors', async () => {
+    vi.mocked(loadChatUncached).mockRejectedValueOnce(
+      new DeterministicPreparationError(
+        'Unknown part type: private-user-content'
+      )
+    )
+
+    const response = await createChatStreamResponse({
+      ...createConfig(),
+      isNewChat: false
+    })
+    const payload = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(payload).toMatchObject({
+      code: 'malformed_request',
+      retryable: false,
+      error:
+        'This conversation could not be sent to the model. Please start a new chat.'
+    })
+    expect(JSON.stringify(payload)).not.toContain('private-user-content')
+    expect(prepareMessages).not.toHaveBeenCalled()
     expect(mocks.stream).not.toHaveBeenCalled()
   })
 

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -81,11 +81,20 @@ export async function createChatStreamResponse(
   // Skip loading chat for new chats optimization
   let initialChat = null
   if (!isNewChat) {
-    const loadChatStart = performance.now()
-    // Read uncached: the prompt must not be built from a snapshot that
-    // predates the previous turn's answer
-    initialChat = await loadChatUncached(chatId, userId)
-    perfTime('loadChat completed', loadChatStart)
+    try {
+      const loadChatStart = performance.now()
+      // Read uncached: the prompt must not be built from a snapshot that
+      // predates the previous turn's answer
+      initialChat = await loadChatUncached(chatId, userId)
+      perfTime('loadChat completed', loadChatStart)
+    } catch (error) {
+      logAPICallErrorDiagnostics(error)
+      console.error('Initial chat load error:', error)
+      return createPublicErrorResponse(error, {
+        status: 500,
+        statusText: 'Internal Server Error'
+      })
+    }
 
     // Authorization check: if chat exists, it must belong to the user
     if (initialChat && initialChat.userId !== userId) {

--- a/lib/streaming/helpers/__tests__/prepare-messages.test.ts
+++ b/lib/streaming/helpers/__tests__/prepare-messages.test.ts
@@ -7,6 +7,7 @@ import {
   upsertMessage
 } from '@/lib/actions/chat'
 import type { Chat } from '@/lib/db/schema'
+import { DeterministicPreparationError } from '@/lib/errors/deterministic-preparation-error'
 import { signFilePartUrls } from '@/lib/storage/r2-client'
 import type { UIMessage } from '@/lib/types/ai'
 
@@ -280,9 +281,58 @@ describe('prepareMessages', () => {
         isNewChat: false
       }
 
-      await expect(prepareMessages(context, null)).rejects.toThrow(
-        'No messages found'
+      await expect(prepareMessages(context, null)).rejects.toMatchObject({
+        name: DeterministicPreparationError.name,
+        message: 'No messages found'
+      })
+    })
+
+    it('should identify a missing message with no fallback as deterministic', async () => {
+      const initialChat: Chat & { messages: UIMessage[] } = {
+        id: chatId,
+        title: 'Test Chat',
+        userId,
+        visibility: 'private',
+        createdAt: new Date(),
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'system',
+            parts: [{ type: 'text', text: 'System context' }]
+          }
+        ]
+      }
+
+      const context: StreamContext = {
+        chatId,
+        userId,
+        modelId: 'gpt-4',
+        trigger: 'regenerate-message',
+        messageId: 'missing-message',
+        initialChat,
+        isNewChat: false
+      }
+
+      await expect(prepareMessages(context, null)).rejects.toBeInstanceOf(
+        DeterministicPreparationError
       )
+    })
+
+    it('should preserve transient chat loading failures', async () => {
+      const loadError = new Error('Database timeout')
+      vi.mocked(loadChat).mockRejectedValue(loadError)
+
+      const context: StreamContext = {
+        chatId,
+        userId,
+        modelId: 'gpt-4',
+        trigger: 'regenerate-message',
+        messageId: 'msg-1',
+        initialChat: null,
+        isNewChat: false
+      }
+
+      await expect(prepareMessages(context, null)).rejects.toBe(loadError)
     })
 
     it('should use fallback when message not found by ID', async () => {

--- a/lib/streaming/helpers/prepare-messages.ts
+++ b/lib/streaming/helpers/prepare-messages.ts
@@ -8,6 +8,7 @@ import {
   upsertMessage
 } from '@/lib/actions/chat'
 import { generateId } from '@/lib/db/schema'
+import { DeterministicPreparationError } from '@/lib/errors/deterministic-preparation-error'
 import {
   getUserFileObjectKeyPrefix,
   signFilePartUrls
@@ -33,7 +34,7 @@ export async function prepareMessages(
       currentChat = await loadChat(chatId, userId)
     }
     if (!currentChat || !currentChat.messages.length) {
-      throw new Error('No messages found')
+      throw new DeterministicPreparationError('No messages found')
     }
 
     let messageIndex = currentChat.messages.findIndex(
@@ -52,7 +53,7 @@ export async function prepareMessages(
       if (lastAssistantIndex >= 0 || lastUserIndex >= 0) {
         messageIndex = Math.max(lastAssistantIndex, lastUserIndex)
       } else {
-        throw new Error(
+        throw new DeterministicPreparationError(
           `Message ${messageId} not found and no fallback available`
         )
       }

--- a/lib/utils/__tests__/message-mapping.test.ts
+++ b/lib/utils/__tests__/message-mapping.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { DeterministicPreparationError } from '@/lib/errors/deterministic-preparation-error'
+import type { DBMessagePartSelect } from '@/lib/types/message-persistence'
+
+import { mapDBPartToUIMessagePart } from '../message-mapping'
+
+function persistedPart(
+  values: Partial<DBMessagePartSelect>
+): DBMessagePartSelect {
+  return values as DBMessagePartSelect
+}
+
+describe('mapDBPartToUIMessagePart', () => {
+  it('identifies an unmappable persisted part as deterministic', () => {
+    expect(() =>
+      mapDBPartToUIMessagePart(persistedPart({ type: 'private-user-content' }))
+    ).toThrow(DeterministicPreparationError)
+  })
+
+  it('identifies a missing persisted tool state as deterministic', () => {
+    expect(() =>
+      mapDBPartToUIMessagePart(
+        persistedPart({ type: 'tool-search', tool_state: null })
+      )
+    ).toThrow(DeterministicPreparationError)
+  })
+})

--- a/lib/utils/message-mapping.ts
+++ b/lib/utils/message-mapping.ts
@@ -1,4 +1,5 @@
 import { generateId } from '@/lib/db/schema'
+import { DeterministicPreparationError } from '@/lib/errors/deterministic-preparation-error'
 import type {
   UIDataTypes,
   UIMessage,
@@ -413,7 +414,9 @@ export function mapDBPartToUIMessagePart(
         // Special handling for tool parts that maintain their type
         if (toolName === 'search') {
           if (!part.tool_state) {
-            throw new Error(`tool_state is undefined for ${toolName}`)
+            throw new DeterministicPreparationError(
+              `tool_state is undefined for ${toolName}`
+            )
           }
 
           switch (part.tool_state) {
@@ -448,13 +451,17 @@ export function mapDBPartToUIMessagePart(
                 errorText: part.tool_errorText!
               }
             default:
-              throw new Error(`Unknown tool state: ${part.tool_state}`)
+              throw new DeterministicPreparationError(
+                `Unknown tool state: ${part.tool_state}`
+              )
           }
         }
 
         if (toolName === 'fetch') {
           if (!part.tool_state) {
-            throw new Error(`tool_state is undefined for ${toolName}`)
+            throw new DeterministicPreparationError(
+              `tool_state is undefined for ${toolName}`
+            )
           }
 
           switch (part.tool_state) {
@@ -489,13 +496,17 @@ export function mapDBPartToUIMessagePart(
                 errorText: part.tool_errorText!
               }
             default:
-              throw new Error(`Unknown tool state: ${part.tool_state}`)
+              throw new DeterministicPreparationError(
+                `Unknown tool state: ${part.tool_state}`
+              )
           }
         }
 
         if (toolName === 'question') {
           if (!part.tool_state) {
-            throw new Error(`tool_state is undefined for ${toolName}`)
+            throw new DeterministicPreparationError(
+              `tool_state is undefined for ${toolName}`
+            )
           }
 
           switch (part.tool_state) {
@@ -530,13 +541,17 @@ export function mapDBPartToUIMessagePart(
                 errorText: part.tool_errorText!
               }
             default:
-              throw new Error(`Unknown tool state: ${part.tool_state}`)
+              throw new DeterministicPreparationError(
+                `Unknown tool state: ${part.tool_state}`
+              )
           }
         }
 
         if (toolName === 'todoWrite') {
           if (!part.tool_state) {
-            throw new Error(`tool_state is undefined for ${toolName}`)
+            throw new DeterministicPreparationError(
+              `tool_state is undefined for ${toolName}`
+            )
           }
 
           switch (part.tool_state) {
@@ -571,13 +586,17 @@ export function mapDBPartToUIMessagePart(
                 errorText: part.tool_errorText!
               }
             default:
-              throw new Error(`Unknown tool state: ${part.tool_state}`)
+              throw new DeterministicPreparationError(
+                `Unknown tool state: ${part.tool_state}`
+              )
           }
         }
 
         if (toolName === 'todoRead') {
           if (!part.tool_state) {
-            throw new Error(`tool_state is undefined for ${toolName}`)
+            throw new DeterministicPreparationError(
+              `tool_state is undefined for ${toolName}`
+            )
           }
 
           switch (part.tool_state) {
@@ -612,7 +631,9 @@ export function mapDBPartToUIMessagePart(
                 errorText: part.tool_errorText!
               }
             default:
-              throw new Error(`Unknown tool state: ${part.tool_state}`)
+              throw new DeterministicPreparationError(
+                `Unknown tool state: ${part.tool_state}`
+              )
           }
         }
 
@@ -664,7 +685,7 @@ export function mapDBPartToUIMessagePart(
       }
 
       // Fallback - should not happen
-      throw new Error(`Unknown part type: ${part.type}`)
+      throw new DeterministicPreparationError(`Unknown part type: ${part.type}`)
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes deterministic preparation failures being classified as retryable `unknown` errors.

Preparation failures caused by invalid stored conversation state now use an explicit internal error type and are presented as non-retryable `malformed_request` errors. Transient failures, such as database timeouts, retain their existing retryable behavior.

## Changes

- Add `DeterministicPreparationError` to identify failures that cannot succeed when replayed with the same state.
- Use it for:
  - Regeneration with no stored messages.
  - Regeneration with no matching or fallback message.
  - Persisted message parts that cannot be mapped.
  - Persisted tool parts with missing or invalid state.
- Map these failures to the existing sanitized `malformed_request` response.
- Preserve provenance by recognizing only errors created by the application, rather than trusting arbitrary error properties.
- Add tests covering classification, serialization, sanitization, persisted-part mapping, and transient failures.

## Testing

- `bun lint`
- `bun typecheck`
- `bun format:check`
- `bun run test`
  - 618 passed
  - 3 skipped
- `bun run build`

Fixes #979