### PR TITLE
fix(analytics): count the turn from user message ids instead of the chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { revalidateTag } from 'next/cache'
 import { cookies } from 'next/headers'
 
-import { loadChat } from '@/lib/actions/chat'
+import { loadChatUncached } from '@/lib/actions/chat'
 import {
   calculateConversationTurn,
   deriveQueryShape,
@@ -201,7 +201,7 @@ export async function POST(req: Request) {
         let conversationTurn = 1 // Default for new chats
         if (!isNewChat) {
           if (!isGuest && userId) {
-            const chat = await loadChat(chatId, userId)
+            const chat = await loadChatUncached(chatId, userId)
             if (chat?.messages) {
               conversationTurn = calculateConversationTurn(
                 chat.messages,

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,13 +1,14 @@
 import { revalidateTag } from 'next/cache'
 import { cookies } from 'next/headers'
 
-import { loadChatUncached } from '@/lib/actions/chat'
 import {
   calculateConversationTurn,
+  calculateConversationTurnFromIds,
   deriveQueryShape,
   trackChatEvent
 } from '@/lib/analytics'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
+import { getUserMessageIds } from '@/lib/db/actions'
 import { generateId } from '@/lib/db/schema'
 import { checkAndEnforceAdaptiveLimit } from '@/lib/rate-limit/adaptive-limit'
 import { checkAndEnforceOverallChatLimit } from '@/lib/rate-limit/chat-limits'
@@ -189,7 +190,7 @@ export async function POST(req: Request) {
     perfTime('createChatStreamResponse resolved', streamStart)
 
     // Track analytics event (non-blocking)
-    // Calculate conversation turn by loading chat history
+    // Calculate conversation turn
     ;(async () => {
       try {
         // Attribute to the authenticated user id, or the client-provided
@@ -201,13 +202,11 @@ export async function POST(req: Request) {
         let conversationTurn = 1 // Default for new chats
         if (!isNewChat) {
           if (!isGuest && userId) {
-            const chat = await loadChatUncached(chatId, userId)
-            if (chat?.messages) {
-              conversationTurn = calculateConversationTurn(
-                chat.messages,
-                message?.id
-              )
-            }
+            const userMessageIds = await getUserMessageIds(chatId, userId)
+            conversationTurn = calculateConversationTurnFromIds(
+              userMessageIds,
+              message?.id
+            )
           } else if (isGuest && Array.isArray(messages)) {
             conversationTurn = calculateConversationTurn(messages, message?.id)
           }

--- a/lib/analytics/__tests__/utils.test.ts
+++ b/lib/analytics/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   calculateConversationTurn,
+  calculateConversationTurnFromIds,
   deriveQueryShape
 } from '@/lib/analytics/utils'
 
@@ -54,5 +55,27 @@ describe('calculateConversationTurn', () => {
   it('counts existing user messages without a current id (regenerate)', () => {
     const fresh = [...history, userMsg('u2')]
     expect(calculateConversationTurn(fresh)).toBe(2)
+  })
+})
+
+describe('calculateConversationTurnFromIds', () => {
+  it('counts a current message when ids are empty', () => {
+    expect(calculateConversationTurnFromIds([], 'u1')).toBe(1)
+  })
+
+  it('counts ids without a current message id', () => {
+    expect(calculateConversationTurnFromIds(['u1', 'u2'])).toBe(2)
+  })
+
+  it('does not double count a current message already present', () => {
+    expect(calculateConversationTurnFromIds(['u1', 'u2'], 'u2')).toBe(2)
+  })
+
+  it('adds a current message not already present', () => {
+    expect(calculateConversationTurnFromIds(['u1', 'u2'], 'u3')).toBe(3)
+  })
+
+  it('returns at least 1', () => {
+    expect(calculateConversationTurnFromIds([])).toBe(1)
   })
 })

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -22,4 +22,8 @@ export type {
   QueryLenBucket,
   QueryShape
 } from './types'
-export { calculateConversationTurn, deriveQueryShape } from './utils'
+export {
+  calculateConversationTurn,
+  calculateConversationTurnFromIds,
+  deriveQueryShape
+} from './utils'

--- a/lib/analytics/utils.ts
+++ b/lib/analytics/utils.ts
@@ -45,9 +45,17 @@ export function calculateConversationTurn(
   messages: UIMessage[],
   currentMessageId?: string
 ): number {
-  const userIds = new Set(
-    messages.filter(msg => msg.role === 'user').map(msg => msg.id)
+  return calculateConversationTurnFromIds(
+    messages.filter(msg => msg.role === 'user').map(msg => msg.id),
+    currentMessageId
   )
+}
+
+export function calculateConversationTurnFromIds(
+  userMessageIds: string[],
+  currentMessageId?: string
+): number {
+  const userIds = new Set(userMessageIds)
   if (currentMessageId) userIds.add(currentMessageId)
   return Math.max(1, userIds.size)
 }

--- a/lib/db/__tests__/user-message-ids.test.ts
+++ b/lib/db/__tests__/user-message-ids.test.ts
@@ -1,0 +1,121 @@
+import { and, eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { messages } from '@/lib/db/schema'
+import { withOptionalRLS } from '@/lib/db/with-rls'
+
+import { getUserMessageIds } from '../actions'
+
+vi.mock('@/lib/db/with-rls', () => ({
+  withOptionalRLS: vi.fn(),
+  withRLS: vi.fn()
+}))
+
+function mockQueries({
+  chat,
+  messageRows = []
+}: {
+  chat?: { userId: string; visibility: 'private' | 'public' }
+  messageRows?: { id: string }[]
+}) {
+  const chatLimit = vi.fn().mockResolvedValue(chat ? [chat] : [])
+  const chatsWhere = vi.fn().mockReturnValue({ limit: chatLimit })
+  const messagesWhere = vi.fn().mockResolvedValue(messageRows)
+  const from = vi
+    .fn()
+    .mockReturnValueOnce({ where: chatsWhere })
+    .mockReturnValueOnce({ where: messagesWhere })
+  const select = vi.fn().mockReturnValue({ from })
+
+  vi.mocked(withOptionalRLS).mockImplementation(async (_userId, callback) =>
+    callback({ select } as never)
+  )
+
+  return { select, messagesWhere }
+}
+
+describe('getUserMessageIds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an empty list without querying messages when the chat is not found', async () => {
+    const { select, messagesWhere } = mockQueries({})
+
+    const result = await getUserMessageIds('chat-1', 'user-1')
+
+    expect(result).toEqual([])
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(messagesWhere).not.toHaveBeenCalled()
+    expect(withOptionalRLS).toHaveBeenCalledWith('user-1', expect.any(Function))
+  })
+
+  it("returns an empty list without querying messages for another user's private chat", async () => {
+    const { select, messagesWhere } = mockQueries({
+      chat: { userId: 'user-2', visibility: 'private' }
+    })
+
+    const result = await getUserMessageIds('chat-1', 'user-1')
+
+    expect(result).toEqual([])
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(messagesWhere).not.toHaveBeenCalled()
+    expect(withOptionalRLS).toHaveBeenCalledWith('user-1', expect.any(Function))
+  })
+
+  it('returns an empty list without querying messages for a private chat without a user ID', async () => {
+    const { select, messagesWhere } = mockQueries({
+      chat: { userId: 'user-1', visibility: 'private' }
+    })
+
+    const result = await getUserMessageIds('chat-1')
+
+    expect(result).toEqual([])
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(messagesWhere).not.toHaveBeenCalled()
+    expect(withOptionalRLS).toHaveBeenCalledWith(null, expect.any(Function))
+  })
+
+  it('returns private chat message ids in order for the owner', async () => {
+    const { select, messagesWhere } = mockQueries({
+      chat: { userId: 'user-1', visibility: 'private' },
+      messageRows: [{ id: 'message-2' }, { id: 'message-1' }]
+    })
+
+    const result = await getUserMessageIds('chat-1', 'user-1')
+
+    expect(result).toEqual(['message-2', 'message-1'])
+    expect(select).toHaveBeenCalledTimes(2)
+    expect(messagesWhere).toHaveBeenCalledExactlyOnceWith(
+      and(eq(messages.chatId, 'chat-1'), eq(messages.role, 'user'))
+    )
+    expect(withOptionalRLS).toHaveBeenCalledWith('user-1', expect.any(Function))
+  })
+
+  it('returns public chat message ids for a different user', async () => {
+    const { select, messagesWhere } = mockQueries({
+      chat: { userId: 'user-2', visibility: 'public' },
+      messageRows: [{ id: 'message-1' }, { id: 'message-2' }]
+    })
+
+    const result = await getUserMessageIds('chat-1', 'user-1')
+
+    expect(result).toEqual(['message-1', 'message-2'])
+    expect(select).toHaveBeenCalledTimes(2)
+    expect(messagesWhere).toHaveBeenCalledTimes(1)
+    expect(withOptionalRLS).toHaveBeenCalledWith('user-1', expect.any(Function))
+  })
+
+  it('maps message rows to a plain string array', async () => {
+    mockQueries({
+      chat: { userId: 'user-1', visibility: 'private' },
+      messageRows: [{ id: 'message-1' }, { id: 'message-2' }]
+    })
+
+    const result = await getUserMessageIds('chat-1', 'user-1')
+
+    expect(result).toEqual(['message-1', 'message-2'])
+    expect(result.every(id => typeof id === 'string')).toBe(true)
+    expect(withOptionalRLS).toHaveBeenCalledWith('user-1', expect.any(Function))
+  })
+})

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -218,6 +218,37 @@ export async function loadChatWithMessages(
   })
 }
 
+export async function getUserMessageIds(
+  chatId: string,
+  userId?: string
+): Promise<string[]> {
+  const count = incrementDbOperationCount()
+  perfLog(`DB - getUserMessageIds called - count: ${count}`)
+
+  return withOptionalRLS(userId || null, async tx => {
+    const [chat] = await tx
+      .select()
+      .from(chats)
+      .where(eq(chats.id, chatId))
+      .limit(1)
+
+    if (!chat) {
+      return []
+    }
+
+    if (chat.visibility === 'private' && (!userId || chat.userId !== userId)) {
+      return []
+    }
+
+    const userMessages = await tx
+      .select({ id: messages.id })
+      .from(messages)
+      .where(and(eq(messages.chatId, chatId), eq(messages.role, 'user')))
+
+    return userMessages.map(message => message.id)
+  })
+}
+
 /**
  * Delete messages after a specific message
  */


### PR DESCRIPTION
## Problem

The analytics block in `app/api/chat/route.ts` loads the whole chat through the cached `loadChat` in order to compute `conversationTurn`.

The read runs in a floating promise while the turn is still streaming, and on a cache miss it stores what it read. What it read is a chat whose last message is the user turn, because the assistant answer has not been persisted yet. So this read is a writer: it is how a pre-answer snapshot becomes the cached value for `chat-<id>` in the first place, and the page path (`app/search/[id]/page.tsx`) reads that value.

## Root cause

`loadChat` is wrapped in `unstable_cache(..., { tags: ['chat-<id>', 'chat'], revalidate: 60 })` and depends on `revalidateTag('chat-<id>')` inside `upsertMessage` to invalidate it.

`revalidateTag()` does not invalidate on the spot: it pushes the tag onto `workStore.pendingRevalidatedTags` (`next/dist/server/web/spec-extension/revalidate.js`), and that queue is flushed by `resolvePendingRevalidations()` in `next/dist/server/route-modules/app-route/module.js` right after the route handler returns its `Response`. The chat route returns a streaming `Response` and persists the assistant answer afterwards, in the `onEnd` callback (`persistStreamResults` -> `upsertMessage`), so that tag invalidation is queued into an already-flushed store and never runs.

`lib/streaming/helpers/prepare-messages.ts` already documents the same-request half of this, at the point where it deliberately avoids re-reading: "loadChat uses unstable_cache which may return stale data even after revalidateTag within the same request".

#1001 made the equivalent change for prompt construction in `lib/streaming/create-chat-stream-response.ts`. This is the sibling read on the analytics path, and it is the one that writes the entry.

## Fix

`calculateConversationTurn` only builds a set of the ids of user-role messages, and the current turn's id is passed in separately. It never looks at parts, at assistant messages, or at content. So instead of reading the chat at all, this adds `getUserMessageIds` in `lib/db/actions.ts`, which selects just those ids under the same `withOptionalRLS` wrapper and the same chat ownership and visibility checks as `loadChatWithMessages`.

The turn semantics stay in one place: `calculateConversationTurnFromIds` holds them, and `calculateConversationTurn` delegates to it, so the guest branch is unchanged in both behaviour and code.

This is strictly less work than what the route did before this PR:

- no `parts` join and no message construction,
- no `signFilePartUrlsInMessages` pass over every file part, which this path performed on a value that was then discarded,
- no cached entry written mid-turn.

The read stays inside the existing floating promise after the streaming response is constructed, so nothing is added before the first token.

## Scope

This is item 2 of #1002 and it does not close that issue. The assistant write still never invalidates the tag, so a page render that lands while a turn is streaming can still install a pre-answer entry that nothing will invalidate. That is item 3, and it is unchanged here.

The computed `conversationTurn` value should be unchanged in the ordinary case: the previous code counted the same user ids, and the current turn's id was always added explicitly, so a snapshot missing only the assistant answer produced the same number. The values can differ only where the cached snapshot was also missing an earlier *user* message. This PR removes that possibility rather than measuring how often it occurred, so `conversationTurn` should be treated as potentially discontinuous at deploy time and not compared across the boundary without checking.

## Verification

- `bun lint`, `bun typecheck`, `bun format:check` clean.
- `bun run test`: 617 passed, 3 skipped, including five new cases for `calculateConversationTurnFromIds` in the existing `lib/analytics/__tests__/utils.test.ts` (empty ids, ids without a current id, a current id already present, a current id not present, and the floor of 1).
- No route-level test added: `app/api/chat/route.ts` has no existing test home and standing up a route harness is out of scope here.
- No schema change and no migration.

Refs #1002.
