### PR TITLE
fix(search): drop domain filters Tavily cannot accept

### DIFF
--- a/lib/tools/search/providers/__tests__/tavily-domains.test.ts
+++ b/lib/tools/search/providers/__tests__/tavily-domains.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TavilySearchProvider } from '../tavily'
+
+describe('TavilySearchProvider domains', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  const searchAndReadBody = async (
+    includeDomains: string[] = [],
+    excludeDomains: string[] = []
+  ) => {
+    vi.stubEnv('TAVILY_API_KEY', 'test-key')
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ results: [], images: [] })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await new TavilySearchProvider().search(
+      'query',
+      5,
+      'basic',
+      includeDomains,
+      excludeDomains
+    )
+
+    const init = fetchMock.mock.calls[0][1]
+    return JSON.parse(init?.body as string)
+  }
+
+  it('drops bare TLDs from include_domains', async () => {
+    const body = await searchAndReadBody(['edu', 'gov'])
+
+    expect(body.include_domains).toEqual([])
+  })
+
+  it('keeps only valid entries in a mixed include_domains list', async () => {
+    const body = await searchAndReadBody(['edu', 'mit.edu', 'gov'])
+
+    expect(body.include_domains).toEqual(['mit.edu'])
+  })
+
+  it('filters exclude_domains including the cloud-injected domain', async () => {
+    vi.stubEnv('MORPHIC_CLOUD_DEPLOYMENT', 'true')
+
+    const body = await searchAndReadBody(
+      ['example.org'],
+      ['com', 'example.net']
+    )
+
+    expect(body.exclude_domains).toEqual(['example.net', 'instagram.com'])
+  })
+
+  it('passes valid domains through untouched', async () => {
+    const body = await searchAndReadBody(
+      ['example.com', '*.example.org'],
+      ['example.net']
+    )
+
+    expect(body.include_domains).toEqual(['example.com', '*.example.org'])
+    expect(body.exclude_domains).toEqual(['example.net'])
+  })
+})

--- a/lib/tools/search/providers/__tests__/tavily-domains.test.ts
+++ b/lib/tools/search/providers/__tests__/tavily-domains.test.ts
@@ -54,6 +54,13 @@ describe('TavilySearchProvider domains', () => {
     expect(body.exclude_domains).toEqual(['example.net', 'instagram.com'])
   })
 
+  it('converts internationalized domains to their ascii form', async () => {
+    const body = await searchAndReadBody(['münchen.de'], ['*.MÜNCHEN.de'])
+
+    expect(body.include_domains).toEqual(['xn--mnchen-3ya.de'])
+    expect(body.exclude_domains).toEqual(['*.xn--mnchen-3ya.de'])
+  })
+
   it('passes valid domains through untouched', async () => {
     const body = await searchAndReadBody(
       ['example.com', '*.example.org'],

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -7,6 +7,21 @@ import { BaseSearchProvider } from './base'
 // started surfacing low-value aggregator/social pages (notably Instagram)
 // that rarely help answer informational queries.
 const CLOUD_EXCLUDED_DOMAINS = ['instagram.com']
+// Tavily rejects the whole request when every entry of a domain list lacks a
+// valid suffix, so bare labels are dropped before the call.
+const VALID_DOMAIN_PATTERN = /^(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/
+
+const normalizeDomains = (domains: string[]) =>
+  domains
+    .map(domain => domain.trim().toLowerCase())
+    .filter(domain => {
+      const suffix = domain.split('.').at(-1) ?? ''
+      return (
+        VALID_DOMAIN_PATTERN.test(domain) &&
+        suffix.length >= 2 &&
+        !/^\d+$/.test(suffix)
+      )
+    })
 
 export class TavilySearchProvider extends BaseSearchProvider {
   async search(
@@ -23,10 +38,13 @@ export class TavilySearchProvider extends BaseSearchProvider {
     const filledQuery =
       query.length < 5 ? query + ' '.repeat(5 - query.length) : query
 
+    const validIncludeDomains = normalizeDomains(includeDomains)
+
     const isCloudDeployment = process.env.MORPHIC_CLOUD_DEPLOYMENT === 'true'
     const effectiveExcludeDomains = isCloudDeployment
       ? Array.from(new Set([...excludeDomains, ...CLOUD_EXCLUDED_DOMAINS]))
       : excludeDomains
+    const validExcludeDomains = normalizeDomains(effectiveExcludeDomains)
 
     const includeImageDescriptions = true
     const response = await fetch('https://api.tavily.com/search', {
@@ -42,8 +60,8 @@ export class TavilySearchProvider extends BaseSearchProvider {
         include_images: true,
         include_image_descriptions: includeImageDescriptions,
         include_answers: true,
-        include_domains: includeDomains,
-        exclude_domains: effectiveExcludeDomains
+        include_domains: validIncludeDomains,
+        exclude_domains: validExcludeDomains
       })
     })
 

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -8,20 +8,27 @@ import { BaseSearchProvider } from './base'
 // that rarely help answer informational queries.
 const CLOUD_EXCLUDED_DOMAINS = ['instagram.com']
 // Tavily rejects the whole request when every entry of a domain list lacks a
-// valid suffix, so bare labels are dropped before the call.
+// valid suffix, so bare labels are dropped before the call. Entries are first
+// resolved to an ASCII hostname so internationalized domains survive.
 const VALID_DOMAIN_PATTERN = /^(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/
 
+const toAsciiHostname = (domain: string): string => {
+  try {
+    return new URL(`https://${domain.trim()}`).hostname
+  } catch {
+    return ''
+  }
+}
+
 const normalizeDomains = (domains: string[]) =>
-  domains
-    .map(domain => domain.trim().toLowerCase())
-    .filter(domain => {
-      const suffix = domain.split('.').at(-1) ?? ''
-      return (
-        VALID_DOMAIN_PATTERN.test(domain) &&
-        suffix.length >= 2 &&
-        !/^\d+$/.test(suffix)
-      )
-    })
+  domains.map(toAsciiHostname).filter(domain => {
+    const suffix = domain.split('.').at(-1) ?? ''
+    return (
+      VALID_DOMAIN_PATTERN.test(domain) &&
+      suffix.length >= 2 &&
+      !/^\d+$/.test(suffix)
+    )
+  })
 
 export class TavilySearchProvider extends BaseSearchProvider {
   async search(


### PR DESCRIPTION
## Problem

A search can fail outright because of the domain filter the model chose, returning no results at all for the turn.

The search tool exposes `include_domains` / `exclude_domains`, and the source-direction guidance tells the model to use them when the user signals a source preference. When the preference is a *class* of sources rather than a site ("academic sources", "official sources", "primary sources"), the model can express it as a bare label such as `edu`, `gov`, `org` or a country code instead of a hostname.

Tavily rejects those, and the failure is not partial: the request errors and the tool reports

```
Tavily search failed: HTTP 400: Bad Request
```

## Root cause

Tavily requires every entry of a domain list to have a valid suffix. Verified directly against the API:

| `include_domains` | Response |
| --- | --- |
| `["edu","gov"]` | **400** `All domains in include_domains are invalid: ['edu', 'gov']. Domains must have a valid suffix (e.g., 'tavily.com' instead of 'tavily').` |
| `["mit.edu","gov"]` | 200, the invalid entry is dropped server side |
| `[]` | 200, unrestricted |

`exclude_domains` behaves the same way, so a single bare label there fails the request too.

So the API already tolerates a mixed list and only fails when *every* entry is unusable. `lib/tools/search/providers/tavily.ts` forwards the model's lists verbatim, which is exactly the case that turns into a hard failure.

## Fix

Drop entries without a valid suffix before building the request body, for both the include list and the effective exclude list (the one that merges the cloud-wide exclusions).

- Mixed lists keep the same behaviour they already had, now decided locally instead of server side.
- An all-invalid list becomes an unrestricted search rather than an error. That matches what the search prompt already prescribes when a domain-restricted search comes back empty: run without the restriction rather than give up.
- Wildcard entries (`*.example.com`) are accepted by the API and are left alone.

This sits next to the existing boundary normalisation in the same provider (the minimum-query-length pad).

## Verification

- `bun lint` / `bun typecheck` / `bun format:check` / `bun run build` / `bun run test` all pass.
- New unit test `lib/tools/search/providers/__tests__/tavily-domains.test.ts` stubs `fetch` and asserts the request body: bare labels dropped, mixed list keeps only the valid entry, exclude list filtered including the cloud-injected domain, valid and wildcard entries passed through untouched.
- The table above was produced by calling the Tavily API directly with each list.
