### PR TITLE
fix(db): allow stateless startup without a database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,13 +35,9 @@ COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/lib/db ./lib/db
 COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
 
-# Create entrypoint script for database migration
-RUN echo '#!/bin/sh\n\
-set -e\n\
-echo "Running database migrations..."\n\
-bun run migrate\n\
-echo "Migrations completed. Starting server..."\n\
-exec "$@"\n' > /app/docker-entrypoint.sh && chmod +x /app/docker-entrypoint.sh
+# Copy entrypoint script for database migration
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
 # Start production server with migration
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ -n "${DATABASE_URL:-}" ] || [ -n "${DATABASE_RESTRICTED_URL:-}" ]; then
+  echo "Running database migrations..."
+  bun run migrate
+  echo "Migrations completed. Starting server..."
+else
+  echo "Database is not configured. Skipping migrations."
+fi
+
+exec "$@"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,7 +13,9 @@ This guide covers the optional features and their configuration in Morphic.
 
 ## Database
 
-Morphic uses PostgreSQL for chat history storage. A database is **optional** for basic usage — without it, Morphic runs in a stateless mode where chat history is not persisted.
+Morphic uses PostgreSQL for persistent application data. A database is **optional** for stateless guest chat. To run without a database, set `ENABLE_GUEST_CHAT=true` and do not configure Supabase. Setting `ENABLE_AUTH=false` creates an anonymous user ID that uses the persistent chat path and will fail without a database.
+
+Without a database, chat history, permalinks (`/search/[id]`), file upload, and feedback are unavailable.
 
 ### Setting Up PostgreSQL
 
@@ -35,7 +37,7 @@ After configuring your database, run migrations to create the necessary tables:
 bun run migrate
 ```
 
-This command applies all migrations from the `drizzle/` directory. Docker runs migrations automatically on startup.
+This command applies all migrations from the `drizzle/` directory. Docker runs migrations automatically on startup when a database connection string is configured. Otherwise, it skips migrations and starts in stateless mode.
 
 ## AI Providers
 

--- a/lib/db/__tests__/index.test.ts
+++ b/lib/db/__tests__/index.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('database configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('defers the missing connection string error until database access', async () => {
+    vi.resetModules()
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('DATABASE_URL', '')
+    vi.stubEnv('DATABASE_RESTRICTED_URL', '')
+
+    const databaseModule = await import('@/lib/db')
+
+    expect(() => databaseModule.db.select).toThrow(
+      'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
+    )
+  })
+
+  it('falls back to DATABASE_URL when the restricted URL is empty', async () => {
+    vi.resetModules()
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/testdb')
+    vi.stubEnv('DATABASE_RESTRICTED_URL', '')
+
+    const databaseModule = await import('@/lib/db')
+
+    expect(() => databaseModule.db.select).not.toThrow()
+  })
+})

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -10,62 +10,70 @@ import * as schema from './schema'
 const isDevelopment = process.env.NODE_ENV === 'development'
 const isTest = process.env.NODE_ENV === 'test'
 
-if (
-  !process.env.DATABASE_URL &&
-  !process.env.DATABASE_RESTRICTED_URL &&
-  !isTest
-) {
-  throw new Error(
-    'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
-  )
-}
-
 // Connection with connection pooling for server environments
 // Prefer restricted user for application runtime
+const restrictedDatabaseUrl =
+  process.env.DATABASE_RESTRICTED_URL?.trim() || undefined
+const databaseUrl = process.env.DATABASE_URL?.trim() || undefined
 const connectionString =
-  process.env.DATABASE_RESTRICTED_URL ?? // Prefer restricted user
-  process.env.DATABASE_URL ??
+  restrictedDatabaseUrl ?? // Prefer restricted user
+  databaseUrl ??
   (isTest ? 'postgres://user:pass@localhost:5432/testdb' : undefined)
 
+const databaseErrorMessage =
+  'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
+
+const createDatabase = (url: string) => {
+  // Log which connection is being used (for debugging)
+  if (isDevelopment) {
+    console.log(
+      '[DB] Using connection:',
+      restrictedDatabaseUrl
+        ? 'Restricted User (RLS Active)'
+        : 'Owner User (RLS Bypassed)'
+    )
+  }
+
+  // SSL configuration: Use environment variable to control SSL
+  // DATABASE_SSL_DISABLED=true disables SSL completely (for local/Docker PostgreSQL)
+  // Default is to enable SSL with certificate verification (for cloud databases like Neon, Supabase)
+  const sslConfig =
+    process.env.DATABASE_SSL_DISABLED === 'true'
+      ? false // Disable SSL entirely for local PostgreSQL
+      : { rejectUnauthorized: true } // Enable SSL with verification for cloud DBs
+
+  const client = postgres(url, {
+    ssl: sslConfig,
+    prepare: false,
+    max: 20 // Max 20 connections
+  })
+
+  return drizzle(client, {
+    schema: { ...schema, ...relations }
+  })
+}
+
+type Database = ReturnType<typeof createDatabase>
+
+export const db: Database = connectionString
+  ? createDatabase(connectionString)
+  : new Proxy({} as Database, {
+      get() {
+        throw new Error(databaseErrorMessage)
+      }
+    })
+
 if (!connectionString) {
-  throw new Error(
-    'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
+  console.warn(
+    '[DB] Database is not configured. Only guest chat (ENABLE_GUEST_CHAT=true) works without a database.'
   )
 }
-
-// Log which connection is being used (for debugging)
-if (isDevelopment) {
-  console.log(
-    '[DB] Using connection:',
-    process.env.DATABASE_RESTRICTED_URL
-      ? 'Restricted User (RLS Active)'
-      : 'Owner User (RLS Bypassed)'
-  )
-}
-
-// SSL configuration: Use environment variable to control SSL
-// DATABASE_SSL_DISABLED=true disables SSL completely (for local/Docker PostgreSQL)
-// Default is to enable SSL with certificate verification (for cloud databases like Neon, Supabase)
-const sslConfig =
-  process.env.DATABASE_SSL_DISABLED === 'true'
-    ? false // Disable SSL entirely for local PostgreSQL
-    : { rejectUnauthorized: true } // Enable SSL with verification for cloud DBs
-
-const client = postgres(connectionString, {
-  ssl: sslConfig,
-  prepare: false,
-  max: 20 // Max 20 connections
-})
-
-export const db = drizzle(client, {
-  schema: { ...schema, ...relations }
-})
 
 // Helper type for all tables
 export type Schema = typeof schema
 
 // Verify restricted user permissions on startup
-if (process.env.DATABASE_RESTRICTED_URL && !isTest) {
+if (restrictedDatabaseUrl && !isTest) {
   // Only run verification in server environments, not during build
   if (typeof window === 'undefined' && process.env.NODE_ENV !== 'production') {
     ;(async () => {


### PR DESCRIPTION
Closes #1004

## Problem

`docs/CONFIGURATION.md` documents a stateless mode, but the app cannot start without a database.

1. `lib/db/index.ts` threw at module evaluation when neither `DATABASE_URL` nor `DATABASE_RESTRICTED_URL` was set.
2. `app/api/chat/route.ts` imports `@/lib/actions/chat` -> `@/lib/db/actions` -> `import { db } from '.'`, so the throw fired while the route module was being evaluated.
3. `ENABLE_GUEST_CHAT` is only read at request time, so it never got a chance to matter.
4. The Docker entrypoint ran `bun run migrate` unconditionally, so the image could not start without a database even after the app code was fixed.

The guest request path never touches the database at runtime: every DB access in the chat route sits behind `!isGuest`, `createEphemeralChatStreamResponse` does not reference `db`, guest rate limiting uses Redis, and `getChats`/`getChatsPage` return early without a user id. So deferring the failure from import time to first use is enough to make stateless guest chat work.

## Changes

- `lib/db/index.ts`: no module-level throw. When a connection string is present the construction path is unchanged, with no added indirection. When it is absent, `db` is a stub that throws the same error on property access, and a warning is logged at startup so a genuine misconfiguration stays visible. Empty and whitespace-only values are normalized, so an empty `DATABASE_RESTRICTED_URL` no longer shadows a valid `DATABASE_URL`.
- `docker-entrypoint.sh` (new) and `Dockerfile`: the inline entrypoint moves to a script and skips migrations when no connection string is configured.
- `docs/CONFIGURATION.md`: stateless mode requires `ENABLE_GUEST_CHAT=true` with no Supabase configuration. `ENABLE_AUTH=false` produces an anonymous user id that takes the persisting path and fails without a database. Chat history, permalinks, file upload, and feedback are unavailable.
- `lib/db/__tests__/index.test.ts` (new): importing without a connection string does not throw and touching `db` does, and an empty restricted URL falls back to `DATABASE_URL`.

## Verification

With `DATABASE_URL` and `DATABASE_RESTRICTED_URL` emptied and `ENABLE_GUEST_CHAT=true`:

```
[DB] Database is not configured. Only guest chat (ENABLE_GUEST_CHAT=true) works without a database.
GET / 200
POST /api/chat 200, streamed a response
```

Both entrypoint branches were exercised: migrations are skipped without a connection string and run with one.

`bun lint`, `bun typecheck`, `bun format:check`, `bun run test` (616 passed), and `bun run build` all pass.

## Note

Deferring the error means a missing `DATABASE_URL` in a deployment that intends to persist now surfaces at request time rather than at boot. The startup warning is there to keep that case discoverable.
