### PR TITLE
chore(docker): add .dockerignore to trim the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules
+**/node_modules
+
+# Build output
+.next
+out
+build
+*.tsbuildinfo
+next-env.d.ts
+
+# Version control
+.git
+.gitignore
+.github
+
+# Environment / secrets
+.env
+.env.*
+# Kept: Next.js inlines NEXT_PUBLIC_* at build time, and building from source
+# is the documented way to enable authentication (docs/DOCKER.md).
+!.env.local
+
+# Test and coverage output
+coverage
+**/*.test.ts
+**/*.test.tsx
+vitest.config.mts
+vitest.setup.ts
+evals
+
+# Local scratch and tooling
+.claude
+.vscode
+.idea
+.vercel
+.tmp
+_local
+.mcp.json
+.DS_Store
+*.pem
+*.log
+
+# Docs and container definitions (not needed by the build)
+docs
+*.md
+Dockerfile
+.dockerignore
+docker-compose.yaml
+searxng-limiter.toml
+searxng-settings.yml


### PR DESCRIPTION
## What

Add a `.dockerignore` at the repo root.

The builder stage runs `COPY . .`, so `node_modules`, `.next`, `.git` and local artifacts were all sent to the daemon, and a stale host `.next` could be copied into the image before the production build ran.

Excluded: dependencies, build output, `.git`/`.github`, `.env*`, coverage and test files, local scratch directories (`.claude`, `.vscode`, `.vercel`, `.tmp`), docs and container definitions.

Two exceptions, both required by the build:

- `config/` is kept because `config/models/cloud.json` is imported by the app
- `.env.local` is kept because Next.js inlines `NEXT_PUBLIC_*` at build time, and `docs/DOCKER.md` documents building from source with `.env.local` to enable authentication

## Verification

Build context transfer (same tree, with `node_modules` present):

| | transferring context |
| --- | --- |
| before | 872.95MB (24.0s) |
| after | 2.28MB (0.1s) |

- `docker build -t morphic:dockerignore-check .` succeeds
- Container starts against a throwaway Postgres: migrations apply and `GET /` returns 200
- The final image contains no env files
- With a sentinel `.env.local`, it is the only env file reaching the builder and its `NEXT_PUBLIC_SUPABASE_URL` is inlined into `.next/static`