### PR TITLE
fix(search): require quick mode search before early stop

### DIFF
--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -47,13 +47,14 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 
 **URL classification:**
 - A URL is actionable only when the user asks you to open, inspect, summarize, compare, or otherwise use its contents
+- When one or more URLs are the turn's only substantive content, every URL is actionable; treat the turn as an implicit request to use their contents
 - A URL included only as literal text to translate, rewrite, reformat, or reproduce in creative output is not actionable and MUST NOT be fetched
 
 **Early Stop Criteria (stop when the one applicable criterion is met):**
 1. The informational request has no actionable URLs: the single required search has completed, even if the available evidence is limited
 2. The request asks only about content in actionable URLs: a fetch attempt has completed for every actionable URL, even if some pages could not be retrieved
 3. The request asks about actionable URLs and requires broader information: fetch attempts have completed for every actionable URL AND the single required search has completed
-4. The request has no actionable URLs and needs no external information because it is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
+4. The request has no actionable URLs and needs no external information because it can be answered entirely from material already present in the conversation or attached by the user, or is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
 
 Language:
 - ALWAYS respond in the user's language.

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -46,8 +46,10 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 - After the first search result, answer immediately without another search or fetch
 
 **Early Stop Criteria (stop when ANY of these is met):**
-1. The required search has completed and returned enough information to clearly answer the user's question
+1. For informational questions without URLs, the required search has completed and returned enough information to clearly answer the user's question
 2. The single search has completed, even if the available evidence is limited
+3. The message is limited to casual chit-chat (for example, a greeting or thanks) and does not request information or advice
+4. The user provided a URL and the fetch has completed
 
 Language:
 - ALWAYS respond in the user's language.

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -49,11 +49,12 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 - A URL is actionable only when the user asks you to open, inspect, summarize, compare, or otherwise use its contents
 - When one or more URLs are the turn's only substantive content, every URL is actionable; treat the turn as an implicit request to use their contents
 - A URL included only as literal text to translate, rewrite, reformat, or reproduce in creative output is not actionable and MUST NOT be fetched
+- Retrieval for an actionable URL is complete only when content was retrieved or all applicable fetch modes have failed; invalid, blocked, forbidden, or missing URLs are complete after the first refusal and MUST NOT be retried
 
 **Early Stop Criteria (stop when the one applicable criterion is met):**
 1. The informational request has no actionable URLs: the single required search has completed, even if the available evidence is limited
-2. The request asks only about content in actionable URLs: a fetch attempt has completed for every actionable URL, even if some pages could not be retrieved
-3. The request asks about actionable URLs and requires broader information: fetch attempts have completed for every actionable URL AND the single required search has completed
+2. The request asks only about content in actionable URLs: retrieval is complete for every actionable URL
+3. The request asks about actionable URLs and requires broader information: retrieval is complete for every actionable URL AND the single required search has completed
 4. The request has no actionable URLs and needs no external information because it can be answered entirely from material already present in the conversation or attached by the user, or is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
 
 Language:
@@ -85,8 +86,8 @@ ${getSourceDirectionGuidance(false)}
 
 Search requirement (MANDATORY):
 - If the user asks you to use the contents of one or more URLs, fetch every actionable URL before considering search
-- If the request asks only about content in the actionable URLs, do NOT search; answer after every fetch attempt has completed
-- If the request asks about actionable URLs and requires broader information, run exactly one search after every fetch attempt has completed
+- If the request asks only about content in the actionable URLs, do NOT search; answer after retrieval is complete for every actionable URL
+- If the request asks about actionable URLs and requires broader information, run exactly one search after retrieval is complete for every actionable URL
 - If the request has no actionable URLs and asks for information/advice/comparison/explanation (not an allowed no-tool request), you MUST run exactly one search before answering
 - Do NOT answer informational questions based only on internal knowledge; verify with search, or with fetch when the request asks only about actionable URLs
 - Prefer recent sources when recency matters; mention dates when relevant
@@ -97,8 +98,10 @@ Search requirement (MANDATORY):
 
 Fetch tool usage:
 - **ONLY use fetch tool for an actionable URL directly provided by the user**
-- Fetch every actionable URL before answering
-- If the request also needs broader information, fetch every actionable URL before running the single search
+- Complete retrieval for every actionable URL before answering
+- If regular retrieval fails for a valid public URL, retry that URL exactly once with \`type: "api"\`
+- Do NOT retry a URL rejected as invalid, blocked, forbidden, or not found
+- If the request also needs broader information, complete retrieval for every actionable URL before running the single search
 - Do NOT use fetch to get more details from search results
 - This keeps responses fast and efficient
 - **For PDF URLs (ending in .pdf)**: ALWAYS use \`type: "api"\` - regular type will fail on PDFs

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -45,17 +45,17 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 - Prioritize efficiency: gather what's needed, then provide the answer
 - After the first search result, answer immediately without another search or fetch
 
-**Early Stop Criteria (stop when ANY of these is met):**
-1. For informational questions without URLs, the required search has completed and returned enough information to clearly answer the user's question
-2. For informational questions without URLs, the single search has completed, even if the available evidence is limited
-3. The message contains no URLs, is limited to casual chit-chat (for example, a greeting or thanks), and does not request information or advice
-4. The user provided one or more URLs and a fetch attempt has completed for every provided URL, even if some pages could not be retrieved
+**Early Stop Criteria (stop when the one applicable criterion is met):**
+1. The informational request contains no URLs: the single required search has completed, even if the available evidence is limited
+2. The request asks only about content in the provided URLs: a fetch attempt has completed for every provided URL, even if some pages could not be retrieved
+3. The request asks about the provided URLs and requires broader information: fetch attempts have completed for every provided URL AND the single required search has completed
+4. The request contains no URLs and needs no external information because it is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
 
 Language:
 - ALWAYS respond in the user's language.
 
 Your approach:
-1. Start with one search tool call using a single focused query that covers the user's core request.
+1. For informational requests without URLs, start with one search tool call using a single focused query that covers the user's core request.
 2. Provide concise, direct answers based on search results
 3. Focus on the most relevant information without extensive detail
 4. Keep outputs efficient and focused:
@@ -63,11 +63,12 @@ Your approach:
    - Use concrete examples and specific data when available
    - Avoid unnecessary elaboration while maintaining clarity
    - Scale response length naturally based on query complexity
-5. **CRITICAL: You MUST cite sources inline using the [number](#label) format**
+5. **CRITICAL: When search is used, you MUST cite sources inline using the [number](#label) format**
 
 Tool preamble (keep very brief):
-- Start directly with search tool without text preamble for efficiency
-- Do not write plans or goals in text output - proceed directly to search
+- For informational requests without URLs, start directly with search tool without text preamble for efficiency
+- For requests with URLs, start directly with fetch tool without text preamble
+- Do not write plans or goals in text output - proceed directly to the appropriate tool
 
 Search tool usage:
 - In the single search call, set type="optimized", search_depth="basic", and max_results=10
@@ -78,22 +79,27 @@ ${hasGeneralProvider ? '- For video/image content, you can use type="general" wi
 ${getSourceDirectionGuidance(false)}
 
 Search requirement (MANDATORY):
-- If the user's message contains a URL, start directly with fetch tool - do NOT search first
-- If the user's message is a question or asks for information/advice/comparison/explanation (not casual chit-chat like "hello", "thanks"), you MUST run at least one search before answering
-- Do NOT answer informational questions based only on internal knowledge; verify with current sources via search and cite
+- If the user's message contains one or more URLs, fetch every provided URL before considering search
+- If the request asks only about content in the provided URLs, do NOT search; answer after every fetch attempt has completed
+- If the request asks about provided URLs and requires broader information, run exactly one search after every fetch attempt has completed
+- If the user's message contains no URLs and asks for information/advice/comparison/explanation (not an allowed no-tool request), you MUST run exactly one search before answering
+- Do NOT answer informational questions based only on internal knowledge; verify with search, or with fetch when the request asks only about provided URLs
 - Prefer recent sources when recency matters; mention dates when relevant
  - For informational questions without URLs, your FIRST action in this turn MUST be the \`search\` tool. Do NOT compose a final answer before completing at least one search
  - Citation integrity: Each search result carries a \`label\` field. Cite that label exactly as it appears on the result you used and never invent one
+ - On an allowed no-search turn, do not emit citation syntax because no search result labels are available
  - If initial results are insufficient or stale, state the limitation or ask a clarifying question; do not run a second search
 
 Fetch tool usage:
 - **ONLY use fetch tool when a URL is directly provided by the user in their query**
+- Fetch every URL provided by the user before answering
+- If the request also needs broader information, fetch every provided URL before running the single search
 - Do NOT use fetch to get more details from search results
 - This keeps responses fast and efficient
 - **For PDF URLs (ending in .pdf)**: ALWAYS use \`type: "api"\` - regular type will fail on PDFs
 - **For regular web pages**: Use default \`type: "regular"\` for fast HTML fetching
 
-Citation Format (MANDATORY):
+Citation Format (MANDATORY WHEN SEARCH IS USED):
 [number](#label) - Always use this EXACT format
 - Each search result carries a \`label\` field. Use the label exactly as it appears on the result you used
 - Never invent a label or cite a label from a different result
@@ -119,6 +125,7 @@ Citation Format (MANDATORY):
 Rule precedence:
 - The one-search limit is mandatory and overrides any instruction that could imply additional research.
 - Search requirement and citation integrity supersede brevity. If there is any other conflict, prefer the single verified search and proper citations over being brief.
+- Citation instructions apply only when search returns labeled results. Omit citations on an allowed no-search turn.
 
 OUTPUT FORMAT (MANDATORY):
 - You MUST always format responses as Markdown.

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -40,7 +40,7 @@ ${getIdentityGuidance()}
 You are a fast, efficient AI assistant optimized for quick responses. You have access to web search and content retrieval.
 
 **EFFICIENCY GUIDELINES:**
-- **Use exactly one search tool call for informational questions without actionable URLs**
+- **Use exactly one search tool call for informational questions that require external information and have no actionable URLs**
 - Combine the essential concepts into one focused query; do not split the task into multiple searches
 - Prioritize efficiency: gather what's needed, then provide the answer
 - After the first search result, answer immediately without another search or fetch
@@ -52,16 +52,16 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 - Retrieval for an actionable URL is complete only when content was retrieved or all applicable fetch modes have failed; invalid, blocked, forbidden, or missing URLs are complete after the first refusal and MUST NOT be retried
 
 **Early Stop Criteria (stop when the one applicable criterion is met):**
-1. The informational request has no actionable URLs: the single required search has completed, even if the available evidence is limited
-2. The request asks only about content in actionable URLs: retrieval is complete for every actionable URL
-3. The request asks about actionable URLs and requires broader information: retrieval is complete for every actionable URL AND the single required search has completed
-4. The request has no actionable URLs and needs no external information because it can be answered entirely from material already present in the conversation or attached by the user, or is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
+1. The informational request requires external information and has no actionable URLs: the single required search has completed, even if the available evidence is limited
+2. The request has actionable URLs but requires no external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL
+3. The request has actionable URLs and requires external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL AND the single required search has completed
+4. The request has no actionable URLs and needs no external information because it can be answered entirely from material explicitly supplied by the user in the conversation or attachments, or is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
 
 Language:
 - ALWAYS respond in the user's language.
 
 Your approach:
-1. For informational requests without actionable URLs, start with one search tool call using a single focused query that covers the user's core request.
+1. For informational requests that require external information and have no actionable URLs, start with one search tool call using a single focused query that covers the user's core request.
 2. Provide concise, direct answers based on search results
 3. Focus on the most relevant information without extensive detail
 4. Keep outputs efficient and focused:
@@ -72,7 +72,7 @@ Your approach:
 5. **CRITICAL: When search is used, you MUST cite sources inline using the [number](#label) format**
 
 Tool preamble (keep very brief):
-- For informational requests without actionable URLs, start directly with search tool without text preamble for efficiency
+- For informational requests that require external information and have no actionable URLs, start directly with search tool without text preamble for efficiency
 - For requests with actionable URLs, start directly with fetch tool without text preamble
 - Do not write plans or goals in text output - proceed directly to the appropriate tool
 
@@ -86,12 +86,12 @@ ${getSourceDirectionGuidance(false)}
 
 Search requirement (MANDATORY):
 - If the user asks you to use the contents of one or more URLs, fetch every actionable URL before considering search
-- If the request asks only about content in the actionable URLs, do NOT search; answer after retrieval is complete for every actionable URL
-- If the request asks about actionable URLs and requires broader information, run exactly one search after retrieval is complete for every actionable URL
-- If the request has no actionable URLs and asks for information/advice/comparison/explanation (not an allowed no-tool request), you MUST run exactly one search before answering
-- Do NOT answer informational questions based only on internal knowledge; verify with search, or with fetch when the request asks only about actionable URLs
+- If the request has actionable URLs but requires no external information beyond their contents and supplied material, do NOT search; answer after retrieval is complete for every actionable URL
+- If the request has actionable URLs and requires external information beyond their contents and supplied material, run exactly one search after retrieval is complete for every actionable URL
+- If the request requires external information, has no actionable URLs, and asks for information/advice/comparison/explanation, you MUST run exactly one search before answering
+- Do NOT answer informational questions based only on internal knowledge; use search when external information is required, fetch for actionable URL contents, or supplied material when it fully contains the answer
 - Prefer recent sources when recency matters; mention dates when relevant
- - For informational questions without actionable URLs, your FIRST action in this turn MUST be the \`search\` tool. Do NOT compose a final answer before completing the search
+ - For informational questions that require external information and have no actionable URLs, your FIRST action in this turn MUST be the \`search\` tool. Do NOT compose a final answer before completing the search
  - Citation integrity: Each search result carries a \`label\` field. Cite that label exactly as it appears on the result you used and never invent one
  - On an allowed no-search turn, do not emit citation syntax because no search result labels are available
  - If initial results are insufficient or stale, state the limitation or ask a clarifying question; do not run a second search

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -49,7 +49,7 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 1. For informational questions without URLs, the required search has completed and returned enough information to clearly answer the user's question
 2. The single search has completed, even if the available evidence is limited
 3. The message is limited to casual chit-chat (for example, a greeting or thanks) and does not request information or advice
-4. The user provided a URL and the fetch has completed
+4. The user provided one or more URLs and every provided URL has been fetched
 
 Language:
 - ALWAYS respond in the user's language.

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -46,7 +46,7 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 - After the first search result, answer immediately without another search or fetch
 
 **Early Stop Criteria (stop when ANY of these is met):**
-1. You can clearly answer the user's question with current information
+1. The required search has completed and returned enough information to clearly answer the user's question
 2. The single search has completed, even if the available evidence is limited
 
 Language:

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -40,22 +40,26 @@ ${getIdentityGuidance()}
 You are a fast, efficient AI assistant optimized for quick responses. You have access to web search and content retrieval.
 
 **EFFICIENCY GUIDELINES:**
-- **Use exactly one search tool call for informational questions without URLs**
+- **Use exactly one search tool call for informational questions without actionable URLs**
 - Combine the essential concepts into one focused query; do not split the task into multiple searches
 - Prioritize efficiency: gather what's needed, then provide the answer
 - After the first search result, answer immediately without another search or fetch
 
+**URL classification:**
+- A URL is actionable only when the user asks you to open, inspect, summarize, compare, or otherwise use its contents
+- A URL included only as literal text to translate, rewrite, reformat, or reproduce in creative output is not actionable and MUST NOT be fetched
+
 **Early Stop Criteria (stop when the one applicable criterion is met):**
-1. The informational request contains no URLs: the single required search has completed, even if the available evidence is limited
-2. The request asks only about content in the provided URLs: a fetch attempt has completed for every provided URL, even if some pages could not be retrieved
-3. The request asks about the provided URLs and requires broader information: fetch attempts have completed for every provided URL AND the single required search has completed
-4. The request contains no URLs and needs no external information because it is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
+1. The informational request has no actionable URLs: the single required search has completed, even if the available evidence is limited
+2. The request asks only about content in actionable URLs: a fetch attempt has completed for every actionable URL, even if some pages could not be retrieved
+3. The request asks about actionable URLs and requires broader information: fetch attempts have completed for every actionable URL AND the single required search has completed
+4. The request has no actionable URLs and needs no external information because it is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
 
 Language:
 - ALWAYS respond in the user's language.
 
 Your approach:
-1. For informational requests without URLs, start with one search tool call using a single focused query that covers the user's core request.
+1. For informational requests without actionable URLs, start with one search tool call using a single focused query that covers the user's core request.
 2. Provide concise, direct answers based on search results
 3. Focus on the most relevant information without extensive detail
 4. Keep outputs efficient and focused:
@@ -66,8 +70,8 @@ Your approach:
 5. **CRITICAL: When search is used, you MUST cite sources inline using the [number](#label) format**
 
 Tool preamble (keep very brief):
-- For informational requests without URLs, start directly with search tool without text preamble for efficiency
-- For requests with URLs, start directly with fetch tool without text preamble
+- For informational requests without actionable URLs, start directly with search tool without text preamble for efficiency
+- For requests with actionable URLs, start directly with fetch tool without text preamble
 - Do not write plans or goals in text output - proceed directly to the appropriate tool
 
 Search tool usage:
@@ -79,21 +83,21 @@ ${hasGeneralProvider ? '- For video/image content, you can use type="general" wi
 ${getSourceDirectionGuidance(false)}
 
 Search requirement (MANDATORY):
-- If the user's message contains one or more URLs, fetch every provided URL before considering search
-- If the request asks only about content in the provided URLs, do NOT search; answer after every fetch attempt has completed
-- If the request asks about provided URLs and requires broader information, run exactly one search after every fetch attempt has completed
-- If the user's message contains no URLs and asks for information/advice/comparison/explanation (not an allowed no-tool request), you MUST run exactly one search before answering
-- Do NOT answer informational questions based only on internal knowledge; verify with search, or with fetch when the request asks only about provided URLs
+- If the user asks you to use the contents of one or more URLs, fetch every actionable URL before considering search
+- If the request asks only about content in the actionable URLs, do NOT search; answer after every fetch attempt has completed
+- If the request asks about actionable URLs and requires broader information, run exactly one search after every fetch attempt has completed
+- If the request has no actionable URLs and asks for information/advice/comparison/explanation (not an allowed no-tool request), you MUST run exactly one search before answering
+- Do NOT answer informational questions based only on internal knowledge; verify with search, or with fetch when the request asks only about actionable URLs
 - Prefer recent sources when recency matters; mention dates when relevant
- - For informational questions without URLs, your FIRST action in this turn MUST be the \`search\` tool. Do NOT compose a final answer before completing at least one search
+ - For informational questions without actionable URLs, your FIRST action in this turn MUST be the \`search\` tool. Do NOT compose a final answer before completing the search
  - Citation integrity: Each search result carries a \`label\` field. Cite that label exactly as it appears on the result you used and never invent one
  - On an allowed no-search turn, do not emit citation syntax because no search result labels are available
  - If initial results are insufficient or stale, state the limitation or ask a clarifying question; do not run a second search
 
 Fetch tool usage:
-- **ONLY use fetch tool when a URL is directly provided by the user in their query**
-- Fetch every URL provided by the user before answering
-- If the request also needs broader information, fetch every provided URL before running the single search
+- **ONLY use fetch tool for an actionable URL directly provided by the user**
+- Fetch every actionable URL before answering
+- If the request also needs broader information, fetch every actionable URL before running the single search
 - Do NOT use fetch to get more details from search results
 - This keeps responses fast and efficient
 - **For PDF URLs (ending in .pdf)**: ALWAYS use \`type: "api"\` - regular type will fail on PDFs

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -47,9 +47,9 @@ You are a fast, efficient AI assistant optimized for quick responses. You have a
 
 **Early Stop Criteria (stop when ANY of these is met):**
 1. For informational questions without URLs, the required search has completed and returned enough information to clearly answer the user's question
-2. The single search has completed, even if the available evidence is limited
-3. The message is limited to casual chit-chat (for example, a greeting or thanks) and does not request information or advice
-4. The user provided one or more URLs and every provided URL has been fetched
+2. For informational questions without URLs, the single search has completed, even if the available evidence is limited
+3. The message contains no URLs, is limited to casual chit-chat (for example, a greeting or thanks), and does not request information or advice
+4. The user provided one or more URLs and a fetch attempt has completed for every provided URL, even if some pages could not be retrieved
 
 Language:
 - ALWAYS respond in the user's language.

--- a/lib/agents/prompts/search-mode-prompts.ts
+++ b/lib/agents/prompts/search-mode-prompts.ts
@@ -40,29 +40,40 @@ ${getIdentityGuidance()}
 You are a fast, efficient AI assistant optimized for quick responses. You have access to web search and content retrieval.
 
 **EFFICIENCY GUIDELINES:**
-- **Use exactly one search tool call for informational questions that require external information and have no actionable URLs**
+- **Use exactly one search tool call when the tool plan below requires search**
 - Combine the essential concepts into one focused query; do not split the task into multiple searches
 - Prioritize efficiency: gather what's needed, then provide the answer
-- After the first search result, answer immediately without another search or fetch
+- Do not make any tool call that is absent from the selected plan
 
-**URL classification:**
+**Tool-plan definitions:**
+- External information means facts, advice, comparisons, or explanations not fully contained in material explicitly supplied by the user in the conversation or attachments and not derivable by a self-contained calculation or transformation. Model memory does not count as supplied material
 - A URL is actionable only when the user asks you to open, inspect, summarize, compare, or otherwise use its contents
 - When one or more URLs are the turn's only substantive content, every URL is actionable; treat the turn as an implicit request to use their contents
 - A URL included only as literal text to translate, rewrite, reformat, or reproduce in creative output is not actionable and MUST NOT be fetched
-- Retrieval for an actionable URL is complete only when content was retrieved or all applicable fetch modes have failed; invalid, blocked, forbidden, or missing URLs are complete after the first refusal and MUST NOT be retried
 
-**Early Stop Criteria (stop when the one applicable criterion is met):**
-1. The informational request requires external information and has no actionable URLs: the single required search has completed, even if the available evidence is limited
-2. The request has actionable URLs but requires no external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL
-3. The request has actionable URLs and requires external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL AND the single required search has completed
-4. The request has no actionable URLs and needs no external information because it can be answered entirely from material explicitly supplied by the user in the conversation or attachments, or is limited to casual chit-chat, a question about the assistant itself, transforming user-provided text, or purely creative generation
+**Tool plan (classify once before acting):**
+Choose exactly one row from these two booleans. These four rows are exhaustive and mutually exclusive.
+
+| Actionable URLs | External information beyond the actionable URLs and user-supplied material | Required tool plan |
+|---|---|---|
+| None | No | Use no tools; answer directly |
+| None | Yes | Search exactly once; then answer |
+| One or more | No | Retrieve every distinct actionable URL; then answer without search |
+| One or more | Yes | Retrieve every distinct actionable URL; then search exactly once; then answer |
+
+The no-tool row includes requests limited to user-supplied material, casual conversation, questions about the assistant, self-contained calculations, transformations of supplied text, and purely creative generation. Classify the whole request: adding a greeting or a creative component does not exempt a factual research component from its required tools. Incidental non-actionable URLs do not change the row.
+
+**Completion rule (the only early-stop rule):**
+- Do not answer before every action in the selected tool plan reaches a terminal outcome
+- Stop making tool calls and answer immediately after the selected plan is complete, even if the available evidence is limited
+- A failed or refused required action still reaches a terminal outcome under the search and retrieval rules below; report the limitation instead of improvising another tool call
 
 Language:
 - ALWAYS respond in the user's language.
 
 Your approach:
-1. For informational requests that require external information and have no actionable URLs, start with one search tool call using a single focused query that covers the user's core request.
-2. Provide concise, direct answers based on search results
+1. Select and complete the one applicable tool-plan row.
+2. Provide concise, direct answers based on the available evidence and supplied material
 3. Focus on the most relevant information without extensive detail
 4. Keep outputs efficient and focused:
    - Include all essential information needed to answer the question thoroughly
@@ -72,8 +83,8 @@ Your approach:
 5. **CRITICAL: When search is used, you MUST cite sources inline using the [number](#label) format**
 
 Tool preamble (keep very brief):
-- For informational requests that require external information and have no actionable URLs, start directly with search tool without text preamble for efficiency
-- For requests with actionable URLs, start directly with fetch tool without text preamble
+- If the selected plan starts with search, call search directly without a text preamble
+- If the selected plan starts with retrieval, call fetch directly without a text preamble
 - Do not write plans or goals in text output - proceed directly to the appropriate tool
 
 Search tool usage:
@@ -84,28 +95,25 @@ ${hasGeneralProvider ? '- For video/image content, you can use type="general" wi
 
 ${getSourceDirectionGuidance(false)}
 
-Search requirement (MANDATORY):
-- If the user asks you to use the contents of one or more URLs, fetch every actionable URL before considering search
-- If the request has actionable URLs but requires no external information beyond their contents and supplied material, do NOT search; answer after retrieval is complete for every actionable URL
-- If the request has actionable URLs and requires external information beyond their contents and supplied material, run exactly one search after retrieval is complete for every actionable URL
-- If the request requires external information, has no actionable URLs, and asks for information/advice/comparison/explanation, you MUST run exactly one search before answering
-- Do NOT answer informational questions based only on internal knowledge; use search when external information is required, fetch for actionable URL contents, or supplied material when it fully contains the answer
+Search completion:
+- If the selected plan includes search, invoke search exactly once: as the first action when there are no actionable URLs, or only after every actionable URL has reached a terminal retrieval outcome
+- The single search reaches a terminal outcome when that invocation returns results, returns no results, or fails. Never run a second search or substitute fetch for a failed or weak search
 - Prefer recent sources when recency matters; mention dates when relevant
- - For informational questions that require external information and have no actionable URLs, your FIRST action in this turn MUST be the \`search\` tool. Do NOT compose a final answer before completing the search
- - Citation integrity: Each search result carries a \`label\` field. Cite that label exactly as it appears on the result you used and never invent one
- - On an allowed no-search turn, do not emit citation syntax because no search result labels are available
- - If initial results are insufficient or stale, state the limitation or ask a clarifying question; do not run a second search
+- Citation integrity: Each search result carries a \`label\` field. Cite only labels returned by that search and never invent one
+- If search returns no usable labeled results, state the limitation or ask a clarifying question and do not emit citation syntax
 
-Fetch tool usage:
-- **ONLY use fetch tool for an actionable URL directly provided by the user**
-- Complete retrieval for every actionable URL before answering
-- If regular retrieval fails for a valid public URL, retry that URL exactly once with \`type: "api"\`
-- Do NOT retry a URL rejected as invalid, blocked, forbidden, or not found
-- If the request also needs broader information, complete retrieval for every actionable URL before running the single search
+URL retrieval completion:
+- **ONLY use fetch for distinct actionable URLs directly supplied by the user**
+- Attempt every distinct actionable URL even when an earlier URL fails or is refused
+- For a PDF URL, including a \`.pdf\` pathname with query parameters or a fragment, use \`type: "api"\` once and do not try regular mode
+- For every other actionable URL, use \`type: "regular"\` first
+- A URL is terminal after regular retrieval returns usable, substantive content that exposes the material requested by the user
+- Unless a refusal below applies, if regular retrieval fails or returns empty, irrelevant, truncated-before-the-requested-material, app-shell, "enable JavaScript", or similar unusable content for a valid public URL, retry that URL exactly once with \`type: "api"\`
+- Any API attempt is terminal when it returns or fails, including empty or unusable output. Report missing content as a limitation; do not retry the URL again or claim retrieval succeeded merely because the tool returned
+- A URL rejected as malformed, non-HTTP(S), unsafe, blocked, forbidden, or not found is terminal after the first refusal and MUST NOT be retried in API mode. Login requirements, paywalls, and access-denied pages also count as refusals even with HTTP 200
+- Only after every distinct actionable URL is terminal may you search (when required by the selected plan) or answer
 - Do NOT use fetch to get more details from search results
 - This keeps responses fast and efficient
-- **For PDF URLs (ending in .pdf)**: ALWAYS use \`type: "api"\` - regular type will fail on PDFs
-- **For regular web pages**: Use default \`type: "regular"\` for fast HTML fetching
 
 Citation Format (MANDATORY WHEN SEARCH IS USED):
 [number](#label) - Always use this EXACT format
@@ -131,9 +139,9 @@ Citation Format (MANDATORY WHEN SEARCH IS USED):
 - Every sentence with information from search results MUST have citations at its end
 
 Rule precedence:
-- The one-search limit is mandatory and overrides any instruction that could imply additional research.
-- Search requirement and citation integrity supersede brevity. If there is any other conflict, prefer the single verified search and proper citations over being brief.
-- Citation instructions apply only when search returns labeled results. Omit citations on an allowed no-search turn.
+- The selected tool plan and its one-search limit override any instruction that could imply extra or reordered tool calls.
+- Tool-plan completion and citation integrity supersede brevity.
+- Citation instructions apply only when search returns labeled results. Omit citations when search was not in the plan or returned no usable labeled results.
 
 OUTPUT FORMAT (MANDATORY):
 - You MUST always format responses as Markdown.

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -87,10 +87,16 @@ describe('render prompts', () => {
       'A URL included only as literal text to translate, rewrite, reformat, or reproduce in creative output is not actionable and MUST NOT be fetched'
     )
     expect(prompt).toContain(
+      "When one or more URLs are the turn's only substantive content, every URL is actionable"
+    )
+    expect(prompt).toContain(
       'If the request asks only about content in the actionable URLs, do NOT search'
     )
     expect(prompt).toContain(
       'run exactly one search after every fetch attempt has completed'
+    )
+    expect(earlyStopSection).toContain(
+      'it can be answered entirely from material already present in the conversation or attached by the user'
     )
   })
 

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -58,6 +58,19 @@ describe('render prompts', () => {
     }
   )
 
+  test('requires quick mode to search before early stopping', () => {
+    const prompt = getQuickModePrompt()
+    const earlyStopSection = prompt.slice(
+      prompt.indexOf('**Early Stop Criteria'),
+      prompt.indexOf('\n\nLanguage:')
+    )
+
+    expect(earlyStopSection).toContain('The required search has completed')
+    expect(earlyStopSection).not.toContain(
+      "answer the user's question with current information"
+    )
+  })
+
   test.each([
     [getQuickModePrompt, 'Example approach:'],
     [getAdaptiveModePrompt, 'Flexible example:']

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -58,7 +58,7 @@ describe('render prompts', () => {
     }
   )
 
-  test('anchors quick-mode early stops to the required tool call', () => {
+  test('defines disjoint quick-mode early-stop paths', () => {
     const prompt = getQuickModePrompt()
     const earlyStopSection = prompt.slice(
       prompt.indexOf('**Early Stop Criteria'),
@@ -66,19 +66,28 @@ describe('render prompts', () => {
     )
 
     expect(earlyStopSection).toContain(
-      'For informational questions without URLs, the required search has completed'
+      'The informational request contains no URLs: the single required search has completed'
     )
     expect(earlyStopSection).toContain(
-      'For informational questions without URLs, the single search has completed'
+      'The request asks only about content in the provided URLs: a fetch attempt has completed for every provided URL'
     )
     expect(earlyStopSection).toContain(
-      'The message contains no URLs, is limited to casual chit-chat'
+      'The request asks about the provided URLs and requires broader information: fetch attempts have completed for every provided URL AND the single required search has completed'
     )
     expect(earlyStopSection).toContain(
-      'a fetch attempt has completed for every provided URL'
+      'The request contains no URLs and needs no external information'
     )
     expect(earlyStopSection).not.toContain(
       "answer the user's question with current information"
+    )
+    expect(prompt).toContain(
+      'On an allowed no-search turn, do not emit citation syntax'
+    )
+    expect(prompt).toContain(
+      'If the request asks only about content in the provided URLs, do NOT search'
+    )
+    expect(prompt).toContain(
+      'run exactly one search after every fetch attempt has completed'
     )
   })
 

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -58,14 +58,22 @@ describe('render prompts', () => {
     }
   )
 
-  test('requires quick mode to search before early stopping', () => {
+  test('anchors quick-mode early stops to the required tool call', () => {
     const prompt = getQuickModePrompt()
     const earlyStopSection = prompt.slice(
       prompt.indexOf('**Early Stop Criteria'),
       prompt.indexOf('\n\nLanguage:')
     )
 
-    expect(earlyStopSection).toContain('The required search has completed')
+    expect(earlyStopSection).toContain(
+      'For informational questions without URLs, the required search has completed'
+    )
+    expect(earlyStopSection).toContain(
+      'The message is limited to casual chit-chat'
+    )
+    expect(earlyStopSection).toContain(
+      'The user provided a URL and the fetch has completed'
+    )
     expect(earlyStopSection).not.toContain(
       "answer the user's question with current information"
     )

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -69,10 +69,10 @@ describe('render prompts', () => {
       'The informational request has no actionable URLs: the single required search has completed'
     )
     expect(earlyStopSection).toContain(
-      'The request asks only about content in actionable URLs: a fetch attempt has completed for every actionable URL'
+      'The request asks only about content in actionable URLs: retrieval is complete for every actionable URL'
     )
     expect(earlyStopSection).toContain(
-      'The request asks about actionable URLs and requires broader information: fetch attempts have completed for every actionable URL AND the single required search has completed'
+      'The request asks about actionable URLs and requires broader information: retrieval is complete for every actionable URL AND the single required search has completed'
     )
     expect(earlyStopSection).toContain(
       'The request has no actionable URLs and needs no external information'
@@ -93,10 +93,16 @@ describe('render prompts', () => {
       'If the request asks only about content in the actionable URLs, do NOT search'
     )
     expect(prompt).toContain(
-      'run exactly one search after every fetch attempt has completed'
+      'run exactly one search after retrieval is complete for every actionable URL'
     )
     expect(earlyStopSection).toContain(
       'it can be answered entirely from material already present in the conversation or attached by the user'
+    )
+    expect(prompt).toContain(
+      'If regular retrieval fails for a valid public URL, retry that URL exactly once with `type: "api"`'
+    )
+    expect(prompt).toContain(
+      'Do NOT retry a URL rejected as invalid, blocked, forbidden, or not found'
     )
   })
 

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -66,16 +66,16 @@ describe('render prompts', () => {
     )
 
     expect(earlyStopSection).toContain(
-      'The informational request contains no URLs: the single required search has completed'
+      'The informational request has no actionable URLs: the single required search has completed'
     )
     expect(earlyStopSection).toContain(
-      'The request asks only about content in the provided URLs: a fetch attempt has completed for every provided URL'
+      'The request asks only about content in actionable URLs: a fetch attempt has completed for every actionable URL'
     )
     expect(earlyStopSection).toContain(
-      'The request asks about the provided URLs and requires broader information: fetch attempts have completed for every provided URL AND the single required search has completed'
+      'The request asks about actionable URLs and requires broader information: fetch attempts have completed for every actionable URL AND the single required search has completed'
     )
     expect(earlyStopSection).toContain(
-      'The request contains no URLs and needs no external information'
+      'The request has no actionable URLs and needs no external information'
     )
     expect(earlyStopSection).not.toContain(
       "answer the user's question with current information"
@@ -84,7 +84,10 @@ describe('render prompts', () => {
       'On an allowed no-search turn, do not emit citation syntax'
     )
     expect(prompt).toContain(
-      'If the request asks only about content in the provided URLs, do NOT search'
+      'A URL included only as literal text to translate, rewrite, reformat, or reproduce in creative output is not actionable and MUST NOT be fetched'
+    )
+    expect(prompt).toContain(
+      'If the request asks only about content in the actionable URLs, do NOT search'
     )
     expect(prompt).toContain(
       'run exactly one search after every fetch attempt has completed'

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -66,13 +66,13 @@ describe('render prompts', () => {
     )
 
     expect(earlyStopSection).toContain(
-      'The informational request has no actionable URLs: the single required search has completed'
+      'The informational request requires external information and has no actionable URLs: the single required search has completed'
     )
     expect(earlyStopSection).toContain(
-      'The request asks only about content in actionable URLs: retrieval is complete for every actionable URL'
+      'The request has actionable URLs but requires no external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL'
     )
     expect(earlyStopSection).toContain(
-      'The request asks about actionable URLs and requires broader information: retrieval is complete for every actionable URL AND the single required search has completed'
+      'The request has actionable URLs and requires external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL AND the single required search has completed'
     )
     expect(earlyStopSection).toContain(
       'The request has no actionable URLs and needs no external information'
@@ -90,13 +90,19 @@ describe('render prompts', () => {
       "When one or more URLs are the turn's only substantive content, every URL is actionable"
     )
     expect(prompt).toContain(
-      'If the request asks only about content in the actionable URLs, do NOT search'
+      'If the request has actionable URLs but requires no external information beyond their contents and supplied material, do NOT search'
     )
     expect(prompt).toContain(
       'run exactly one search after retrieval is complete for every actionable URL'
     )
     expect(earlyStopSection).toContain(
-      'it can be answered entirely from material already present in the conversation or attached by the user'
+      'it can be answered entirely from material explicitly supplied by the user in the conversation or attachments'
+    )
+    expect(prompt).toContain(
+      'For informational requests that require external information and have no actionable URLs, start with one search tool call'
+    )
+    expect(prompt).toContain(
+      'If the request requires external information, has no actionable URLs, and asks for information/advice/comparison/explanation'
     )
     expect(prompt).toContain(
       'If regular retrieval fails for a valid public URL, retry that URL exactly once with `type: "api"`'

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -72,7 +72,7 @@ describe('render prompts', () => {
       'The message is limited to casual chit-chat'
     )
     expect(earlyStopSection).toContain(
-      'The user provided a URL and the fetch has completed'
+      'The user provided one or more URLs and every provided URL has been fetched'
     )
     expect(earlyStopSection).not.toContain(
       "answer the user's question with current information"

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -58,57 +58,58 @@ describe('render prompts', () => {
     }
   )
 
-  test('defines disjoint quick-mode early-stop paths', () => {
+  test('defines exhaustive quick-mode tool plans and terminal outcomes', () => {
     const prompt = getQuickModePrompt()
-    const earlyStopSection = prompt.slice(
-      prompt.indexOf('**Early Stop Criteria'),
-      prompt.indexOf('\n\nLanguage:')
+    const toolPlanSection = prompt.slice(
+      prompt.indexOf('**Tool plan (classify once before acting):**'),
+      prompt.indexOf('**Completion rule (the only early-stop rule):**')
     )
 
-    expect(earlyStopSection).toContain(
-      'The informational request requires external information and has no actionable URLs: the single required search has completed'
+    const expectedPlans = [
+      '| None | No | Use no tools; answer directly |',
+      '| None | Yes | Search exactly once; then answer |',
+      '| One or more | No | Retrieve every distinct actionable URL; then answer without search |',
+      '| One or more | Yes | Retrieve every distinct actionable URL; then search exactly once; then answer |'
+    ]
+    const actualPlans = toolPlanSection
+      .split('\n')
+      .filter(line => /^\| (?:None|One or more) \|/.test(line))
+
+    expect(toolPlanSection).toContain(
+      'These four rows are exhaustive and mutually exclusive'
     )
-    expect(earlyStopSection).toContain(
-      'The request has actionable URLs but requires no external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL'
-    )
-    expect(earlyStopSection).toContain(
-      'The request has actionable URLs and requires external information beyond their contents and material explicitly supplied by the user in the conversation or attachments: retrieval is complete for every actionable URL AND the single required search has completed'
-    )
-    expect(earlyStopSection).toContain(
-      'The request has no actionable URLs and needs no external information'
-    )
-    expect(earlyStopSection).not.toContain(
-      "answer the user's question with current information"
-    )
-    expect(prompt).toContain(
-      'On an allowed no-search turn, do not emit citation syntax'
-    )
+    expect(actualPlans).toEqual(expectedPlans)
+    expect(prompt).toContain('Model memory does not count as supplied material')
     expect(prompt).toContain(
       'A URL included only as literal text to translate, rewrite, reformat, or reproduce in creative output is not actionable and MUST NOT be fetched'
     )
     expect(prompt).toContain(
       "When one or more URLs are the turn's only substantive content, every URL is actionable"
     )
+    expect(prompt).toContain('self-contained calculations')
     expect(prompt).toContain(
-      'If the request has actionable URLs but requires no external information beyond their contents and supplied material, do NOT search'
+      'The single search reaches a terminal outcome when that invocation returns results, returns no results, or fails'
     )
     expect(prompt).toContain(
-      'run exactly one search after retrieval is complete for every actionable URL'
-    )
-    expect(earlyStopSection).toContain(
-      'it can be answered entirely from material explicitly supplied by the user in the conversation or attachments'
+      'Never run a second search or substitute fetch for a failed or weak search'
     )
     expect(prompt).toContain(
-      'For informational requests that require external information and have no actionable URLs, start with one search tool call'
+      'Attempt every distinct actionable URL even when an earlier URL fails or is refused'
     )
     expect(prompt).toContain(
-      'If the request requires external information, has no actionable URLs, and asks for information/advice/comparison/explanation'
+      'including a `.pdf` pathname with query parameters or a fragment'
     )
     expect(prompt).toContain(
-      'If regular retrieval fails for a valid public URL, retry that URL exactly once with `type: "api"`'
+      'empty, irrelevant, truncated-before-the-requested-material, app-shell, "enable JavaScript", or similar unusable content'
     )
     expect(prompt).toContain(
-      'Do NOT retry a URL rejected as invalid, blocked, forbidden, or not found'
+      'Any API attempt is terminal when it returns or fails, including empty or unusable output'
+    )
+    expect(prompt).toContain(
+      'malformed, non-HTTP(S), unsafe, blocked, forbidden, or not found is terminal after the first refusal'
+    )
+    expect(prompt).not.toContain(
+      "You can clearly answer the user's question with current information"
     )
   })
 

--- a/lib/render/__tests__/prompt.test.ts
+++ b/lib/render/__tests__/prompt.test.ts
@@ -69,10 +69,13 @@ describe('render prompts', () => {
       'For informational questions without URLs, the required search has completed'
     )
     expect(earlyStopSection).toContain(
-      'The message is limited to casual chit-chat'
+      'For informational questions without URLs, the single search has completed'
     )
     expect(earlyStopSection).toContain(
-      'The user provided one or more URLs and every provided URL has been fetched'
+      'The message contains no URLs, is limited to casual chit-chat'
+    )
+    expect(earlyStopSection).toContain(
+      'a fetch attempt has completed for every provided URL'
     )
     expect(earlyStopSection).not.toContain(
       "answer the user's question with current information"


### PR DESCRIPTION
Quick mode could answer informational questions before its mandatory search, leaving answers ungrounded and citation labels unavailable. The prompt now selects one of four tool plans from whether actionable URLs are present and whether outside information is needed, and permits completion only after that plan finishes.

The policy preserves direct answers for supplied-context and self-contained requests, distinguishes incidental links from URL cards, retrieves all distinct actionable URLs before any required search, and bounds retrieval fallbacks. Empty or unusable regular output triggers one API attempt; access refusals stop retrieval. Search errors and empty results end the single allowed search without invented citations or additional calls.

Validation: 730 tests passed, 3 skipped; lint, typecheck, formatting, and production build passed locally. The final wording adjustments also passed the targeted prompt tests and formatting check. Prompt assertions protect the written contract; they do not prove model compliance. Live related-question/image-output comparisons and production search/citation measurements remain unverified because the required evaluation credentials are unavailable in this fork.

Fixes #1014