### PR TITLE
perf(prompts): let adaptive mode issue independent searches in one step

### DIFF
--- a/lib/agents/prompts/__tests__/search-mode-prompts.test.ts
+++ b/lib/agents/prompts/__tests__/search-mode-prompts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getAdaptiveModePrompt,
+  getQuickModePrompt
+} from '../search-mode-prompts'
+
+describe('search mode prompts', () => {
+  it('adds bounded parallel searches to adaptive mode', () => {
+    const prompt = getAdaptiveModePrompt()
+
+    expect(prompt).toContain(
+      'independent searches for several angles in the same step'
+    )
+    expect(prompt).toContain('Use sequential searches only when')
+    expect(prompt).toContain('at most 3 searches in parallel')
+  })
+
+  it('does not add bounded parallel searches to quick mode', () => {
+    const prompt = getQuickModePrompt()
+
+    expect(prompt).not.toContain(
+      'independent searches for several angles in the same step'
+    )
+    expect(prompt).not.toContain('Use sequential searches only when')
+    expect(prompt).not.toContain('at most 3 searches in parallel')
+  })
+})

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -180,6 +180,8 @@ function getApproachStrategy(): string {
    - Use type="general" for current events/news (then fetch for content)
    - Pattern: Search → Identify top sources → Fetch if needed → Synthesize
    - Multiple searches with different angles for comprehensive coverage
+   - Issue independent searches for several angles in the same step, with at most 3 searches in parallel
+   - Use sequential searches only when the next query depends on a previous result
 
 Mandatory search for questions:
 - If the user's message contains a URL, fetch the provided URL - do NOT search first


### PR DESCRIPTION
## Problem

In adaptive mode, a query that needs several independent research angles gets one search at a time. Each search is its own step, so work that has no ordering dependency between the angles is serialized and the research phase runs longer than it needs to.

## Root cause

`getApproachStrategy()` in `lib/agents/prompts/search-mode-prompts.ts` tells the model to use "multiple searches with different angles" but never says when they may go out together. Nothing in the stack prevents it: `parallelToolCalls` is not set anywhere in the repository, so the AI SDK and provider default (parallel tool calls enabled) applies. The instruction was the only thing missing.

## Fix

Two bullets in the `Search and fetch strategy` section of `getApproachStrategy()`:

- issue independent searches for several angles in the same step, at most 3 in parallel
- keep searches sequential only when the next query depends on a previous result

The fan-out cap is there to bound search-provider calls per step.

`getApproachStrategy()` is referenced only from `getAdaptiveModePrompt()`, so quick mode is untouched. No tool, UI, or provider configuration changes.

## Verification

`bun lint`, `bun typecheck`, `bun format:check`, `bun run build` and `bun run test` all pass. A new `lib/agents/prompts/__tests__/search-mode-prompts.test.ts` asserts the instruction is present in the adaptive prompt and absent from the quick prompt, so the mode boundary this change rests on is covered by a test.

## Why this is a draft

An offline replay over a fixed query set does not support shipping this as it stands.

The intent was to shorten the research phase on heavy turns. That is not what happened. Splitting the turns by how many tool calls they made, the light turns did get faster, while the turns that make the most tool calls, the ones this change was written for, got slower. The paired median across the whole set is flat. Issuing several searches at once makes a step wait on the slowest of them and lands all of their results in context together, which appears to cost more than the serialization it removes precisely where the turn is already heavy.

There is a second effect worth a decision. Larger, less frequent context increments reuse less of the prompt cache than the incremental append that sequential searches produce, so the same answer is assembled from more uncached input. That works against the context and cost direction of the recent search projection work.

Quality held: citation resolution was unchanged, the structured-output rate did not regress, and answer length was flat.

Open questions for a reviewer: whether to retry with a fan-out cap of 2, whether to scope the instruction to light turns only, or whether the sequential default is simply correct here and this should be dropped. Numbers behind the above are in the internal run log.
