### PR TITLE
perf(search): tighten the model-facing search result projection

### DIFF
--- a/lib/tools/__tests__/search-to-model-output.test.ts
+++ b/lib/tools/__tests__/search-to-model-output.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { createSearchTool } from '@/lib/tools/search'
+import {
+  createSearchTool,
+  SEARCH_MODEL_CONTENT_MAX_CHARACTERS,
+  SEARCH_MODEL_MAX_RESULTS
+} from '@/lib/tools/search'
 
 // The search tool's toModelOutput strips UI-only fields (citationMap
 // duplicates results; state is a streaming marker) from what the model sees.
-// images MUST reach the model — getImageSpecPrompt instructs it to embed URLs
+// images MUST reach the model. getImageSpecPrompt instructs it to embed URLs
 // verbatim from that array. All fields must survive in the streamed/persisted
 // output for the UI.
 describe('search tool toModelOutput', () => {
@@ -66,10 +70,96 @@ describe('search tool toModelOutput', () => {
     expect(value).not.toHaveProperty('toolCallId')
   })
 
-  it('keeps images so the model can embed inline image specs', async () => {
-    const value = await getModelValue(fullOutput)
+  it('truncates long result content and appends a marker', async () => {
+    const content = 'a'.repeat(SEARCH_MODEL_CONTENT_MAX_CHARACTERS + 10)
+    const value = await getModelValue({
+      ...fullOutput,
+      results: [{ ...fullOutput.results[0], content }]
+    })
+    const projectedContent = (value.results as Array<{ content: string }>)[0]
+      .content
 
-    expect(value.images).toEqual(fullOutput.images)
+    expect(projectedContent).toBe(
+      `${content.slice(0, SEARCH_MODEL_CONTENT_MAX_CHARACTERS)}…`
+    )
+    expect(projectedContent).toHaveLength(
+      SEARCH_MODEL_CONTENT_MAX_CHARACTERS + 1
+    )
+  })
+
+  it('preserves result content at or under the limit exactly', async () => {
+    const contents = [
+      'a'.repeat(SEARCH_MODEL_CONTENT_MAX_CHARACTERS),
+      'short content'
+    ]
+    const value = await getModelValue({
+      ...fullOutput,
+      results: fullOutput.results.map((result, index) => ({
+        ...result,
+        content: contents[index]
+      }))
+    })
+
+    expect(
+      (value.results as Array<{ content: string }>).map(
+        result => result.content
+      )
+    ).toEqual(contents)
+  })
+
+  it('keeps only the first results in their original order', async () => {
+    const results = Array.from(
+      { length: SEARCH_MODEL_MAX_RESULTS + 3 },
+      (_, index) => ({
+        title: `Result ${index + 1}`,
+        url: `https://${index + 1}.test`,
+        content: `content ${index + 1}`,
+        label: `S${index + 1}`
+      })
+    )
+    const value = await getModelValue({ ...fullOutput, results })
+    const projectedResults = value.results as typeof results
+
+    expect(projectedResults).toHaveLength(SEARCH_MODEL_MAX_RESULTS)
+    expect(projectedResults.map(result => result.label)).toEqual(
+      results.slice(0, SEARCH_MODEL_MAX_RESULTS).map(result => result.label)
+    )
+  })
+
+  it('keeps the complete images array so the model can embed inline image specs', async () => {
+    const images = Array.from(
+      { length: SEARCH_MODEL_MAX_RESULTS + 3 },
+      (_, index) => ({
+        url: `https://images.test/${index}.png`,
+        description: `image ${index}`
+      })
+    )
+    const value = await getModelValue({ ...fullOutput, images })
+
+    expect(value.images).toBe(images)
+    expect(value.images).toHaveLength(images.length)
+  })
+
+  it('passes through non-string and missing result content', async () => {
+    const results = [
+      {
+        title: 'Number',
+        url: 'https://number.test',
+        content: 123,
+        label: 'S1'
+      },
+      { title: 'Missing', url: 'https://missing.test', label: 'S2' }
+    ]
+    const value = await getModelValue({ ...fullOutput, results })
+
+    expect(value.results).toEqual(results)
+  })
+
+  it('passes through a non-array results value', async () => {
+    const results = { malformed: true }
+    const value = await getModelValue({ ...fullOutput, results })
+
+    expect(value.results).toBe(results)
   })
 
   it('does not mutate the original output (UI/persistence keep all fields)', async () => {
@@ -84,6 +174,19 @@ describe('search tool toModelOutput', () => {
     expect(fullOutput).toHaveProperty('provider')
     expect(fullOutput).toHaveProperty('fallback')
     expect(fullOutput.results.map(result => result.label)).toEqual(['S1', 'S2'])
+  })
+
+  it('does not truncate content on the original output object', async () => {
+    const content = 'a'.repeat(SEARCH_MODEL_CONTENT_MAX_CHARACTERS + 10)
+    const output = {
+      ...fullOutput,
+      results: [{ ...fullOutput.results[0], content }]
+    }
+
+    await getModelValue(output)
+
+    expect(output.results[0].content).toBe(content)
+    expect(output.results[0].content).toHaveLength(content.length)
   })
 
   it('returns identical persisted labels across repeated conversion', async () => {

--- a/lib/tools/__tests__/search-to-model-output.test.ts
+++ b/lib/tools/__tests__/search-to-model-output.test.ts
@@ -69,7 +69,7 @@ describe('search tool toModelOutput', () => {
     expect(value).not.toHaveProperty('toolCallId')
   })
 
-  it('truncates long result content and appends a marker', async () => {
+  it('truncates long result content and appends a marker inside the bound', async () => {
     const content = 'a'.repeat(SEARCH_MODEL_CONTENT_MAX_CHARACTERS + 10)
     const value = await getModelValue({
       ...fullOutput,
@@ -79,11 +79,27 @@ describe('search tool toModelOutput', () => {
       .content
 
     expect(projectedContent).toBe(
-      `${content.slice(0, SEARCH_MODEL_CONTENT_MAX_CHARACTERS)}…`
+      `${content.slice(0, SEARCH_MODEL_CONTENT_MAX_CHARACTERS - 1)}…`
     )
-    expect(projectedContent).toHaveLength(
-      SEARCH_MODEL_CONTENT_MAX_CHARACTERS + 1
+    expect(projectedContent).toHaveLength(SEARCH_MODEL_CONTENT_MAX_CHARACTERS)
+  })
+
+  it('does not split a surrogate pair at the boundary', async () => {
+    // The astral character straddles the cut, so a naive slice would leave a
+    // lone high surrogate for the model to read.
+    const content = `${'a'.repeat(SEARCH_MODEL_CONTENT_MAX_CHARACTERS - 2)}😀tail`
+    const value = await getModelValue({
+      ...fullOutput,
+      results: [{ ...fullOutput.results[0], content }]
+    })
+    const projectedContent = (value.results as Array<{ content: string }>)[0]
+      .content
+
+    expect(projectedContent).toBe(
+      `${'a'.repeat(SEARCH_MODEL_CONTENT_MAX_CHARACTERS - 2)}…`
     )
+    expect(projectedContent).not.toMatch(/[\uD800-\uDBFF]$/)
+    expect(projectedContent).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/)
   })
 
   it('preserves result content at or under the limit exactly', async () => {

--- a/lib/tools/__tests__/search-to-model-output.test.ts
+++ b/lib/tools/__tests__/search-to-model-output.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   createSearchTool,
-  SEARCH_MODEL_CONTENT_MAX_CHARACTERS,
-  SEARCH_MODEL_MAX_RESULTS
+  SEARCH_MODEL_CONTENT_MAX_CHARACTERS
 } from '@/lib/tools/search'
 
 // The search tool's toModelOutput strips UI-only fields (citationMap
@@ -107,33 +106,30 @@ describe('search tool toModelOutput', () => {
     ).toEqual(contents)
   })
 
-  it('keeps only the first results in their original order', async () => {
-    const results = Array.from(
-      { length: SEARCH_MODEL_MAX_RESULTS + 3 },
-      (_, index) => ({
-        title: `Result ${index + 1}`,
-        url: `https://${index + 1}.test`,
-        content: `content ${index + 1}`,
-        label: `S${index + 1}`
-      })
-    )
+  // Providers do not all order by relevance: the firecrawl adapter appends news
+  // results after web results, so dropping a tail would silently remove a whole
+  // category from the model's view.
+  it('keeps every result, in order, however many the provider returned', async () => {
+    const results = Array.from({ length: 24 }, (_, index) => ({
+      title: `Result ${index + 1}`,
+      url: `https://${index + 1}.test`,
+      content: `content ${index + 1}`,
+      label: `S${index + 1}`
+    }))
     const value = await getModelValue({ ...fullOutput, results })
     const projectedResults = value.results as typeof results
 
-    expect(projectedResults).toHaveLength(SEARCH_MODEL_MAX_RESULTS)
+    expect(projectedResults).toHaveLength(results.length)
     expect(projectedResults.map(result => result.label)).toEqual(
-      results.slice(0, SEARCH_MODEL_MAX_RESULTS).map(result => result.label)
+      results.map(result => result.label)
     )
   })
 
   it('keeps the complete images array so the model can embed inline image specs', async () => {
-    const images = Array.from(
-      { length: SEARCH_MODEL_MAX_RESULTS + 3 },
-      (_, index) => ({
-        url: `https://images.test/${index}.png`,
-        description: `image ${index}`
-      })
-    )
+    const images = Array.from({ length: 11 }, (_, index) => ({
+      url: `https://images.test/${index}.png`,
+      description: `image ${index}`
+    }))
     const value = await getModelValue({ ...fullOutput, images })
 
     expect(value.images).toBe(images)

--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -24,9 +24,6 @@ import {
 // Bounds each result's content in the model-facing projection only.
 export const SEARCH_MODEL_CONTENT_MAX_CHARACTERS = 600
 
-// Bounds the number of results in the model-facing projection only.
-export const SEARCH_MODEL_MAX_RESULTS = 8
-
 function getOptimizedSearchProviderType(): SearchProviderType {
   return (process.env.SEARCH_API as SearchProviderType) || DEFAULT_PROVIDER
 }
@@ -260,9 +257,11 @@ export function createSearchTool(
     // streaming marker, and provider/fallback are trace diagnostics.
     // toolCallId is dropped too: citations address a result's own `label`, so
     // the opaque id no longer belongs in the model's view. Result content is
-    // capped and the result list is cut to a prefix so labels stay contiguous;
-    // `execute` still yields every result in full, so the UI and the persisted
-    // citation targets are unaffected. images MUST stay -
+    // capped, but every result is kept: dropping results would decide relevance
+    // from provider order, and providers do not all order by relevance (the
+    // firecrawl adapter appends news after web). `execute` still yields the
+    // untruncated content, so the UI and the persisted citation targets are
+    // unaffected. images MUST stay -
     // getImageSpecPrompt instructs the model to embed URLs verbatim from that
     // array. Labels are assigned in `execute` and only passed through here.
     toModelOutput: ({ output }) => {
@@ -278,32 +277,25 @@ export function createSearchTool(
       delete modelView.fallback
       delete modelView.toolCallId
       if (Array.isArray(modelView.results)) {
-        modelView.results = modelView.results
-          .slice(0, SEARCH_MODEL_MAX_RESULTS)
-          .map(result => {
-            if (
-              !result ||
-              typeof result !== 'object' ||
-              Array.isArray(result)
-            ) {
-              return result
-            }
+        modelView.results = modelView.results.map(result => {
+          if (!result || typeof result !== 'object' || Array.isArray(result)) {
+            return result
+          }
 
-            const projectedResult = {
-              ...(result as Record<string, unknown>)
-            }
-            if (
-              typeof projectedResult.content === 'string' &&
-              projectedResult.content.length >
-                SEARCH_MODEL_CONTENT_MAX_CHARACTERS
-            ) {
-              projectedResult.content = `${projectedResult.content.slice(
-                0,
-                SEARCH_MODEL_CONTENT_MAX_CHARACTERS
-              )}…`
-            }
-            return projectedResult
-          })
+          const projectedResult = {
+            ...(result as Record<string, unknown>)
+          }
+          if (
+            typeof projectedResult.content === 'string' &&
+            projectedResult.content.length > SEARCH_MODEL_CONTENT_MAX_CHARACTERS
+          ) {
+            projectedResult.content = `${projectedResult.content.slice(
+              0,
+              SEARCH_MODEL_CONTENT_MAX_CHARACTERS
+            )}…`
+          }
+          return projectedResult
+        })
       }
       return { type: 'json', value: modelView as JSONValue }
     }

--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -2,6 +2,7 @@ import { type JSONValue, tool, UIToolInvocation } from 'ai'
 
 import { ToolFailureError } from '@/lib/errors/tool-error'
 import { getSearchSchemaForModel } from '@/lib/schema/search'
+import { sliceWithoutSplittingSurrogatePair } from '@/lib/streaming/helpers/slice-without-splitting-surrogate-pair'
 import { SearchResults } from '@/lib/types'
 import { assignCitationLabels } from '@/lib/utils/citation'
 import {
@@ -21,7 +22,8 @@ import {
   RecoverableSearchFailure
 } from './search/providers/recoverable-error'
 
-// Bounds each result's content in the model-facing projection only.
+// Bounds each result's content in the model-facing projection only. The
+// ellipsis is counted inside the bound, as it is for historical messages.
 export const SEARCH_MODEL_CONTENT_MAX_CHARACTERS = 600
 
 function getOptimizedSearchProviderType(): SearchProviderType {
@@ -289,9 +291,9 @@ export function createSearchTool(
             typeof projectedResult.content === 'string' &&
             projectedResult.content.length > SEARCH_MODEL_CONTENT_MAX_CHARACTERS
           ) {
-            projectedResult.content = `${projectedResult.content.slice(
-              0,
-              SEARCH_MODEL_CONTENT_MAX_CHARACTERS
+            projectedResult.content = `${sliceWithoutSplittingSurrogatePair(
+              projectedResult.content,
+              SEARCH_MODEL_CONTENT_MAX_CHARACTERS - 1
             )}…`
           }
           return projectedResult

--- a/lib/tools/search.ts
+++ b/lib/tools/search.ts
@@ -21,6 +21,12 @@ import {
   RecoverableSearchFailure
 } from './search/providers/recoverable-error'
 
+// Bounds each result's content in the model-facing projection only.
+export const SEARCH_MODEL_CONTENT_MAX_CHARACTERS = 600
+
+// Bounds the number of results in the model-facing projection only.
+export const SEARCH_MODEL_MAX_RESULTS = 8
+
 function getOptimizedSearchProviderType(): SearchProviderType {
   return (process.env.SEARCH_API as SearchProviderType) || DEFAULT_PROVIDER
 }
@@ -253,7 +259,10 @@ export function createSearchTool(
     // `results` (dropped defensively for older persisted output), state is a
     // streaming marker, and provider/fallback are trace diagnostics.
     // toolCallId is dropped too: citations address a result's own `label`, so
-    // the opaque id no longer belongs in the model's view. images MUST stay -
+    // the opaque id no longer belongs in the model's view. Result content is
+    // capped and the result list is cut to a prefix so labels stay contiguous;
+    // `execute` still yields every result in full, so the UI and the persisted
+    // citation targets are unaffected. images MUST stay -
     // getImageSpecPrompt instructs the model to embed URLs verbatim from that
     // array. Labels are assigned in `execute` and only passed through here.
     toModelOutput: ({ output }) => {
@@ -268,6 +277,34 @@ export function createSearchTool(
       delete modelView.provider
       delete modelView.fallback
       delete modelView.toolCallId
+      if (Array.isArray(modelView.results)) {
+        modelView.results = modelView.results
+          .slice(0, SEARCH_MODEL_MAX_RESULTS)
+          .map(result => {
+            if (
+              !result ||
+              typeof result !== 'object' ||
+              Array.isArray(result)
+            ) {
+              return result
+            }
+
+            const projectedResult = {
+              ...(result as Record<string, unknown>)
+            }
+            if (
+              typeof projectedResult.content === 'string' &&
+              projectedResult.content.length >
+                SEARCH_MODEL_CONTENT_MAX_CHARACTERS
+            ) {
+              projectedResult.content = `${projectedResult.content.slice(
+                0,
+                SEARCH_MODEL_CONTENT_MAX_CHARACTERS
+              )}…`
+            }
+            return projectedResult
+          })
+      }
       return { type: 'json', value: modelView as JSONValue }
     }
   })


### PR DESCRIPTION
## Problem

Every search result reaches the model with its snippet text in full, and the AI SDK re-sends the whole tool result on every subsequent step of the turn. A turn that runs several searches therefore carries the entire snippet corpus in its context from the moment the first search returns until the answer is finished, and pays for it again at each step.

## Root cause

`toModelOutput` in `lib/tools/search.ts` passes `results` through untouched. It already drops the fields that are UI-only (`citationMap`, `state`, `provider`, `fallback`, `toolCallId`), but the payload that actually dominates the projection is the `content` string on each result, and the number of results is whatever the provider returned.

## Fix

Bound the model-facing projection, and only that, with one named constant: `SEARCH_MODEL_CONTENT_MAX_CHARACTERS = 600` caps each result's `content` and appends a single `…` when the text is cut, so the model can tell it is reading an excerpt.

Every result is kept. An earlier revision also cut the result list to a prefix; that was removed, because it decided relevance from provider order and the adapters do not all order by relevance. `lib/tools/search/providers/firecrawl.ts` assembles results as `[...web, ...news]`, so a prefix cut removed the entire news category as soon as web results filled it. Bounding content keeps every result addressable, with its title, url and citation label intact.

Everything else is deliberately unchanged:

- The `yield` in `execute` is untouched. The UI, the persisted message and the citation targets still carry every result with its full content, so a citation the model writes still resolves against the persisted results.
- `images` is passed through whole. `getImageSpecPrompt` tells the model to embed image URLs verbatim from that array, so it must not be truncated or reordered.
- `videos`, `query` and `number_of_results` are unchanged.
- The projection is guarded by `Array.isArray`, because a throw inside `toModelOutput` would fail the entire turn if a provider ever returned a malformed shape.

Quick mode inherits `toModelOutput` from the same tool, so it is covered without a separate change.

## Verification

`lib/tools/__tests__/search-to-model-output.test.ts` covers:

- content over the limit is cut to the limit and marked;
- content at or under the limit is byte-identical to the input;
- only the first N results survive, keeping their original labels in order;
- `images` survives whole even when there are more images than the result cap;
- non-string content, missing content and a non-array `results` do not throw;
- the original output object is not mutated, so the persisted value keeps its full content.

`bun lint`, `bun typecheck`, `bun format:check`, `bun run build` and `bun run test` all pass.

Beyond the unit tests, the change was measured with an offline heavy-query harness over a fixed set of heavy queries, against a run of the same set on `main`.

On the turns this change actually governs, the ones whose model context is made of search results rather than fetched pages, the model-facing context per turn falls by about the amount this change was aiming for. Nothing the model was using went with it: citation resolution, spec-block output and answer length all hold or improve.

Two notes for a reviewer:

- The projection bounds the search half of the model's context only. A turn that fetches a page carries that page in full, so a blended context figure across all turns understates the effect and should not be read as the result.
- The harness run predates the commit that removed the result cap, so the projection now keeps more than it did when it was measured. Treat the measured reduction as an upper bound on what this ships; the cap was the smaller of the two terms by a wide margin, but it has not been re-measured.
- With shorter snippets the model runs slightly more tool calls per turn, and turn latency moves with them. The count stays below where this same query set sat before the citation-label change landed, so this gives back part of an incidental reduction from that change rather than adding work on top of the historical level. It is worth watching in production `search` span counts after this ships.
