### PR TITLE
fix(streaming): build the prompt from an uncached chat read

### DIFF
--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -34,6 +34,17 @@ const getCachedChatWithMessages = (
   return cachedFunction()
 }
 
+async function signChatFilePartUrls(
+  chat: (Chat & { messages: UIMessage[] }) | null
+): Promise<(Chat & { messages: UIMessage[] }) | null> {
+  if (!chat) return null
+
+  return {
+    ...chat,
+    messages: await signFilePartUrlsInMessages(chat.messages)
+  }
+}
+
 /**
  * Get all chats for the current user
  */
@@ -67,12 +78,23 @@ export async function loadChat(
 ): Promise<(Chat & { messages: UIMessage[] }) | null> {
   // Use cached version for individual chat loading
   const chat = await getCachedChatWithMessages(chatId, requestingUserId)
-  if (!chat) return null
 
-  return {
-    ...chat,
-    messages: await signFilePartUrlsInMessages(chat.messages)
-  }
+  return signChatFilePartUrls(chat)
+}
+
+/**
+ * Load a chat bypassing the request cache.
+ * The assistant answer is persisted after the streaming response has been
+ * returned, so its revalidateTag never reaches the cache and a cached read
+ * can miss the previous turn's answer.
+ */
+export async function loadChatUncached(
+  chatId: string,
+  requestingUserId?: string
+): Promise<(Chat & { messages: UIMessage[] }) | null> {
+  const chat = await dbActions.loadChatWithMessages(chatId, requestingUserId)
+
+  return signChatFilePartUrls(chat)
 }
 
 /**

--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -34,7 +34,8 @@ vi.mock('@/instrumentation', () => ({
 }))
 
 vi.mock('@/lib/actions/chat', () => ({
-  loadChat: vi.fn()
+  loadChat: vi.fn(),
+  loadChatUncached: vi.fn()
 }))
 
 vi.mock('@/lib/agents/researcher', () => ({
@@ -66,6 +67,7 @@ vi.mock('@/lib/utils/usage-logging', () => ({
   logUsage: vi.fn()
 }))
 
+import { loadChat, loadChatUncached } from '@/lib/actions/chat'
 import { researcher } from '@/lib/agents/researcher'
 import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-response'
 import { describeStreamError } from '@/lib/streaming/helpers/describe-stream-error'
@@ -159,6 +161,16 @@ describe('createChatStreamResponse', () => {
     expect(researcher).toHaveBeenCalledWith(
       expect.objectContaining({ chatId: 'chat-id' })
     )
+  })
+
+  it('loads an existing chat without the cache', async () => {
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse({ ...createConfig(), isNewChat: false })
+    await mocks.finishPromise
+
+    expect(loadChatUncached).toHaveBeenCalledWith('chat-id', 'user-id')
+    expect(loadChat).not.toHaveBeenCalled()
   })
 
   it('does not mark the span as failed for an aborted stream error', async () => {

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -14,7 +14,7 @@ import {
 } from '@/lib/errors/tool-error'
 import { isTracingEnabled } from '@/lib/utils/telemetry'
 
-import { loadChat } from '../actions/chat'
+import { loadChatUncached } from '../actions/chat'
 import { generateChatTitle } from '../agents/title-generator'
 import {
   getMaxAllowedTokens,
@@ -82,8 +82,9 @@ export async function createChatStreamResponse(
   let initialChat = null
   if (!isNewChat) {
     const loadChatStart = performance.now()
-    // Fetch chat data for authorization check and cache it
-    initialChat = await loadChat(chatId, userId)
+    // Read uncached: the prompt must not be built from a snapshot that
+    // predates the previous turn's answer
+    initialChat = await loadChatUncached(chatId, userId)
     perfTime('loadChat completed', loadChatStart)
 
     // Authorization check: if chat exists, it must belong to the user


### PR DESCRIPTION
## Problem

On a continuation turn the model can be sent a history that is missing its own previous answer: the replayed messages end with the user's previous message followed by the new one. Two consequences:

- the model is asked to continue a thread without the answer it just gave;
- when the missing answer reappears on a later turn it is inserted in the middle of the prompt rather than appended, which breaks the provider's prompt-cache prefix for everything after it.

The answer is not lost. It is committed to the database well before the next turn starts; only the read used to build the prompt misses it.

## Root cause

`lib/actions/chat.ts` wraps `loadChatWithMessages` in `unstable_cache(..., { tags: ['chat-<id>', 'chat'], revalidate: 60 })` and relies on `revalidateTag('chat-<id>', 'max')` inside `upsertMessage` to invalidate it.

In Next.js 16, `revalidateTag()` does not invalidate on the spot. It pushes the tag onto `workStore.pendingRevalidatedTags` (`next/dist/server/web/spec-extension/revalidate.js`), and that queue is flushed by `resolvePendingRevalidations()` in `next/dist/server/route-modules/app-route/module.js`, which runs immediately after the route handler returns its `Response`.

The chat route returns a streaming `Response`, and the assistant answer is persisted later, in the `onEnd` callback of `toUIMessageStreamResponse` (`persistStreamResults` -> `upsertMessage`). By then the queue has already been flushed, so that `revalidateTag` is never executed. `unstable_cache` also serves a stale entry and revalidates in the background rather than blocking, so once an entry written during the turn survives, a following turn reads a snapshot that predates the answer.

The user message does not have this problem: it is upserted inside `prepareMessages`, before the handler returns, so its `revalidateTag` is flushed normally. That asymmetry is why the defect only ever drops the assistant side.

## Fix

Add `loadChatUncached` in `lib/actions/chat.ts` (same work as `loadChat`, without the `unstable_cache` wrapper) and use it in `create-chat-stream-response.ts` for the existing-chat branch, so the prompt is always built from the database. One indexed query is added on a request that is about to make a multi-second model call.

`loadChat` and every `revalidateTag` call are left unchanged; the page render path is untouched.

## Verification

- New test in `lib/streaming/__tests__/create-chat-stream-response.test.ts`: an existing chat is loaded through the uncached loader and the cached `loadChat` is not called.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (612 passed, 3 skipped) all pass locally. `bun run build` was not run locally: it needs `.env.local`, and pristine `main` fails identically in the same sandbox, so it is left to CI.
- The mechanism was checked against production data before the fix: for the turns that showed this shape, the preceding assistant message was already committed, and persisted message ordering alternates user/assistant with no gap.