### PR TITLE
fix(search): rewrite site-only Tavily queries into a domain filter

### DIFF
--- a/lib/tools/search/providers/__tests__/tavily-domains.test.ts
+++ b/lib/tools/search/providers/__tests__/tavily-domains.test.ts
@@ -10,7 +10,8 @@ describe('TavilySearchProvider domains', () => {
 
   const searchAndReadBody = async (
     includeDomains: string[] = [],
-    excludeDomains: string[] = []
+    excludeDomains: string[] = [],
+    query: string = 'query'
   ) => {
     vi.stubEnv('TAVILY_API_KEY', 'test-key')
     const fetchMock = vi.fn(
@@ -20,7 +21,7 @@ describe('TavilySearchProvider domains', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     await new TavilySearchProvider().search(
-      'query',
+      query,
       5,
       'basic',
       includeDomains,
@@ -69,5 +70,50 @@ describe('TavilySearchProvider domains', () => {
 
     expect(body.include_domains).toEqual(['example.com', '*.example.org'])
     expect(body.exclude_domains).toEqual(['example.net'])
+  })
+
+  it('converts a site-only query into a domain term and include_domains entry', async () => {
+    const body = await searchAndReadBody([], [], 'site:example.com')
+
+    expect(body.query).toBe('example.com')
+    expect(body.include_domains).toEqual(['example.com'])
+  })
+
+  it('converts multiple site-only operators into domain terms', async () => {
+    const body = await searchAndReadBody(
+      ['existing.net'],
+      [],
+      'site:example.com SITE:example.org'
+    )
+
+    expect(body.query).toBe('example.com example.org')
+    expect(body.include_domains).toEqual([
+      'existing.net',
+      'example.com',
+      'example.org'
+    ])
+  })
+
+  it('leaves a site operator combined with search terms unchanged', async () => {
+    const query = 'site:example.com remodeling services'
+    const body = await searchAndReadBody([], [], query)
+
+    expect(body.query).toBe(query)
+    expect(body.include_domains).toEqual([])
+  })
+
+  it('leaves a query without site operators unchanged', async () => {
+    const query = 'remodeling services'
+    const body = await searchAndReadBody([], [], query)
+
+    expect(body.query).toBe(query)
+    expect(body.include_domains).toEqual([])
+  })
+
+  it('drops an invalid site-only domain from include_domains', async () => {
+    const body = await searchAndReadBody([], [], 'site:edu')
+
+    expect(body.query).toBe('edu  ')
+    expect(body.include_domains).toEqual([])
   })
 })

--- a/lib/tools/search/providers/__tests__/tavily-domains.test.ts
+++ b/lib/tools/search/providers/__tests__/tavily-domains.test.ts
@@ -110,10 +110,17 @@ describe('TavilySearchProvider domains', () => {
     expect(body.include_domains).toEqual([])
   })
 
-  it('drops an invalid site-only domain from include_domains', async () => {
+  it('leaves a site-only query whose domains are all invalid unchanged', async () => {
     const body = await searchAndReadBody([], [], 'site:edu')
 
-    expect(body.query).toBe('edu  ')
+    expect(body.query).toBe('site:edu')
     expect(body.include_domains).toEqual([])
+  })
+
+  it('keeps only the valid domains of a mixed site-only query', async () => {
+    const body = await searchAndReadBody([], [], 'site:example.com site:edu')
+
+    expect(body.query).toBe('example.com')
+    expect(body.include_domains).toEqual(['example.com'])
   })
 })

--- a/lib/tools/search/providers/__tests__/tavily-domains.test.ts
+++ b/lib/tools/search/providers/__tests__/tavily-domains.test.ts
@@ -117,6 +117,21 @@ describe('TavilySearchProvider domains', () => {
     expect(body.include_domains).toEqual([])
   })
 
+  it('punycodes an internationalized site-only operand', async () => {
+    const body = await searchAndReadBody([], [], 'site:münchen.de')
+
+    expect(body.query).toBe('xn--mnchen-3ya.de')
+    expect(body.include_domains).toEqual(['xn--mnchen-3ya.de'])
+  })
+
+  it('leaves a site operand carrying a port unchanged', async () => {
+    const query = 'site:example.com:8080'
+    const body = await searchAndReadBody([], [], query)
+
+    expect(body.query).toBe(query)
+    expect(body.include_domains).toEqual([])
+  })
+
   it('leaves a site operand carrying a path unchanged', async () => {
     const query = 'site:example.com/docs'
     const body = await searchAndReadBody([], [], query)

--- a/lib/tools/search/providers/__tests__/tavily-domains.test.ts
+++ b/lib/tools/search/providers/__tests__/tavily-domains.test.ts
@@ -117,6 +117,14 @@ describe('TavilySearchProvider domains', () => {
     expect(body.include_domains).toEqual([])
   })
 
+  it('leaves a site operand carrying a path unchanged', async () => {
+    const query = 'site:example.com/docs'
+    const body = await searchAndReadBody([], [], query)
+
+    expect(body.query).toBe(query)
+    expect(body.include_domains).toEqual([])
+  })
+
   it('keeps only the valid domains of a mixed site-only query', async () => {
     const body = await searchAndReadBody([], [], 'site:example.com site:edu')
 

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -13,11 +13,15 @@ const CLOUD_EXCLUDED_DOMAINS = ['instagram.com']
 const VALID_DOMAIN_PATTERN = /^(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/
 
 // Tavily rejects a query whose only content is `site:` operators, so those
-// queries are rewritten into domain terms plus an include_domains entry.
+// queries are rewritten into domain terms plus an include_domains entry. Only a
+// bare hostname operand qualifies: a path, port or scheme carries a restriction
+// include_domains cannot express, and dropping it would widen the search.
+const SITE_OPERATOR_PATTERN = /^site:(\*\.)?[a-z0-9.-]+$/i
+
 const extractSiteOnlyDomains = (query: string): string[] | null => {
   const tokens = query.trim().split(/\s+/)
 
-  if (tokens.some(token => !/^site:\S+$/i.test(token))) {
+  if (tokens.some(token => !SITE_OPERATOR_PATTERN.test(token))) {
     return null
   }
 

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -14,9 +14,11 @@ const VALID_DOMAIN_PATTERN = /^(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/
 
 // Tavily rejects a query whose only content is `site:` operators, so those
 // queries are rewritten into domain terms plus an include_domains entry. Only a
-// bare hostname operand qualifies: a path, port or scheme carries a restriction
-// include_domains cannot express, and dropping it would widen the search.
-const SITE_OPERATOR_PATTERN = /^site:(\*\.)?[a-z0-9.-]+$/i
+// bare host operand qualifies: a path, port, scheme or userinfo carries a
+// restriction include_domains cannot express, and dropping it would widen the
+// search. Everything else is left to normalizeDomains, which punycodes an
+// internationalized host and rejects what is not a domain.
+const SITE_OPERATOR_PATTERN = /^site:[^\s/:?#@\\]+$/i
 
 const extractSiteOnlyDomains = (query: string): string[] | null => {
   const tokens = query.trim().split(/\s+/)

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -54,7 +54,14 @@ export class TavilySearchProvider extends BaseSearchProvider {
     this.validateApiKey(apiKey, 'TAVILY')
 
     const siteOnlyDomains = extractSiteOnlyDomains(query)
-    const effectiveQuery = siteOnlyDomains?.join(' ') ?? query
+    const validSiteDomains = siteOnlyDomains
+      ? normalizeDomains(siteOnlyDomains)
+      : []
+    // Rewriting only when an operand survives validation keeps an unusable
+    // restriction failing instead of turning it into an unrestricted search.
+    const effectiveQuery = validSiteDomains.length
+      ? validSiteDomains.join(' ')
+      : query
 
     // Tavily API requires a minimum of 5 characters in the query
     const filledQuery =
@@ -62,10 +69,10 @@ export class TavilySearchProvider extends BaseSearchProvider {
         ? effectiveQuery + ' '.repeat(5 - effectiveQuery.length)
         : effectiveQuery
 
-    const validIncludeDomains = normalizeDomains([
-      ...includeDomains,
-      ...(siteOnlyDomains ?? [])
-    ])
+    const validIncludeDomains = [
+      ...normalizeDomains(includeDomains),
+      ...validSiteDomains
+    ]
 
     const isCloudDeployment = process.env.MORPHIC_CLOUD_DEPLOYMENT === 'true'
     const effectiveExcludeDomains = isCloudDeployment

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -12,6 +12,18 @@ const CLOUD_EXCLUDED_DOMAINS = ['instagram.com']
 // resolved to an ASCII hostname so internationalized domains survive.
 const VALID_DOMAIN_PATTERN = /^(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/
 
+// Tavily rejects a query whose only content is `site:` operators, so those
+// queries are rewritten into domain terms plus an include_domains entry.
+const extractSiteOnlyDomains = (query: string): string[] | null => {
+  const tokens = query.trim().split(/\s+/)
+
+  if (tokens.some(token => !/^site:\S+$/i.test(token))) {
+    return null
+  }
+
+  return tokens.map(token => token.slice(5))
+}
+
 const toAsciiHostname = (domain: string): string => {
   try {
     return new URL(`https://${domain.trim()}`).hostname
@@ -41,11 +53,19 @@ export class TavilySearchProvider extends BaseSearchProvider {
     const apiKey = process.env.TAVILY_API_KEY
     this.validateApiKey(apiKey, 'TAVILY')
 
+    const siteOnlyDomains = extractSiteOnlyDomains(query)
+    const effectiveQuery = siteOnlyDomains?.join(' ') ?? query
+
     // Tavily API requires a minimum of 5 characters in the query
     const filledQuery =
-      query.length < 5 ? query + ' '.repeat(5 - query.length) : query
+      effectiveQuery.length < 5
+        ? effectiveQuery + ' '.repeat(5 - effectiveQuery.length)
+        : effectiveQuery
 
-    const validIncludeDomains = normalizeDomains(includeDomains)
+    const validIncludeDomains = normalizeDomains([
+      ...includeDomains,
+      ...(siteOnlyDomains ?? [])
+    ])
 
     const isCloudDeployment = process.env.MORPHIC_CLOUD_DEPLOYMENT === 'true'
     const effectiveExcludeDomains = isCloudDeployment

--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -12,12 +12,8 @@ const CLOUD_EXCLUDED_DOMAINS = ['instagram.com']
 // resolved to an ASCII hostname so internationalized domains survive.
 const VALID_DOMAIN_PATTERN = /^(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/
 
-// Tavily rejects a query whose only content is `site:` operators, so those
-// queries are rewritten into domain terms plus an include_domains entry. Only a
-// bare host operand qualifies: a path, port, scheme or userinfo carries a
-// restriction include_domains cannot express, and dropping it would widen the
-// search. Everything else is left to normalizeDomains, which punycodes an
-// internationalized host and rejects what is not a domain.
+// Tavily rejects a query made only of `site:` operators. Operands with a path
+// or port are left alone since include_domains cannot express them.
 const SITE_OPERATOR_PATTERN = /^site:[^\s/:?#@\\]+$/i
 
 const extractSiteOnlyDomains = (query: string): string[] | null => {
@@ -63,8 +59,6 @@ export class TavilySearchProvider extends BaseSearchProvider {
     const validSiteDomains = siteOnlyDomains
       ? normalizeDomains(siteOnlyDomains)
       : []
-    // Rewriting only when an operand survives validation keeps an unusable
-    // restriction failing instead of turning it into an unrestricted search.
     const effectiveQuery = validSiteDomains.length
       ? validSiteDomains.join(' ')
       : query


### PR DESCRIPTION
## Problem

The model sometimes issues a search whose query is nothing but a Google style
`site:` operator, for example `site:example.com`, while leaving the tool's own
`include_domains` parameter empty. Tavily rejects that request:

```
HTTP 400
{"detail":{"error":"Query cannot consist only of site: operators. Please provide search terms."}}
```

The search tool call then fails outright, so the model never gets the domain
restricted results it asked for and has to report a limitation instead.

## Root cause

Tavily only rejects a query that has **no searchable terms left** once the
`site:` operators are removed. Verified directly against `api.tavily.com`:

| query | include_domains | result |
| --- | --- | --- |
| `site:willsremodeling.com` | `[]` | 400, message above |
| `willsremodeling.com` | `[]` | 200 |
| `site:edu dry ice ethanol bath safety` | `[]` | 200 |

So a query that mixes `site:` with real terms is accepted and must not be
touched. Only the site-only shape is broken, and the provider already owns two
other Tavily specific normalizations in the same place (the minimum query
length padding and `normalizeDomains`).

## Fix

`lib/tools/search/providers/tavily.ts` only. Before the request body is built,
a site-only query is detected (one or more `site:<domain>` tokens and nothing
else). In that case the domains are:

1. merged into `include_domains`, flowing through the existing
   `normalizeDomains` validation unchanged, so an entry such as `site:edu` is
   still dropped as an invalid domain, and
2. used as the query text, so the request carries real search terms.

The rewrite is applied only when at least one extracted operand survives that
validation. If none does, for example `site:edu`, the query and
`include_domains` are passed through untouched so the request keeps failing
rather than silently becoming an unrestricted search. A mixed query keeps only
its valid domains, which narrows the scope rather than broadening it.

Every other query, including `site:` combined with real terms, reaches Tavily
byte for byte as it does today. The minimum length padding, the cloud exclude
domain injection and the domain normalization are unchanged.

This is deliberately Tavily specific: SearXNG and Brave handle `site:` in the
query natively, so the shared search tool and the other providers are untouched,
and so are the prompts.

## Verification

- New unit tests in `lib/tools/search/providers/__tests__/tavily-domains.test.ts`
  cover the site-only single and multiple domain cases, the uppercase `SITE:`
  form, a site-only query merged with pre-existing `include_domains`, `site:`
  combined with real terms (unchanged), a query with no `site:` operator
  (unchanged), a site-only query whose domains are all invalid (unchanged), and
  a mixed valid/invalid site-only query keeping only the valid domain.
- Live check against `api.tavily.com` with the exact request shapes: the
  pre-fix shape returns 400 with the message above, the post-fix shape returns
  200 and surfaces the requested site.
- `bun lint`, `bun typecheck`, `bun format:check`, `bun run test`,
  `bun run build` all pass.
