### PR TITLE
fix(storage): re-sign file parts that arrive without an object key

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -84,11 +84,41 @@ export async function POST(req: Request) {
 
     const guestChatEnabled = process.env.ENABLE_GUEST_CHAT === 'true'
     const isGuest = !userId
+
+    const keylessFilePartCount = Array.isArray(message?.parts)
+      ? message.parts.filter(
+          (part: unknown) =>
+            typeof part === 'object' &&
+            part !== null &&
+            (part as { type?: unknown }).type === 'file' &&
+            !(part as { key?: unknown }).key
+        ).length
+      : 0
+
     if (isGuest && !guestChatEnabled) {
       return new Response('Authentication required', {
         status: 401,
         statusText: 'Unauthorized'
       })
+    }
+
+    if (keylessFilePartCount > 0) {
+      console.warn(
+        'Keyless file parts received',
+        JSON.stringify({
+          chatId,
+          messageId: message?.id ?? messageId ?? null,
+          trigger,
+          keylessFilePartCount,
+          clientSource:
+            typeof body.clientSource === 'string' ? body.clientSource : null,
+          userAgent: req.headers.get('user-agent'),
+          referer,
+          origin: req.headers.get('origin'),
+          secFetchSite: req.headers.get('sec-fetch-site'),
+          vercelId: req.headers.get('x-vercel-id')
+        })
+      )
     }
 
     if (isGuest) {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -102,6 +102,16 @@ export async function POST(req: Request) {
       })
     }
 
+    if (isGuest) {
+      const forwardedFor = req.headers.get('x-forwarded-for') || ''
+      const ip =
+        forwardedFor.split(',')[0]?.trim() ||
+        req.headers.get('x-real-ip') ||
+        null
+      const guestLimitResponse = await checkAndEnforceGuestLimit(ip)
+      if (guestLimitResponse) return guestLimitResponse
+    }
+
     if (keylessFilePartCount > 0) {
       console.warn(
         'Keyless file parts received',
@@ -119,16 +129,6 @@ export async function POST(req: Request) {
           vercelId: req.headers.get('x-vercel-id')
         })
       )
-    }
-
-    if (isGuest) {
-      const forwardedFor = req.headers.get('x-forwarded-for') || ''
-      const ip =
-        forwardedFor.split(',')[0]?.trim() ||
-        req.headers.get('x-real-ip') ||
-        null
-      const guestLimitResponse = await checkAndEnforceGuestLimit(ip)
-      if (guestLimitResponse) return guestLimitResponse
     }
 
     const cookieStore = await cookies()

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -112,25 +112,6 @@ export async function POST(req: Request) {
       if (guestLimitResponse) return guestLimitResponse
     }
 
-    if (keylessFilePartCount > 0) {
-      console.warn(
-        'Keyless file parts received',
-        JSON.stringify({
-          chatId,
-          messageId: message?.id ?? messageId ?? null,
-          trigger,
-          keylessFilePartCount,
-          clientSource:
-            typeof body.clientSource === 'string' ? body.clientSource : null,
-          userAgent: req.headers.get('user-agent'),
-          referer,
-          origin: req.headers.get('origin'),
-          secFetchSite: req.headers.get('sec-fetch-site'),
-          vercelId: req.headers.get('x-vercel-id')
-        })
-      )
-    }
-
     const cookieStore = await cookies()
 
     // Get search mode from cookie
@@ -190,6 +171,25 @@ export async function POST(req: Request) {
         const adaptiveLimitResponse = await checkAndEnforceAdaptiveLimit(userId)
         if (adaptiveLimitResponse) return adaptiveLimitResponse
       }
+    }
+
+    if (keylessFilePartCount > 0) {
+      console.warn(
+        'Keyless file parts received',
+        JSON.stringify({
+          chatId,
+          messageId: message?.id ?? messageId ?? null,
+          trigger,
+          keylessFilePartCount,
+          clientSource:
+            typeof body.clientSource === 'string' ? body.clientSource : null,
+          userAgent: req.headers.get('user-agent'),
+          referer,
+          origin: req.headers.get('origin'),
+          secFetchSite: req.headers.get('sec-fetch-site'),
+          vercelId: req.headers.get('x-vercel-id')
+        })
+      )
     }
 
     const streamStart = performance.now()

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -155,6 +155,7 @@ export function Chat({
             trigger, // Use AI SDK's default trigger value directly
             chatId: chatId,
             messageId,
+            clientSource: 'web',
             analyticsId: getDistinctId(),
             ...(isGuest ? { messages } : {}),
             message:

--- a/lib/actions/__tests__/chat.test.ts
+++ b/lib/actions/__tests__/chat.test.ts
@@ -6,6 +6,10 @@ import { generateChatTitle } from '@/lib/agents/title-generator'
 import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import type { Chat, Message } from '@/lib/db/schema'
+import {
+  getUserFileObjectKeyPrefix,
+  signFilePartUrlsInMessages
+} from '@/lib/storage/r2-client'
 import type { UIMessage } from '@/lib/types/ai'
 
 import {
@@ -28,6 +32,10 @@ import {
 vi.mock('@/lib/auth/get-current-user')
 vi.mock('@/lib/db/actions')
 vi.mock('@/lib/agents/title-generator')
+vi.mock('@/lib/storage/r2-client', () => ({
+  getUserFileObjectKeyPrefix: vi.fn((userId: string) => `${userId}/`),
+  signFilePartUrlsInMessages: vi.fn(async messages => messages)
+}))
 
 describe('Chat Actions', () => {
   beforeEach(() => {
@@ -129,6 +137,11 @@ describe('Chat Actions', () => {
       expect(dbActions.loadChatWithMessages).toHaveBeenCalledWith(
         chatId,
         userId
+      )
+      expect(getUserFileObjectKeyPrefix).toHaveBeenCalledWith(userId)
+      expect(signFilePartUrlsInMessages).toHaveBeenCalledWith(
+        mockChat.messages,
+        { keylessKeyPrefix: `${userId}/` }
       )
     })
 

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -7,7 +7,10 @@ import { getCurrentUserId } from '@/lib/auth/get-current-user'
 import * as dbActions from '@/lib/db/actions'
 import type { Chat, Message } from '@/lib/db/schema'
 import { generateId } from '@/lib/db/schema'
-import { signFilePartUrlsInMessages } from '@/lib/storage/r2-client'
+import {
+  getUserFileObjectKeyPrefix,
+  signFilePartUrlsInMessages
+} from '@/lib/storage/r2-client'
 import type { UIMessage } from '@/lib/types/ai'
 import { getTextFromParts } from '@/lib/utils/message-utils'
 
@@ -41,7 +44,9 @@ async function signChatFilePartUrls(
 
   return {
     ...chat,
-    messages: await signFilePartUrlsInMessages(chat.messages)
+    messages: await signFilePartUrlsInMessages(chat.messages, {
+      keylessKeyPrefix: getUserFileObjectKeyPrefix(chat.userId)
+    })
   }
 }
 

--- a/lib/storage/__tests__/r2-client.test.ts
+++ b/lib/storage/__tests__/r2-client.test.ts
@@ -178,6 +178,48 @@ describe('R2 client', () => {
     })
   })
 
+  describe('getObjectKeyFromSignedUrl', () => {
+    it('extracts decoded keys from the configured R2 bucket', async () => {
+      delete process.env.S3_ENDPOINT
+      process.env.R2_ACCOUNT_ID = 'account-id'
+
+      const { getObjectKeyFromSignedUrl } = await importR2Client()
+
+      expect(
+        getObjectKeyFromSignedUrl(
+          'https://TEST-BUCKET.ACCOUNT-ID.r2.cloudflarestorage.com/user-id/chats/chat-id/my%20file.pdf?X-Amz-Signature=value'
+        )
+      ).toBe('user-id/chats/chat-id/my file.pdf')
+    })
+
+    it('extracts decoded keys from a path-style endpoint with a base path', async () => {
+      process.env.S3_ENDPOINT = 'https://storage.example.com/s3/'
+
+      const { getObjectKeyFromSignedUrl } = await importR2Client()
+
+      expect(
+        getObjectKeyFromSignedUrl(
+          'https://storage.example.com/s3/test-bucket/user-id/my%20file.pdf?signature=value'
+        )
+      ).toBe('user-id/my file.pdf')
+    })
+
+    it('rejects URLs that do not identify an object in the configured bucket', async () => {
+      const { getObjectKeyFromSignedUrl } = await importR2Client()
+
+      for (const url of [
+        'https://other.example.com/test-bucket/user-id/file.pdf',
+        'https://r2.example.com/other-bucket/user-id/file.pdf',
+        'https://r2.example.com/test-bucket/',
+        'https://r2.example.com/test-bucket/bad%ZZname.pdf',
+        'not a URL',
+        'data:text/plain,hello'
+      ]) {
+        expect(getObjectKeyFromSignedUrl(url)).toBeUndefined()
+      }
+    })
+  })
+
   describe('getObjectContentMd5', () => {
     it('reads the digest off a single-part ETag', async () => {
       const md5 = 'd41d8cd98f00b204e9800998ecf8427e'
@@ -315,6 +357,62 @@ describe('R2 client', () => {
     ])
   })
 
+  it('derives and signs a keyless object inside the allowed prefix', async () => {
+    s3Mocks.getSignedUrl.mockResolvedValue('https://signed.example.com/fresh')
+
+    const { signFilePartUrls } = await importR2Client()
+
+    await expect(
+      signFilePartUrls(
+        [
+          {
+            type: 'file',
+            mediaType: 'application/pdf',
+            filename: 'my file.pdf',
+            url: 'https://r2.example.com/test-bucket/user-123/chats/chat-123/my%20file.pdf?signature=expired'
+          }
+        ],
+        { allowedKeyPrefix: 'user-123/' }
+      )
+    ).resolves.toEqual([
+      {
+        type: 'file',
+        key: 'user-123/chats/chat-123/my file.pdf',
+        mediaType: 'application/pdf',
+        filename: 'my file.pdf',
+        url: 'https://signed.example.com/fresh'
+      }
+    ])
+  })
+
+  it('preserves a keyless object outside the allowed prefix', async () => {
+    const part = {
+      type: 'file',
+      mediaType: 'image/png',
+      filename: 'file.png',
+      url: 'https://r2.example.com/test-bucket/other-user/file.png?signature=expired'
+    }
+    const { signFilePartUrls } = await importR2Client()
+
+    await expect(
+      signFilePartUrls([part], { allowedKeyPrefix: 'user-123/' })
+    ).resolves.toEqual([part])
+    expect(s3Mocks.getSignedUrl).not.toHaveBeenCalled()
+  })
+
+  it('does not derive a keyless object without a prefix option', async () => {
+    const part = {
+      type: 'file',
+      mediaType: 'image/png',
+      filename: 'file.png',
+      url: 'https://r2.example.com/test-bucket/user-123/file.png?signature=expired'
+    }
+    const { signFilePartUrls } = await importR2Client()
+
+    await expect(signFilePartUrls([part])).resolves.toEqual([part])
+    expect(s3Mocks.getSignedUrl).not.toHaveBeenCalled()
+  })
+
   it('rejects object keys outside the allowed prefix', async () => {
     const { signFilePartUrls } = await importR2Client()
 
@@ -361,6 +459,50 @@ describe('R2 client', () => {
         mediaType: 'image/png',
         filename: 'file.png',
         url: 'https://signed.example.com/file'
+      }
+    ])
+  })
+
+  it('derives only keyless owner objects when signing stored messages', async () => {
+    s3Mocks.getSignedUrl
+      .mockResolvedValueOnce('https://signed.example.com/derived')
+      .mockResolvedValueOnce('https://signed.example.com/existing')
+
+    const { signFilePartUrlsInMessages } = await importR2Client()
+
+    await expect(
+      signFilePartUrlsInMessages(
+        [
+          {
+            parts: [
+              {
+                type: 'file',
+                url: 'https://r2.example.com/test-bucket/user-123/file.png?signature=expired'
+              },
+              {
+                type: 'file',
+                key: 'other-user/file.png',
+                url: ''
+              }
+            ]
+          }
+        ],
+        { keylessKeyPrefix: 'user-123/' }
+      )
+    ).resolves.toEqual([
+      {
+        parts: [
+          {
+            type: 'file',
+            key: 'user-123/file.png',
+            url: 'https://signed.example.com/derived'
+          },
+          {
+            type: 'file',
+            key: 'other-user/file.png',
+            url: 'https://signed.example.com/existing'
+          }
+        ]
       }
     ])
   })

--- a/lib/storage/r2-client.ts
+++ b/lib/storage/r2-client.ts
@@ -51,6 +51,7 @@ let _r2Client: S3Client | null = null
 
 type SignFilePartUrlsOptions = {
   allowedKeyPrefix?: string
+  keylessKeyPrefix?: string
 }
 
 export function getR2Client(): S3Client {
@@ -99,6 +100,61 @@ export function isObjectStorageConfigured() {
 
 function normalizeObjectKey(key: string) {
   return key.replace(/^\/+/, '')
+}
+
+function decodeObjectKey(pathname: string): string | undefined {
+  const encodedKey = pathname.replace(/^\/+/, '')
+  if (!encodedKey) return undefined
+
+  try {
+    return encodedKey
+      .split('/')
+      .map(segment => decodeURIComponent(segment))
+      .join('/')
+  } catch {
+    return undefined
+  }
+}
+
+export function getObjectKeyFromSignedUrl(url: string): string | undefined {
+  let parsedUrl: URL
+
+  try {
+    parsedUrl = new URL(url)
+  } catch {
+    return undefined
+  }
+
+  const bucketName = process.env.R2_BUCKET_NAME || 'user-uploads'
+  const s3Endpoint = process.env.S3_ENDPOINT?.replace(/\/+$/, '')
+
+  if (s3Endpoint) {
+    let parsedEndpoint: URL
+
+    try {
+      parsedEndpoint = new URL(s3Endpoint)
+    } catch {
+      return undefined
+    }
+
+    if (parsedUrl.origin !== parsedEndpoint.origin) return undefined
+
+    const endpointPath = parsedEndpoint.pathname.replace(/\/+$/, '')
+    const bucketPath = `${endpointPath}/${bucketName}/`
+    if (!parsedUrl.pathname.startsWith(bucketPath)) return undefined
+
+    return decodeObjectKey(parsedUrl.pathname.slice(bucketPath.length))
+  }
+
+  const accountId = process.env.R2_ACCOUNT_ID
+  if (!accountId || parsedUrl.protocol !== 'https:') return undefined
+
+  const expectedHost = `${bucketName}.${accountId}.r2.cloudflarestorage.com`
+  if (parsedUrl.host.toLowerCase() !== expectedHost.toLowerCase()) {
+    return undefined
+  }
+
+  return decodeObjectKey(parsedUrl.pathname)
 }
 
 export function getChatFileObjectKeyPrefix(userId: string, chatId: string) {
@@ -204,7 +260,25 @@ export async function signFilePartUrls(
       }
 
       if (!part.key) {
-        return part
+        const keylessKeyPrefix =
+          options.allowedKeyPrefix ?? options.keylessKeyPrefix
+        if (!keylessKeyPrefix) return part
+
+        const key = getObjectKeyFromSignedUrl(part.url)
+        if (!key || !isObjectKeyWithinPrefix(key, keylessKeyPrefix)) {
+          return part
+        }
+
+        try {
+          return {
+            ...part,
+            key,
+            url: await getSignedFileUrl(key)
+          }
+        } catch (error) {
+          console.error('Failed to sign file URL:', error)
+          return { ...part, key, url: '' }
+        }
       }
 
       if (
@@ -228,12 +302,13 @@ export async function signFilePartUrls(
 }
 
 export async function signFilePartUrlsInMessages<T extends { parts?: any[] }>(
-  messages: T[]
+  messages: T[],
+  options: SignFilePartUrlsOptions = {}
 ): Promise<T[]> {
   return Promise.all(
     messages.map(async message => ({
       ...message,
-      parts: await signFilePartUrls(message.parts)
+      parts: await signFilePartUrls(message.parts, options)
     }))
   )
 }


### PR DESCRIPTION
## Problem

A chat file part that is submitted with a `url` but without a `key` breaks the chat once its URL expires. Every later turn fails in about two seconds with `bad_request`, and the model call reports:

```
Error while downloading file. Upstream status code: 403.
```

The user cannot recover the chat: resending the question fails the same way, because the broken attachment is replayed as part of the history on every turn.

## Root cause

- `/api/upload` returns both the object `key` and a presigned `url`, whose lifetime is `R2_SIGNED_URL_EXPIRES_SECONDS` (one hour by default).
- `signFilePartUrls` (`lib/storage/r2-client.ts`) only handles parts that carry a `key`. A part without one is returned as is, so the submit-time ownership check and signing are both skipped.
- `lib/utils/message-mapping.ts` then persists `file_url` = the presigned URL and `file_key` = null.
- On replay, a keyed part is signed again on every load. A keyless part replays its stored URL unchanged. Once that URL expires, the provider can no longer download the file and the request fails.

The objects behind these parts are ordinary uploads under the owner's key prefix. Only the key is missing from the part.

## Fix

- `getObjectKeyFromSignedUrl` recognizes a URL addressed to the configured bucket, following the endpoint shapes `getR2Client()` builds (R2 virtual-hosted, or path style with `S3_ENDPOINT`), and returns the decoded object key. Any other URL yields nothing.
- `signFilePartUrls`: a keyless part whose URL points at the configured bucket and whose derived key falls inside the caller's user prefix is treated as keyed. It gets its `key` and a freshly signed URL. On submit, the part is therefore persisted with `file_key` like any other upload.
- A key is never derived without a prefix to check it against, so a crafted URL cannot get another user's object signed. Keyless parts that do not qualify are left unchanged, and keyed parts behave exactly as before.
- Loading a chat passes the owner's prefix for key derivation. Rows already stored without a key are signed again on load, so existing chats recover without a data migration.

## Verification

- Unit tests:
  - URL parsing: the configured R2 host and a path-style endpoint are recognized, and encoded segments are decoded.
  - Rejected URLs: other hosts, other buckets, empty keys, malformed encoding and non-URL input.
  - Keyless part inside the prefix is signed again.
  - Keyless part outside the prefix, or with no prefix given, is left unchanged.
  - Keyed parts behave as before, including the submit-time rejection of a key outside the user's prefix.
  - The history path signs a stored keyless part again.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run build`, `bun run test`.
