### PR TITLE
perf(chat): cap replayed history when the prompt cache is cold

### DIFF
--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -8,7 +8,8 @@ const mocks = vi.hoisted(() => ({
     end: vi.fn()
   },
   forceFlush: vi.fn(),
-  finishPromise: Promise.resolve()
+  finishPromise: Promise.resolve(),
+  trimColdStartHistory: vi.fn()
 }))
 
 vi.mock('ai', () => ({
@@ -48,6 +49,10 @@ vi.mock('@/lib/agents/title-generator', () => ({
 
 vi.mock('@/lib/streaming/helpers/attachment-sizes', () => ({
   resolveAttachmentSizes: vi.fn(async (messages: unknown) => messages)
+}))
+
+vi.mock('@/lib/streaming/helpers/trim-cold-start-history', () => ({
+  trimColdStartHistory: mocks.trimColdStartHistory
 }))
 
 vi.mock('@/lib/streaming/helpers/persist-stream-results', () => ({
@@ -150,6 +155,10 @@ describe('createChatStreamResponse', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.finishPromise = Promise.resolve()
+    mocks.trimColdStartHistory.mockImplementation((messages: unknown[]) => ({
+      messages,
+      trimmedAtCurrentTurn: false
+    }))
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
@@ -338,6 +347,25 @@ describe('createChatStreamResponse', () => {
     expect(mocks.span.update).toHaveBeenCalledWith({
       input: 'hello',
       output: 'Answer'
+    })
+  })
+
+  it('records a cold-start history trim on the root span', async () => {
+    mocks.trimColdStartHistory.mockImplementationOnce(
+      (messages: unknown[]) => ({
+        messages,
+        trimmedAtCurrentTurn: true
+      })
+    )
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(createConfig())
+    await mocks.finishPromise
+
+    expect(mocks.span.update).toHaveBeenCalledWith({
+      input: 'hello',
+      output: 'Answer',
+      metadata: { coldStartHistoryTrimmed: true }
     })
   })
 

--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -379,7 +379,8 @@ describe('createChatStreamResponse', () => {
     await mocks.finishPromise
 
     expect(mocks.trimColdStartHistory).toHaveBeenCalledWith(expect.any(Array), {
-      limit: Math.min(200_000, getMaxAllowedTokens(config.model))
+      limit: Math.min(200_000, getMaxAllowedTokens(config.model)),
+      modelId: 'gpt-4o-mini'
     })
   })
 

--- a/lib/streaming/__tests__/create-chat-stream-response.test.ts
+++ b/lib/streaming/__tests__/create-chat-stream-response.test.ts
@@ -52,6 +52,7 @@ vi.mock('@/lib/streaming/helpers/attachment-sizes', () => ({
 }))
 
 vi.mock('@/lib/streaming/helpers/trim-cold-start-history', () => ({
+  COLD_START_HISTORY_TOKEN_LIMIT: 200_000,
   trimColdStartHistory: mocks.trimColdStartHistory
 }))
 
@@ -79,6 +80,7 @@ import { createChatStreamResponse } from '@/lib/streaming/create-chat-stream-res
 import { describeStreamError } from '@/lib/streaming/helpers/describe-stream-error'
 import { EMPTY_RESPONSE_STATUS_MESSAGE } from '@/lib/streaming/helpers/is-empty-response'
 import { prepareMessages } from '@/lib/streaming/helpers/prepare-messages'
+import { getMaxAllowedTokens } from '@/lib/utils/context-window'
 
 type StreamOptions = {
   onError: (event: { error: unknown }) => void
@@ -366,6 +368,18 @@ describe('createChatStreamResponse', () => {
       input: 'hello',
       output: 'Answer',
       metadata: { coldStartHistoryTrimmed: true }
+    })
+  })
+
+  it('bounds the cold-start history limit by the model input window', async () => {
+    const config = createConfig()
+    mocks.stream.mockResolvedValue(createFakeResult())
+
+    await createChatStreamResponse(config)
+    await mocks.finishPromise
+
+    expect(mocks.trimColdStartHistory).toHaveBeenCalledWith(expect.any(Array), {
+      limit: Math.min(200_000, getMaxAllowedTokens(config.model))
     })
   })
 

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -234,7 +234,8 @@ export async function createChatStreamResponse(
                   COLD_START_HISTORY_TOKEN_LIMIT,
                   getMaxAllowedTokens(model)
                 )
-              : 0
+              : 0,
+          modelId: model.id
         }
       )
       coldStartHistoryTrimmed = coldStartHistory.trimmedAtCurrentTurn

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -48,7 +48,10 @@ import {
 } from './helpers/stream-error-diagnostics'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
 import { summarizeCarriedContext } from './helpers/summarize-carried-context'
-import { trimColdStartHistory } from './helpers/trim-cold-start-history'
+import {
+  COLD_START_HISTORY_TOKEN_LIMIT,
+  trimColdStartHistory
+} from './helpers/trim-cold-start-history'
 import type { StreamContext } from './helpers/types'
 import { BaseStreamConfig } from './types'
 
@@ -222,7 +225,18 @@ export async function createChatStreamResponse(
         messagesWithoutSpec,
         userId
       )
-      const coldStartHistory = trimColdStartHistory(messagesWithAttachmentSizes)
+      const coldStartHistory = trimColdStartHistory(
+        messagesWithAttachmentSizes,
+        {
+          limit:
+            COLD_START_HISTORY_TOKEN_LIMIT > 0
+              ? Math.min(
+                  COLD_START_HISTORY_TOKEN_LIMIT,
+                  getMaxAllowedTokens(model)
+                )
+              : 0
+        }
+      )
       coldStartHistoryTrimmed = coldStartHistory.trimmedAtCurrentTurn
       const messagesToConvert = dedupeAttachments(
         capHistoricalAttachments(

--- a/lib/streaming/create-chat-stream-response.ts
+++ b/lib/streaming/create-chat-stream-response.ts
@@ -48,6 +48,7 @@ import {
 } from './helpers/stream-error-diagnostics'
 import { stripSpecFromMessages } from './helpers/strip-spec-from-messages'
 import { summarizeCarriedContext } from './helpers/summarize-carried-context'
+import { trimColdStartHistory } from './helpers/trim-cold-start-history'
 import type { StreamContext } from './helpers/types'
 import { BaseStreamConfig } from './types'
 
@@ -128,6 +129,7 @@ export async function createChatStreamResponse(
     let rootOutput: string | undefined
     let carriedContext: Record<string, number> | undefined
     let contextWindowTruncated = false
+    let coldStartHistoryTrimmed = false
 
     const endTracing = async () => {
       if (rootSpan) {
@@ -157,6 +159,7 @@ export async function createChatStreamResponse(
         const metadata = {
           ...(carriedContext !== undefined && { carriedContext }),
           ...(contextWindowTruncated && { contextWindowTruncated }),
+          ...(coldStartHistoryTrimmed && { coldStartHistoryTrimmed }),
           ...failureMetadata
         }
         const update = {
@@ -219,9 +222,11 @@ export async function createChatStreamResponse(
         messagesWithoutSpec,
         userId
       )
+      const coldStartHistory = trimColdStartHistory(messagesWithAttachmentSizes)
+      coldStartHistoryTrimmed = coldStartHistory.trimmedAtCurrentTurn
       const messagesToConvert = dedupeAttachments(
         capHistoricalAttachments(
-          compactHistoricalMessages(messagesWithAttachmentSizes)
+          compactHistoricalMessages(coldStartHistory.messages)
         )
       )
       carriedContext = summarizeCarriedContext(messagesToConvert)

--- a/lib/streaming/helpers/__tests__/trim-cold-start-history.test.ts
+++ b/lib/streaming/helpers/__tests__/trim-cold-start-history.test.ts
@@ -1,0 +1,229 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseColdStartHistoryTokenLimit,
+  trimColdStartHistory
+} from '../trim-cold-start-history'
+
+const START = new Date('2026-01-01T00:00:00.000Z')
+const WARM_GAP_MS = 30 * 60 * 1000
+const COLD_GAP_MS = WARM_GAP_MS + 1
+
+function timestamp(offsetMs: number): Date {
+  return new Date(START.getTime() + offsetMs)
+}
+
+function message(
+  id: string,
+  role: 'user' | 'assistant',
+  createdAt: Date | string | undefined,
+  parts: UIMessage['parts'] = [{ type: 'text', text: 'content'.repeat(8) }]
+): UIMessage {
+  return {
+    id,
+    role,
+    parts,
+    ...(createdAt !== undefined && { metadata: { createdAt } })
+  }
+}
+
+function turn(
+  index: number,
+  createdAt: Date | string | undefined,
+  assistantParts?: UIMessage['parts']
+): UIMessage[] {
+  return [
+    message(`u${index}`, 'user', createdAt),
+    message(`a${index}`, 'assistant', createdAt, assistantParts)
+  ]
+}
+
+function userIds(messages: UIMessage[]): string[] {
+  return messages.filter(item => item.role === 'user').map(item => item.id)
+}
+
+describe('trimColdStartHistory', () => {
+  it('only advances the cut as cold turns are appended', () => {
+    let messages: UIMessage[] = []
+    let dropped = new Set<string>()
+
+    for (let i = 0; i < 8; i++) {
+      messages = messages.concat(turn(i, timestamp(i * COLD_GAP_MS)))
+      const result = trimColdStartHistory(messages, {
+        now: timestamp(i * COLD_GAP_MS),
+        limit: 20
+      })
+      const kept = new Set(userIds(result.messages))
+      const nextDropped = new Set(userIds(messages).filter(id => !kept.has(id)))
+
+      for (const id of dropped) expect(nextDropped.has(id)).toBe(true)
+      dropped = nextDropped
+    }
+
+    expect(dropped.size).toBeGreaterThan(0)
+  })
+
+  it('keeps the previous output as a prefix when a warm turn is appended', () => {
+    const atColdStart = [
+      ...turn(0, timestamp(0)),
+      ...turn(1, timestamp(WARM_GAP_MS)),
+      ...turn(2, timestamp(2 * WARM_GAP_MS)),
+      ...turn(3, timestamp(3 * WARM_GAP_MS)),
+      ...turn(4, timestamp(3 * WARM_GAP_MS + COLD_GAP_MS))
+    ]
+    const first = trimColdStartHistory(atColdStart, {
+      now: timestamp(3 * WARM_GAP_MS + COLD_GAP_MS),
+      limit: 20
+    }).messages
+    const second = trimColdStartHistory(
+      atColdStart.concat(turn(5, timestamp(4 * WARM_GAP_MS + COLD_GAP_MS))),
+      {
+        now: timestamp(4 * WARM_GAP_MS + COLD_GAP_MS),
+        limit: 20
+      }
+    ).messages
+
+    expect(second.slice(0, first.length)).toEqual(first)
+  })
+
+  it('leaves fewer than five turns untouched', () => {
+    const messages = Array.from({ length: 4 }, (_, i) =>
+      turn(i, timestamp(i * COLD_GAP_MS))
+    ).flat()
+    const result = trimColdStartHistory(messages, {
+      now: timestamp(4 * COLD_GAP_MS),
+      limit: 1
+    })
+
+    expect(result.messages).toBe(messages)
+    expect(result.trimmedAtCurrentTurn).toBe(false)
+  })
+
+  it('does not trim when every gap is at most the idle boundary', () => {
+    const messages = Array.from({ length: 7 }, (_, i) =>
+      turn(i, timestamp(i * WARM_GAP_MS))
+    ).flat()
+
+    expect(
+      trimColdStartHistory(messages, {
+        now: timestamp(7 * WARM_GAP_MS),
+        limit: 1
+      }).messages
+    ).toBe(messages)
+  })
+
+  it('does not treat a missing historical timestamp as cold', () => {
+    const messages = [
+      ...turn(0, timestamp(0)),
+      ...turn(1, timestamp(WARM_GAP_MS)),
+      ...turn(2, timestamp(2 * WARM_GAP_MS)),
+      ...turn(3, undefined),
+      ...turn(4, timestamp(2 * WARM_GAP_MS + COLD_GAP_MS))
+    ]
+
+    expect(
+      trimColdStartHistory(messages, {
+        now: timestamp(2 * WARM_GAP_MS + COLD_GAP_MS),
+        limit: 1
+      }).messages
+    ).toBe(messages)
+  })
+
+  it('uses now for a missing timestamp on the last user message', () => {
+    const now = timestamp(3 * WARM_GAP_MS + COLD_GAP_MS)
+    const messages = [
+      ...turn(0, timestamp(0)),
+      ...turn(1, timestamp(WARM_GAP_MS)),
+      ...turn(2, timestamp(2 * WARM_GAP_MS)),
+      ...turn(3, timestamp(3 * WARM_GAP_MS)),
+      ...turn(4, undefined)
+    ]
+    const result = trimColdStartHistory(messages, { now, limit: 20 })
+
+    expect(userIds(result.messages)).toEqual(['u0', 'u4'])
+    expect(result.trimmedAtCurrentTurn).toBe(true)
+  })
+
+  it('keeps the first and current turns whole', () => {
+    const toolParts = [
+      {
+        type: 'tool-search',
+        toolCallId: 'call-current',
+        state: 'output-available',
+        input: { query: 'current' },
+        output: { results: ['current'] }
+      }
+    ] as unknown as UIMessage['parts']
+    const messages = [
+      ...turn(0, timestamp(0)),
+      ...turn(1, timestamp(WARM_GAP_MS), toolParts),
+      ...turn(2, timestamp(2 * WARM_GAP_MS)),
+      ...turn(3, timestamp(3 * WARM_GAP_MS)),
+      ...turn(4, timestamp(3 * WARM_GAP_MS + COLD_GAP_MS), toolParts)
+    ]
+    const result = trimColdStartHistory(messages, {
+      now: timestamp(3 * WARM_GAP_MS + COLD_GAP_MS),
+      limit: 20
+    })
+
+    expect(result.messages.map(item => item.id)).toEqual([
+      'u0',
+      'a0',
+      'u4',
+      'a4'
+    ])
+    expect(result.messages[0].role).toBe('user')
+    expect(result.messages.at(-1)?.parts).toEqual(toolParts)
+  })
+
+  it('disables trimming when the limit is zero', () => {
+    const messages = Array.from({ length: 6 }, (_, i) =>
+      turn(i, timestamp(i * COLD_GAP_MS))
+    ).flat()
+
+    expect(
+      trimColdStartHistory(messages, {
+        now: timestamp(6 * COLD_GAP_MS),
+        limit: 0
+      }).messages
+    ).toBe(messages)
+  })
+
+  it('parses the configured limit', () => {
+    expect(parseColdStartHistoryTokenLimit(undefined)).toBe(200_000)
+    expect(parseColdStartHistoryTokenLimit('')).toBe(200_000)
+    expect(parseColdStartHistoryTokenLimit('not-a-number')).toBe(200_000)
+    expect(parseColdStartHistoryTokenLimit('-1')).toBe(200_000)
+    expect(parseColdStartHistoryTokenLimit('0')).toBe(0)
+    expect(parseColdStartHistoryTokenLimit('3.9')).toBe(3)
+    expect(parseColdStartHistoryTokenLimit('0.5')).toBe(1)
+  })
+
+  it('flags only the turn whose cold event advances the cut', () => {
+    const coldMessages = [
+      ...turn(0, timestamp(0)),
+      ...turn(1, timestamp(WARM_GAP_MS)),
+      ...turn(2, timestamp(2 * WARM_GAP_MS)),
+      ...turn(3, timestamp(3 * WARM_GAP_MS)),
+      ...turn(4, timestamp(3 * WARM_GAP_MS + COLD_GAP_MS))
+    ]
+    const coldResult = trimColdStartHistory(coldMessages, {
+      now: timestamp(3 * WARM_GAP_MS + COLD_GAP_MS),
+      limit: 20
+    })
+    const warmResult = trimColdStartHistory(
+      coldMessages.concat(turn(5, timestamp(4 * WARM_GAP_MS + COLD_GAP_MS))),
+      {
+        now: timestamp(4 * WARM_GAP_MS + COLD_GAP_MS),
+        limit: 20
+      }
+    )
+
+    expect(coldResult.trimmedAtCurrentTurn).toBe(true)
+    expect(warmResult.trimmedAtCurrentTurn).toBe(false)
+    expect(warmResult.messages.length).toBeLessThan(
+      coldMessages.length + turn(5, timestamp(0)).length
+    )
+  })
+})

--- a/lib/streaming/helpers/__tests__/trim-cold-start-history.test.ts
+++ b/lib/streaming/helpers/__tests__/trim-cold-start-history.test.ts
@@ -177,6 +177,42 @@ describe('trimColdStartHistory', () => {
     expect(result.messages.at(-1)?.parts).toEqual(toolParts)
   })
 
+  it('budgets history by what is replayed, not by execution details', () => {
+    const executionHeavyParts = [
+      { type: 'reasoning', text: 'r'.repeat(100_000) },
+      {
+        type: 'tool-search',
+        toolCallId: 'call-heavy',
+        state: 'output-available',
+        input: { query: 'heavy' },
+        output: {
+          results: [
+            {
+              title: 'Source',
+              url: 'https://example.com',
+              content: 'x'.repeat(100_000)
+            }
+          ]
+        }
+      },
+      { type: 'text', text: 'Short answer.' }
+    ] as unknown as UIMessage['parts']
+    const messages = [
+      ...turn(0, timestamp(0)),
+      ...turn(1, timestamp(WARM_GAP_MS), executionHeavyParts),
+      ...turn(2, timestamp(2 * WARM_GAP_MS), executionHeavyParts),
+      ...turn(3, timestamp(3 * WARM_GAP_MS), executionHeavyParts),
+      ...turn(4, timestamp(3 * WARM_GAP_MS + COLD_GAP_MS))
+    ]
+    const result = trimColdStartHistory(messages, {
+      now: timestamp(3 * WARM_GAP_MS + COLD_GAP_MS),
+      limit: 1_000
+    })
+
+    expect(result.messages).toBe(messages)
+    expect(result.trimmedAtCurrentTurn).toBe(false)
+  })
+
   it('disables trimming when the limit is zero', () => {
     const messages = Array.from({ length: 6 }, (_, i) =>
       turn(i, timestamp(i * COLD_GAP_MS))

--- a/lib/streaming/helpers/__tests__/trim-cold-start-history.test.ts
+++ b/lib/streaming/helpers/__tests__/trim-cold-start-history.test.ts
@@ -213,6 +213,27 @@ describe('trimColdStartHistory', () => {
     expect(result.trimmedAtCurrentTurn).toBe(false)
   })
 
+  it('counts replayed text with the model tokenizer when a model is given', () => {
+    const denseText = '日本語の文章'.repeat(100)
+    const coldAt = timestamp(3 * WARM_GAP_MS + COLD_GAP_MS)
+    const messages = Array.from({ length: 5 }, (_, i) => {
+      const createdAt = i === 4 ? coldAt : timestamp(i * WARM_GAP_MS)
+      return [
+        message(`u${i}`, 'user', createdAt, [
+          { type: 'text', text: denseText }
+        ]),
+        message(`a${i}`, 'assistant', createdAt)
+      ]
+    }).flat()
+    const options = { now: coldAt, limit: 1_200 }
+
+    expect(trimColdStartHistory(messages, options).messages).toBe(messages)
+    expect(
+      trimColdStartHistory(messages, { ...options, modelId: 'gpt-4o-mini' })
+        .trimmedAtCurrentTurn
+    ).toBe(true)
+  })
+
   it('disables trimming when the limit is zero', () => {
     const messages = Array.from({ length: 6 }, (_, i) =>
       turn(i, timestamp(i * COLD_GAP_MS))

--- a/lib/streaming/helpers/trim-cold-start-history.ts
+++ b/lib/streaming/helpers/trim-cold-start-history.ts
@@ -1,0 +1,150 @@
+import type { UIMessage } from 'ai'
+
+import { estimateAttachmentTokens } from '@/lib/utils/attachment-tokens'
+
+const DEFAULT_COLD_START_HISTORY_TOKEN_LIMIT = 200_000
+const CACHE_IDLE_MS = 30 * 60 * 1000
+const MIN_TURNS = 5
+const MESSAGE_TOKEN_OVERHEAD = 4
+
+export function parseColdStartHistoryTokenLimit(
+  raw: string | undefined
+): number {
+  const value = raw?.trim()
+  if (!value) return DEFAULT_COLD_START_HISTORY_TOKEN_LIMIT
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_COLD_START_HISTORY_TOKEN_LIMIT
+  }
+
+  return parsed === 0 ? 0 : Math.max(1, Math.floor(parsed))
+}
+
+export const COLD_START_HISTORY_TOKEN_LIMIT = parseColdStartHistoryTokenLimit(
+  process.env.COLD_START_HISTORY_TOKEN_LIMIT
+)
+
+type Turn = {
+  messages: UIMessage[]
+  timestamp?: number
+  tokens: number
+}
+
+function serializedLength(value: unknown): number {
+  if (value === undefined) return 0
+
+  try {
+    return JSON.stringify(value)?.length ?? 0
+  } catch {
+    return 0
+  }
+}
+
+function estimateMessageTokens(message: UIMessage): number {
+  let chars = 0
+  let attachmentTokens = 0
+
+  for (const part of message.parts) {
+    if (part.type === 'text' || part.type === 'reasoning') {
+      chars += part.text.length
+    } else if (part.type === 'dynamic-tool' || part.type.startsWith('tool-')) {
+      const toolPart = part as { input?: unknown; output?: unknown }
+      chars += serializedLength(toolPart.input)
+      chars += serializedLength(toolPart.output)
+    } else if (part.type.startsWith('data-')) {
+      chars += serializedLength((part as { data?: unknown }).data)
+    } else if (part.type === 'file') {
+      const filePart = part as { mediaType?: string; size?: number }
+      attachmentTokens += estimateAttachmentTokens(filePart)
+    }
+  }
+
+  return Math.ceil(chars / 4) + MESSAGE_TOKEN_OVERHEAD + attachmentTokens
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (!(value instanceof Date) && typeof value !== 'string') return undefined
+
+  const timestamp = value instanceof Date ? value.getTime() : Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : undefined
+}
+
+function getCreatedAt(message: UIMessage): unknown {
+  const metadata = message.metadata
+  if (!metadata || typeof metadata !== 'object') return undefined
+
+  return (metadata as { createdAt?: unknown }).createdAt
+}
+
+function buildTurns(messages: UIMessage[], now: Date): Turn[] {
+  const userIndexes = messages.flatMap((message, index) =>
+    message.role === 'user' ? [index] : []
+  )
+  if (userIndexes.length === 0) return []
+
+  return userIndexes.map((userIndex, turnIndex) => {
+    const start = turnIndex === 0 ? 0 : userIndex
+    const end = userIndexes[turnIndex + 1] ?? messages.length
+    const turnMessages = messages.slice(start, end)
+    const timestamp =
+      parseTimestamp(getCreatedAt(messages[userIndex])) ??
+      (turnIndex === userIndexes.length - 1 ? now.getTime() : undefined)
+
+    return {
+      messages: turnMessages,
+      timestamp,
+      tokens: turnMessages.reduce(
+        (total, message) => total + estimateMessageTokens(message),
+        0
+      )
+    }
+  })
+}
+
+export function trimColdStartHistory(
+  messages: UIMessage[],
+  options: { now?: Date; limit?: number } = {}
+): { messages: UIMessage[]; trimmedAtCurrentTurn: boolean } {
+  const limit = options.limit ?? COLD_START_HISTORY_TOKEN_LIMIT
+  if (limit <= 0) return { messages, trimmedAtCurrentTurn: false }
+
+  const turns = buildTurns(messages, options.now ?? new Date())
+  if (turns.length < MIN_TURNS) {
+    return { messages, trimmedAtCurrentTurn: false }
+  }
+
+  let cut = 1
+  let trimmedAtCurrentTurn = false
+
+  for (let i = 1; i < turns.length; i++) {
+    const previousTimestamp = turns[i - 1].timestamp
+    const timestamp = turns[i].timestamp
+    const cold =
+      previousTimestamp !== undefined &&
+      timestamp !== undefined &&
+      timestamp - previousTimestamp > CACHE_IDLE_MS
+
+    if (!cold || i + 1 < MIN_TURNS) continue
+
+    let total = turns[0].tokens
+    for (let j = cut; j <= i; j++) total += turns[j].tokens
+
+    const cutBefore = cut
+    while (total > limit && cut < i) {
+      total -= turns[cut].tokens
+      cut += 1
+    }
+
+    if (i === turns.length - 1 && cut > cutBefore) {
+      trimmedAtCurrentTurn = true
+    }
+  }
+
+  if (cut === 1) return { messages, trimmedAtCurrentTurn: false }
+
+  return {
+    messages: [turns[0], ...turns.slice(cut)].flatMap(turn => turn.messages),
+    trimmedAtCurrentTurn
+  }
+}

--- a/lib/streaming/helpers/trim-cold-start-history.ts
+++ b/lib/streaming/helpers/trim-cold-start-history.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from 'ai'
 
 import { estimateAttachmentTokens } from '@/lib/utils/attachment-tokens'
+import { countTextTokens } from '@/lib/utils/context-window'
 
 import { compactHistoricalMessages } from './compact-historical-messages'
 
@@ -27,49 +28,73 @@ export const COLD_START_HISTORY_TOKEN_LIMIT = parseColdStartHistoryTokenLimit(
   process.env.COLD_START_HISTORY_TOKEN_LIMIT
 )
 
+type ReplayedText = {
+  text: string
+  fixedTokens: number
+}
+
 type Turn = {
   messages: UIMessage[]
   timestamp?: number
-  tokens: number
+  replayed: ReplayedText[]
 }
 
-function serializedLength(value: unknown): number {
-  if (value === undefined) return 0
+const textEncoder = new TextEncoder()
+
+function serialize(value: unknown): string {
+  if (value === undefined) return ''
 
   try {
-    return JSON.stringify(value)?.length ?? 0
+    return JSON.stringify(value) ?? ''
   } catch {
-    return 0
+    return ''
   }
 }
 
-function estimateReplayedMessageTokens(message: UIMessage): number {
-  let chars = 0
+function describeReplayedMessage(message: UIMessage): ReplayedText {
+  const texts: string[] = []
   let attachmentTokens = 0
 
   for (const part of message.parts) {
     if (part.type === 'text' || part.type === 'reasoning') {
-      chars += part.text.length
+      texts.push(part.text)
     } else if (part.type === 'dynamic-tool' || part.type.startsWith('tool-')) {
       const toolPart = part as { input?: unknown; output?: unknown }
-      chars += serializedLength(toolPart.input)
-      chars += serializedLength(toolPart.output)
+      texts.push(serialize(toolPart.input), serialize(toolPart.output))
     } else if (part.type.startsWith('data-')) {
-      chars += serializedLength((part as { data?: unknown }).data)
+      texts.push(serialize((part as { data?: unknown }).data))
     } else if (part.type === 'file') {
       const filePart = part as { mediaType?: string; size?: number }
       attachmentTokens += estimateAttachmentTokens(filePart)
     }
   }
 
-  return Math.ceil(chars / 4) + MESSAGE_TOKEN_OVERHEAD + attachmentTokens
+  return {
+    text: texts.join(''),
+    fixedTokens: MESSAGE_TOKEN_OVERHEAD + attachmentTokens
+  }
 }
 
-// Estimated on the message's historical replay form, which depends only on
+// Described on the message's historical replay form, which depends only on
 // the message itself, so the estimate does not change as the thread grows.
-function estimateMessageTokens(message: UIMessage): number {
-  return compactHistoricalMessages([message]).reduce(
-    (total, replayed) => total + estimateReplayedMessageTokens(replayed),
+function describeMessage(message: UIMessage): ReplayedText[] {
+  return compactHistoricalMessages([message]).map(describeReplayedMessage)
+}
+
+// A token always spans at least one UTF-8 byte, so this bounds any tokenizer
+// without running one.
+function tokenUpperBound(turn: Turn): number {
+  return turn.replayed.reduce(
+    (total, { text, fixedTokens }) =>
+      total + textEncoder.encode(text).length + fixedTokens,
+    0
+  )
+}
+
+function countTurnTokens(turn: Turn, modelId?: string): number {
+  return turn.replayed.reduce(
+    (total, { text, fixedTokens }) =>
+      total + countTextTokens(text, modelId) + fixedTokens,
     0
   )
 }
@@ -105,17 +130,14 @@ function buildTurns(messages: UIMessage[], now: Date): Turn[] {
     return {
       messages: turnMessages,
       timestamp,
-      tokens: turnMessages.reduce(
-        (total, message) => total + estimateMessageTokens(message),
-        0
-      )
+      replayed: turnMessages.flatMap(describeMessage)
     }
   })
 }
 
 export function trimColdStartHistory(
   messages: UIMessage[],
-  options: { now?: Date; limit?: number } = {}
+  options: { now?: Date; limit?: number; modelId?: string } = {}
 ): { messages: UIMessage[]; trimmedAtCurrentTurn: boolean } {
   const limit = options.limit ?? COLD_START_HISTORY_TOKEN_LIMIT
   if (limit <= 0) return { messages, trimmedAtCurrentTurn: false }
@@ -125,6 +147,13 @@ export function trimColdStartHistory(
     return { messages, trimmedAtCurrentTurn: false }
   }
 
+  const upperBound = turns.reduce(
+    (total, turn) => total + tokenUpperBound(turn),
+    0
+  )
+  if (upperBound <= limit) return { messages, trimmedAtCurrentTurn: false }
+
+  const tokens = turns.map(turn => countTurnTokens(turn, options.modelId))
   let cut = 1
   let trimmedAtCurrentTurn = false
 
@@ -138,12 +167,12 @@ export function trimColdStartHistory(
 
     if (!cold || i + 1 < MIN_TURNS) continue
 
-    let total = turns[0].tokens
-    for (let j = cut; j <= i; j++) total += turns[j].tokens
+    let total = tokens[0]
+    for (let j = cut; j <= i; j++) total += tokens[j]
 
     const cutBefore = cut
     while (total > limit && cut < i) {
-      total -= turns[cut].tokens
+      total -= tokens[cut]
       cut += 1
     }
 

--- a/lib/streaming/helpers/trim-cold-start-history.ts
+++ b/lib/streaming/helpers/trim-cold-start-history.ts
@@ -2,6 +2,8 @@ import type { UIMessage } from 'ai'
 
 import { estimateAttachmentTokens } from '@/lib/utils/attachment-tokens'
 
+import { compactHistoricalMessages } from './compact-historical-messages'
+
 const DEFAULT_COLD_START_HISTORY_TOKEN_LIMIT = 200_000
 const CACHE_IDLE_MS = 30 * 60 * 1000
 const MIN_TURNS = 5
@@ -41,7 +43,7 @@ function serializedLength(value: unknown): number {
   }
 }
 
-function estimateMessageTokens(message: UIMessage): number {
+function estimateReplayedMessageTokens(message: UIMessage): number {
   let chars = 0
   let attachmentTokens = 0
 
@@ -61,6 +63,15 @@ function estimateMessageTokens(message: UIMessage): number {
   }
 
   return Math.ceil(chars / 4) + MESSAGE_TOKEN_OVERHEAD + attachmentTokens
+}
+
+// Estimated on the message's historical replay form, which depends only on
+// the message itself, so the estimate does not change as the thread grows.
+function estimateMessageTokens(message: UIMessage): number {
+  return compactHistoricalMessages([message]).reduce(
+    (total, replayed) => total + estimateReplayedMessageTokens(replayed),
+    0
+  )
 }
 
 function parseTimestamp(value: unknown): number | undefined {

--- a/lib/utils/context-window.ts
+++ b/lib/utils/context-window.ts
@@ -155,6 +155,24 @@ function getEncoder(modelId: string) {
 }
 
 /**
+ * Token count for plain text, using the model's tokenizer when available
+ */
+export function countTextTokens(text: string, modelId?: string): number {
+  if (!text) return 0
+
+  const encoder = modelId ? getEncoder(modelId) : null
+  if (encoder) {
+    try {
+      return encoder.encode(text).length
+    } catch {
+      // Fall through to the character approximation
+    }
+  }
+
+  return Math.ceil(text.length / 4)
+}
+
+/**
  * Estimate token count for a message
  * Uses tiktoken for accurate counting when available
  */


### PR DESCRIPTION
## Problem

Long authenticated threads replay their whole history on every turn. While the provider's prompt cache is warm that history is cheap, because the prompt cache is prefix-append and all-or-nothing. When the cache has expired (the thread was idle long enough), the request pays for the entire prompt again, and nothing bounds how much history that request carries.

## Root cause

The only history bound today is `truncateMessages` (`lib/utils/context-window.ts`), which keeps the first user message plus as much as fits counted from the end of the conversation. That window is defined by distance from the tail, so on a thread that stays above the limit the cut moves every turn and the prompt prefix changes every turn, which defeats caching entirely. It is therefore only suitable as a last resort at the model's context limit, and there is no lower, cache-safe cap.

## Fix

A request whose cache is already cold is the one point where rewriting the prefix costs nothing extra, so that is where the replayed history is capped.

- New `trimColdStartHistory` helper (`lib/streaming/helpers/trim-cold-start-history.ts`), applied on the authenticated stream path right after attachment sizes are resolved and before the existing history guards.
- It walks user turns from oldest to newest. A turn counts as a cold start when its user message was sent more than 30 minutes after the previous one. At a cold start, once the thread has at least 5 turns, if the first turn plus the retained turns exceeds the limit, the cut moves forward by whole turns (a user message with the assistant messages that follow it, so tool calls and results stay together) until it fits. The first turn is always kept and the current turn is never dropped.
- The cut only moves forward and is recomputed on every request from persisted messages and their timestamps. The cut at a given turn depends only on the messages up to that turn, so later requests reproduce the same output and the prefix stays stable until the next cold start. Nothing is persisted and there is no schema change.
- Token estimates are taken per message on that message's historical replay form (the output of `compactHistoricalMessages` for the message alone: answer text and bounded source context, without reasoning or tool calls). That form depends only on the message, so the estimate matches what is actually replayed and does not drift between requests. Text is counted with the same model tokenizer `context-window` uses (`countTextTokens`, falling back to a character approximation), so token-dense scripts are not undercounted. The tokenizer only runs when the history could exceed the limit at all: a token always spans at least one UTF-8 byte, so when the byte length of the replayed history already fits, the trim returns without counting. Attachments keep their size-based estimate.
- Short threads (fewer than 5 turns) are never trimmed.
- The limit is `COLD_START_HISTORY_TOKEN_LIMIT` (default `200000`, `0` disables), parsed the same way as the existing history attachment settings. When the selected model's usable input window (`getMaxAllowedTokens`) is smaller, that window is used instead, so small-window models are trimmed at the cold start rather than being left to the tail-based `truncateMessages` cut on every later turn.
- The guest (ephemeral) path is unchanged: its message timestamps come from the request body.
- The root `research` span carries `coldStartHistoryTrimmed: true` on the turn where a cold start moved the cut, so the guard's firing is observable.

Known one-off: on the first request after deploy, a long thread may resolve a cut from an earlier cold start. If that request happens to be warm it rewrites the prefix once, and the following turns are cached again.

## Verification

- Unit tests for the helper: the cut never moves backward as turns are appended; appending a warm turn keeps the previous output as an exact prefix; no trim below 5 turns, at a gap of 30 minutes or less, or when a historical timestamp is missing; the first turn is always kept and turns are cut whole; `0` disables; env parsing falls back to the default on empty or invalid values; the span flag is set only on the turn whose cold start moved the cut.
- Wiring tests: the authenticated stream response adds `coldStartHistoryTrimmed` only when the helper reports a trim; the ephemeral path is unchanged.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test`.
